### PR TITLE
feat: add module implications support

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -18,7 +18,7 @@
     "@repo/domain": "workspace:*",
     "@repo/scaffold": "workspace:*",
     "effect": "4.0.0-beta.59",
-    "effect-boxes": "^0.10.3"
+    "effect-boxes": "^0.11.0"
   },
   "devDependencies": {
     "@repo/config-typescript": "workspace:*",

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -11,18 +11,146 @@ import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
 interface CollectedTarget {
   kind: Exclude<typeof TargetKind.Type, "init">;
   name: string;
-  modules: ReadonlyArray<typeof ModuleId.Type>;
+  modules: Array<typeof ModuleId.Type>;
+  confirmed: boolean;
 }
+
+const formatTargetSummary = (targets: ReadonlyArray<CollectedTarget>): string =>
+  targets
+    .map((t) => {
+      const status = t.confirmed ? "\u2713" : "\u25CB";
+      const modules =
+        t.modules.length > 0 ? t.modules.join(", ") : "(no modules)";
+      return `  ${status} ${t.kind}/${t.name}  [${modules}]`;
+    })
+    .join("\n");
+
+/**
+ * Resolve module implications: when a module implies another module on a
+ * different target kind, ensure that target+module exists in the collection.
+ * Returns true if any new implications were added.
+ */
+const resolveImplications = (targets: Array<CollectedTarget>) =>
+  Effect.gen(function* () {
+    const catalog = yield* ModuleCatalog;
+    let changed = false;
+
+    for (const target of targets) {
+      for (const moduleId of target.modules) {
+        const definition = yield* catalog.get(moduleId);
+        for (const implication of definition.implies ?? []) {
+          const candidates = targets.filter(
+            (t) => t.kind === implication.targetKind,
+          );
+
+          if (candidates.length === 0) {
+            const name = yield* Prompt.text({
+              message: `Module "${definition.title}" requires a ${implication.targetKind} target. What should it be called?`,
+            });
+            targets.push({
+              kind: implication.targetKind as Exclude<
+                typeof TargetKind.Type,
+                "init"
+              >,
+              name,
+              modules: [implication.moduleId],
+              confirmed: false,
+            });
+            changed = true;
+          } else if (candidates.length === 1) {
+            const candidate = candidates[0];
+            if (
+              candidate &&
+              !candidate.modules.includes(implication.moduleId)
+            ) {
+              candidate.modules.push(implication.moduleId);
+              candidate.confirmed = false;
+              changed = true;
+            }
+          } else {
+            const alreadyPresent = candidates.some((c) =>
+              c.modules.includes(implication.moduleId),
+            );
+            if (!alreadyPresent) {
+              const chosen = yield* Prompt.select({
+                message: `Module "${definition.title}" implies "${implication.moduleId}". Which ${implication.targetKind} target should receive it?`,
+                choices: candidates.map((c) => ({
+                  title: `${c.kind}/${c.name}`,
+                  value: c.name,
+                })),
+              });
+              const found = candidates.find((c) => c.name === chosen);
+              if (found) {
+                found.modules.push(implication.moduleId);
+                found.confirmed = false;
+                changed = true;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return changed;
+  });
+
+/**
+ * Build a set of all module IDs that are currently implied by modules in the
+ * collection, keyed as "targetKind:moduleId".
+ */
+const getActiveImplications = (targets: ReadonlyArray<CollectedTarget>) =>
+  Effect.gen(function* () {
+    const catalog = yield* ModuleCatalog;
+    const allModuleIds = targets.flatMap((t) => t.modules);
+    return yield* catalog.getImplications(allModuleIds);
+  });
+
+/**
+ * Remove implications that are no longer needed after a user edits modules.
+ */
+const removeOrphanedImplications = (targets: Array<CollectedTarget>) =>
+  Effect.gen(function* () {
+    const catalog = yield* ModuleCatalog;
+    const activeImplications = yield* getActiveImplications(targets);
+    let changed = false;
+
+    for (const target of targets) {
+      const toRemove: Array<typeof ModuleId.Type> = [];
+      for (const moduleId of target.modules) {
+        const isImplied = yield* catalog.isImpliedByAny(
+          moduleId,
+          target.kind,
+        );
+        if (
+          isImplied &&
+          !activeImplications.has(`${target.kind}:${moduleId}`)
+        ) {
+          toRemove.push(moduleId);
+        }
+      }
+      if (toRemove.length > 0) {
+        target.modules = target.modules.filter((m) => !toRemove.includes(m));
+        changed = true;
+      }
+    }
+
+    // Remove empty targets
+    const before = targets.length;
+    const remaining = targets.filter((t) => t.modules.length > 0);
+    targets.length = 0;
+    targets.push(...remaining);
+    if (targets.length !== before) changed = true;
+
+    return changed;
+  });
 
 const collectTargetsInteractive = Effect.gen(function* () {
   const catalog = yield* ModuleCatalog;
   const targetModuleMap = yield* catalog.targetModuleMap;
 
-  const targets = yield* Ref.make<Array<CollectedTarget>>([]);
-  let loop = true;
+  const targets: Array<CollectedTarget> = [];
 
-  while (loop) {
-    // 1. Select target kind
+  const addTarget = Effect.gen(function* () {
     const kind = yield* Prompt.select({
       message: "What kind of target do you want to add?",
       choices: Array.from(targetModuleMap.entries()).map(
@@ -30,18 +158,16 @@ const collectTargetsInteractive = Effect.gen(function* () {
       ),
     });
 
-    // 2. Name the target
     const name = yield* Prompt.text({
       message: `What should this ${kind} target be called?`,
     });
 
-    // 3. Select modules for this target
     const targetEntry = targetModuleMap.get(kind);
     const availableModules = targetEntry?.modules ?? [];
     const modules =
       availableModules.length > 0
         ? yield* Prompt.multiSelect({
-            message: `Which modules do you want to add to "${kind}${name ? `-${name}` : ""}"?`,
+            message: `Which modules do you want to add to "${kind}/${name}"?`,
             choices: availableModules.map((mod) => ({
               title: mod.title,
               value: mod.id,
@@ -50,23 +176,90 @@ const collectTargetsInteractive = Effect.gen(function* () {
           })
         : [];
 
-    yield* Ref.update(targets, (ts) => [...ts, { kind, name, modules }]);
+    targets.push({ kind, name, modules: [...modules], confirmed: false });
+  });
 
-    // 4. Add another or continue?
-    const next = yield* Prompt.select({
-      message: "What would you like to do next?",
+  // Collect first target
+  yield* addTarget;
+
+  // Resolve implications (fixed-point)
+  let implChanged = true;
+  while (implChanged) {
+    implChanged = yield* resolveImplications(targets);
+  }
+
+  // Confirmation loop
+  let allConfirmed = false;
+  while (!allConfirmed) {
+    yield* Effect.log(`\nCurrent targets:\n${formatTargetSummary(targets)}`);
+
+    const unconfirmed = targets.filter((t) => !t.confirmed);
+    if (unconfirmed.length === 0) {
+      allConfirmed = true;
+      break;
+    }
+
+    type Action = "confirm-all" | "edit" | "add";
+    const action = yield* Prompt.select<Action>({
+      message: "What would you like to do?",
       choices: [
-        { title: "Continue", value: "continue" as const },
-        { title: "Add another target", value: "add" as const },
+        { title: "Confirm all targets", value: "confirm-all" as Action },
+        { title: "Edit a target's modules", value: "edit" as Action },
+        { title: "Add another target", value: "add" as Action },
       ],
     });
 
-    if (next === "continue") {
-      loop = false;
+    if (action === "confirm-all") {
+      for (const t of targets) t.confirmed = true;
+      allConfirmed = true;
+    } else if (action === "edit") {
+      const targetToEdit = yield* Prompt.select({
+        message: "Which target do you want to edit?",
+        choices: targets.map((t, i) => ({
+          title: `${t.kind}/${t.name}  [${t.modules.join(", ")}]`,
+          value: i,
+        })),
+      });
+
+      const t = targets[targetToEdit];
+      if (t) {
+        const targetEntry = targetModuleMap.get(t.kind);
+        const availableModules = targetEntry?.modules ?? [];
+
+        if (availableModules.length > 0) {
+          const newModules = yield* Prompt.multiSelect({
+            message: `Select modules for "${t.kind}/${t.name}":`,
+            choices: availableModules.map((mod) => ({
+              title: mod.title,
+              value: mod.id,
+              description: mod.description,
+              selected: t.modules.includes(mod.id),
+            })),
+          });
+          t.modules = [...newModules];
+          t.confirmed = true;
+
+          // Cascade: remove orphaned implications then re-resolve
+          yield* removeOrphanedImplications(targets);
+          let changed = true;
+          while (changed) {
+            changed = yield* resolveImplications(targets);
+          }
+        } else {
+          t.confirmed = true;
+        }
+      }
+    } else {
+      yield* addTarget;
+
+      let changed = true;
+      while (changed) {
+        changed = yield* resolveImplications(targets);
+      }
     }
   }
 
-  return yield* Ref.get(targets);
+  return targets;
 });
 
 export const add = Command.make(

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -2,8 +2,12 @@ import { ModuleCatalog } from "@repo/catalog";
 import type { ModuleId, TargetKind } from "@repo/domain/Catalog";
 import { TargetIdentity } from "@repo/domain/Catalog";
 import type { Selection } from "@repo/domain/Selection";
-import { Effect, Option, Ref, Schedule } from "effect";
+import { Console, Effect, Option, Ref, Schedule } from "effect";
 import { Command, Prompt } from "effect/unstable/cli";
+import { Ansi, Box } from "effect-boxes";
+import { Border } from "../components/Border";
+import { HorizontalRadio } from "../components/HorizontalRadio";
+import { Padding } from "../components/Padding";
 import { dryRunFlag, rootFlag, yesFlag } from "../flags";
 import { ConfigureService } from "../service/ConfigureService";
 import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
@@ -15,15 +19,35 @@ interface CollectedTarget {
   confirmed: boolean;
 }
 
-const formatTargetSummary = (targets: ReadonlyArray<CollectedTarget>): string =>
-  targets
-    .map((t) => {
-      const status = t.confirmed ? "\u2713" : "\u25CB";
-      const modules =
-        t.modules.length > 0 ? t.modules.join(", ") : "(no modules)";
-      return `  ${status} ${t.kind}/${t.name}  [${modules}]`;
-    })
-    .join("\n");
+const formatTargetSummary = (
+  targets: ReadonlyArray<CollectedTarget>,
+): Box.Box<Ansi.AnsiStyle> => {
+  const statuses = targets.map((t) =>
+    t.confirmed
+      ? Box.char("✓").pipe(Box.annotate(Ansi.green))
+      : Box.char("○").pipe(Box.annotate(Ansi.dim)),
+  );
+
+  const labels = targets.map((t) =>
+    Box.text(`${t.kind}/${t.name}`).pipe(Box.annotate(Ansi.bold)),
+  );
+
+  const modules = targets.map((t) =>
+    t.modules.length > 0
+      ? Box.text(t.modules.join(", ")).pipe(Box.annotate(Ansi.cyan))
+      : Box.text("(no modules)").pipe(Box.annotate(Ansi.dim)),
+  );
+
+  return Box.hsep(
+    [
+      Box.vcat(statuses, Box.center1),
+      Box.vcat(labels, Box.left),
+      Box.vcat(modules, Box.left),
+    ],
+    2,
+    Box.top,
+  );
+};
 
 /**
  * Resolve module implications: when a module implies another module on a
@@ -107,8 +131,13 @@ const getActiveImplications = (targets: ReadonlyArray<CollectedTarget>) =>
 
 /**
  * Remove implications that are no longer needed after a user edits modules.
+ * Modules in `pinned` were explicitly selected by the user and must not be
+ * removed even if they are no longer actively implied.
  */
-const removeOrphanedImplications = (targets: Array<CollectedTarget>) =>
+const removeOrphanedImplications = (
+  targets: Array<CollectedTarget>,
+  pinned: ReadonlySet<string> = new Set(),
+) =>
   Effect.gen(function* () {
     const catalog = yield* ModuleCatalog;
     const activeImplications = yield* getActiveImplications(targets);
@@ -117,10 +146,8 @@ const removeOrphanedImplications = (targets: Array<CollectedTarget>) =>
     for (const target of targets) {
       const toRemove: Array<typeof ModuleId.Type> = [];
       for (const moduleId of target.modules) {
-        const isImplied = yield* catalog.isImpliedByAny(
-          moduleId,
-          target.kind,
-        );
+        if (pinned.has(`${target.kind}:${moduleId}`)) continue;
+        const isImplied = yield* catalog.isImpliedByAny(moduleId, target.kind);
         if (
           isImplied &&
           !activeImplications.has(`${target.kind}:${moduleId}`)
@@ -151,7 +178,7 @@ const collectTargetsInteractive = Effect.gen(function* () {
   const targets: Array<CollectedTarget> = [];
 
   const addTarget = Effect.gen(function* () {
-    const kind = yield* Prompt.select({
+    const kind = yield* HorizontalRadio({
       message: "What kind of target do you want to add?",
       choices: Array.from(targetModuleMap.entries()).map(
         ([value, { title }]) => ({ title, value }),
@@ -182,6 +209,11 @@ const collectTargetsInteractive = Effect.gen(function* () {
   // Collect first target
   yield* addTarget;
 
+  // The user explicitly chose modules for the first target, mark it confirmed
+  if (targets[0] && targets[0].modules.length > 0) {
+    targets[0].confirmed = true;
+  }
+
   // Resolve implications (fixed-point)
   let implChanged = true;
   while (implChanged) {
@@ -191,21 +223,28 @@ const collectTargetsInteractive = Effect.gen(function* () {
   // Confirmation loop
   let allConfirmed = false;
   while (!allConfirmed) {
-    yield* Effect.log(`\nCurrent targets:\n${formatTargetSummary(targets)}`);
-
-    const unconfirmed = targets.filter((t) => !t.confirmed);
-    if (unconfirmed.length === 0) {
-      allConfirmed = true;
-      break;
-    }
+    yield* Console.log(
+      Box.renderPrettySync(
+        Box.vsep(
+          [
+            Box.text("Current targets and modules:").pipe(
+              Box.annotate(Ansi.bold),
+            ),
+            formatTargetSummary(targets),
+          ],
+          1,
+          Box.left,
+        ).pipe(Padding(0, 1), Border),
+      ),
+    );
 
     type Action = "confirm-all" | "edit" | "add";
-    const action = yield* Prompt.select<Action>({
+    const action = yield* HorizontalRadio<Action>({
       message: "What would you like to do?",
       choices: [
-        { title: "Confirm all targets", value: "confirm-all" as Action },
-        { title: "Edit a target's modules", value: "edit" as Action },
-        { title: "Add another target", value: "add" as Action },
+        { title: "Confirm all", value: "confirm-all" as Action },
+        { title: "Edit modules", value: "edit" as Action },
+        { title: "Add target", value: "add" as Action },
       ],
     });
 
@@ -240,7 +279,9 @@ const collectTargetsInteractive = Effect.gen(function* () {
           t.confirmed = true;
 
           // Cascade: remove orphaned implications then re-resolve
-          yield* removeOrphanedImplications(targets);
+          // Pin the user's explicit selections so they aren't stripped
+          const pinned = new Set(newModules.map((m) => `${t.kind}:${m}`));
+          yield* removeOrphanedImplications(targets, pinned);
           let changed = true;
           while (changed) {
             changed = yield* resolveImplications(targets);

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -238,13 +238,12 @@ const collectTargetsInteractive = Effect.gen(function* () {
       ),
     );
 
-    type Action = "confirm-all" | "edit" | "add";
-    const action = yield* HorizontalRadio<Action>({
+    const action = yield* HorizontalRadio<"confirm-all" | "edit" | "add">({
       message: "What would you like to do?",
       choices: [
-        { title: "Confirm all", value: "confirm-all" as Action },
-        { title: "Edit modules", value: "edit" as Action },
-        { title: "Add target", value: "add" as Action },
+        { title: "Confirm all", value: "confirm-all" },
+        { title: "Edit modules", value: "edit" },
+        { title: "Add target", value: "add" },
       ],
     });
 

--- a/apps/cli/src/components/HorizontalRadio.ts
+++ b/apps/cli/src/components/HorizontalRadio.ts
@@ -1,23 +1,10 @@
 import { Data, Effect } from "effect";
 import { Prompt } from "effect/unstable/cli";
-import { Ansi, Box } from "effect-boxes";
+import { Ansi, Box, Cmd } from "effect-boxes";
 import { Border } from "./Border";
 import { Padding } from "./Padding";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
-
-// TODO: replace with clearLines in v0.11.0 of effect-boxes
-const ESC = "\x1B[";
-const eraseLines = (rows: number): string => {
-  let command = "";
-  for (let i = 0; i < rows; i++) {
-    command += `${ESC}2K` + (i < rows - 1 ? `${ESC}1A` : "");
-  }
-  if (rows > 0) {
-    command += `${ESC}G`;
-  }
-  return command;
-};
 
 export const HorizontalRadio = <A extends string>(
   options: Prompt.SelectOptions<A>,
@@ -107,7 +94,9 @@ export const HorizontalRadio = <A extends string>(
     },
     clear: (_state, _action) =>
       Effect.gen(function* () {
-        return eraseLines(renderLayout(_state, false).rows);
+        return Cmd.clearLines(renderLayout(_state, false).rows).pipe(
+          Box.renderPrettySync,
+        );
       }),
   });
 };

--- a/apps/cli/src/components/HorizontalRadio.ts
+++ b/apps/cli/src/components/HorizontalRadio.ts
@@ -1,0 +1,113 @@
+import { Data, Effect } from "effect";
+import { Prompt } from "effect/unstable/cli";
+import { Ansi, Box } from "effect-boxes";
+import { Border } from "./Border";
+import { Padding } from "./Padding";
+
+const Action = Data.taggedEnum<Prompt.ActionDefinition>();
+
+// TODO: replace with clearLines in v0.11.0 of effect-boxes
+const ESC = "\x1B[";
+const eraseLines = (rows: number): string => {
+  let command = "";
+  for (let i = 0; i < rows; i++) {
+    command += `${ESC}2K` + (i < rows - 1 ? `${ESC}1A` : "");
+  }
+  if (rows > 0) {
+    command += `${ESC}G`;
+  }
+  return command;
+};
+
+export const HorizontalRadio = <A extends string>(
+  options: Prompt.SelectOptions<A>,
+): Prompt.Prompt<A> => {
+  const { message, choices } = options;
+
+  const renderLayout = (cursor: number, submitted: boolean) => {
+    const prefix = submitted
+      ? Box.text("✔").pipe(Box.annotate(Ansi.green))
+      : Box.text("?").pipe(Box.annotate(Ansi.cyan));
+
+    const label = Box.text(message).pipe(Box.annotate(Ansi.bold));
+
+    const items = choices.map((c, i) => {
+      const isSelected = i === cursor;
+
+      return Box.text(c.title).pipe(
+        Padding(0, 2),
+        Border,
+        Box.annotate(
+          isSelected ? Ansi.combine(Ansi.cyan, Ansi.bold) : Ansi.dim,
+        ),
+      );
+    });
+
+    if (submitted) {
+      const selected = choices[cursor];
+      return Box.hsep(
+        [
+          prefix,
+          label,
+          Box.text(selected?.title ?? "").pipe(Box.annotate(Ansi.cyan)),
+        ],
+        1,
+        Box.top,
+      );
+    }
+
+    return Box.vcat(
+      [
+        Box.hsep([prefix, label, Box.text(" ")], 2, Box.center1),
+        Box.hsep(items, 2, Box.center1),
+      ],
+      Box.left,
+    );
+  };
+
+  return Prompt.custom<number, A>(0, {
+    render: (cursor, action) => {
+      const layout = Action.$match(action, {
+        Beep: () => renderLayout(cursor, false),
+        Submit: () => renderLayout(cursor, true),
+        NextFrame: ({ state }) => renderLayout(state, false),
+        default: () => renderLayout(cursor, false),
+      });
+      const rendered = Box.renderPrettySync(layout);
+      return Effect.succeed(
+        action._tag === "Submit" ? `${rendered}\n` : rendered,
+      );
+    },
+    process: (input, cursor) => {
+      switch (input.key.name) {
+        case "right":
+        case "l":
+        case "tab":
+          return Effect.succeed(
+            Action.NextFrame({ state: (cursor + 1) % choices.length }),
+          );
+        case "left":
+        case "h":
+          return Effect.succeed(
+            Action.NextFrame({
+              state: (cursor - 1 + choices.length) % choices.length,
+            }),
+          );
+        case "enter":
+        case "return": {
+          const selected = choices[cursor];
+          if (selected) {
+            return Effect.succeed(Action.Submit({ value: selected.value }));
+          }
+          return Effect.succeed(Action.Beep());
+        }
+        default:
+          return Effect.succeed(Action.NextFrame({ state: cursor }));
+      }
+    },
+    clear: (_state, _action) =>
+      Effect.gen(function* () {
+        return eraseLines(renderLayout(_state, false).rows);
+      }),
+  });
+};

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@playwright/test": "^1.59.1",
         "@types/bun": "^1.3.13",
         "effect": "4.0.0-beta.59",
-        "effect-boxes": "^0.10.3",
+        "effect-boxes": "^0.11.0",
         "tsmetrics-core": "^1.4.1",
         "turbo": "^2.9.6",
         "typescript": "6.0.3",
@@ -27,7 +27,7 @@
         "@repo/domain": "workspace:*",
         "@repo/scaffold": "workspace:*",
         "effect": "4.0.0-beta.59",
-        "effect-boxes": "^0.10.3",
+        "effect-boxes": "^0.11.0",
       },
       "devDependencies": {
         "@repo/config-typescript": "workspace:*",
@@ -850,7 +850,7 @@
 
     "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
 
-    "effect-boxes": ["effect-boxes@0.10.3", "", { "dependencies": { "effect": "4.0.0-beta.59" } }, "sha512-bLjBHjrOD3pgLiDQUFagYwrfG1M3Qydo4F2Rnd6atN2VbwC7v2FRr+QWss9PTpA5waPeP7IEPf4IMTJZg2uusQ=="],
+    "effect-boxes": ["effect-boxes@0.11.0", "", { "dependencies": { "effect": "4.0.0-beta.59" } }, "sha512-m2COPNTmQJKRw7a5NWgCK2cMV80pRDraqHOaCimBHPOEUwpc+bICHIy7Mn+8gICc1+AVTzdAbNEA2uskv82ojQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.322", "", {}, "sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@effect/language-service": "^0.85.1",
     "@effect/platform-bun": "4.0.0-beta.59",
     "effect": "4.0.0-beta.59",
-    "effect-boxes": "^0.10.3",
+    "effect-boxes": "^0.11.0",
     "@playwright/test": "^1.59.1",
     "@types/bun": "^1.3.13",
     "tsmetrics-core": "^1.4.1",

--- a/packages/catalog/src/ModuleCatalog.ts
+++ b/packages/catalog/src/ModuleCatalog.ts
@@ -2,6 +2,7 @@ import { CatalogNotFound } from "@repo/domain/Blueprint";
 import type {
   ModuleDefinition,
   ModuleId,
+  ModuleImplication,
   TargetIdentity,
   TargetKind,
 } from "@repo/domain/Catalog";
@@ -15,6 +16,10 @@ export class ModuleCatalog extends Context.Service<ModuleCatalog>()(
     make: Effect.gen(function* () {
       const targetCatalog = yield* TargetCatalog;
       const index = new Map(moduleRegistry.map((m) => [m.id, m]));
+
+      const keys: ReadonlyArray<typeof ModuleId.Type> = Array.from(
+        index.keys(),
+      );
 
       const get = Effect.fn("ModuleCatalog.get")(function* (
         moduleId: typeof ModuleId.Type,
@@ -41,6 +46,32 @@ export class ModuleCatalog extends Context.Service<ModuleCatalog>()(
           target.matches(supportedOn),
         );
       });
+
+      const isImpliedByAny = Effect.fn("ModuleCatalog.isImpliedByAny")(
+        function* (
+          moduleId: typeof ModuleId.Type,
+          targetKind: typeof TargetKind.Type,
+        ) {
+          const allImplies = moduleRegistry.flatMap((def) => def.implies ?? []);
+          return allImplies.some(
+            (imp: typeof ModuleImplication.Type) =>
+              imp.moduleId === moduleId && imp.targetKind === targetKind,
+          );
+        },
+      );
+
+      const getImplications = Effect.fn("ModuleCatalog.getImplications")(
+        function* (moduleIds: ReadonlyArray<typeof ModuleId.Type>) {
+          const active = new Set<string>();
+          for (const moduleId of moduleIds) {
+            const definition = yield* get(moduleId);
+            for (const imp of definition.implies ?? []) {
+              active.add(`${imp.targetKind}:${imp.moduleId}`);
+            }
+          }
+          return active;
+        },
+      );
 
       const targetModuleMap = Effect.gen(function* () {
         const result = new Map<
@@ -75,8 +106,11 @@ export class ModuleCatalog extends Context.Service<ModuleCatalog>()(
       });
 
       return {
+        keys,
         get,
         isSupportedOn,
+        isImpliedByAny,
+        getImplications,
         targetModuleMap,
       };
     }),

--- a/packages/catalog/src/registry/moduleRegistry.ts
+++ b/packages/catalog/src/registry/moduleRegistry.ts
@@ -312,6 +312,7 @@ export const moduleRegistry: ReadonlyArray<typeof ModuleDefinition.Type> = [
         },
       },
     ],
+    implies: [{ targetKind: "server", moduleId: "http-api-server" }],
     contributions: {
       files: [
         {
@@ -451,6 +452,7 @@ export const moduleRegistry: ReadonlyArray<typeof ModuleDefinition.Type> = [
         },
       },
     ],
+    implies: [{ targetKind: "server", moduleId: "http-rpc-server" }],
     contributions: {
       files: [
         {
@@ -630,6 +632,7 @@ export const moduleRegistry: ReadonlyArray<typeof ModuleDefinition.Type> = [
         },
       },
     ],
+    implies: [{ targetKind: "server", moduleId: "chat-server" }],
     contributions: {
       files: [
         {
@@ -791,6 +794,7 @@ export const moduleRegistry: ReadonlyArray<typeof ModuleDefinition.Type> = [
         },
       },
     ],
+    implies: [{ targetKind: "server", moduleId: "ws-presence-server" }],
     contributions: {
       files: [
         {

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 export const ModuleId = Schema.Union([
   Schema.Literal("turbo"),
@@ -104,6 +104,11 @@ export const SupportedOn = Schema.Union([
   }),
 ]);
 
+export const ModuleImplication = Schema.Struct({
+  targetKind: TargetKind,
+  moduleId: ModuleId,
+});
+
 export const ModuleDependency = Schema.Struct({
   requiredTarget: Schema.optional(
     Schema.Struct({
@@ -170,6 +175,10 @@ export const ModuleDefinition = Schema.Struct({
   description: Schema.String,
   supportedOn: Schema.Array(SupportedOn),
   dependencies: Schema.Array(ModuleDependency),
+  implies: Schema.Array(ModuleImplication).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
   contributions: DesiredContributions,
 });
 


### PR DESCRIPTION
## Goals/Scope

Add module implications support to enable automatic resolution of dependent modules.

## Description

- Add module implications support with automatic resolution
- Integrate module implication resolution into add command
- Add horizontal radio prompt component for better UX
- Upgrade effect-boxes dependency to v0.11.0