### PR TITLE
refactor: add llm mode for cli

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,9 +7,7 @@
     "build": "bun build src/index.ts --outdir=dist --target=bun --minify",
     "build:types": "tsc --emitDeclarationOnly",
     "dev": "bun --watch run src/index.ts",
-    "start": "bun run src/index.ts init -r ./.temp",
-    "start:add": "bun run src/index.ts add -r ./.temp --dry-run",
-    "registry:analyse": "bun run src/index.ts graph",
+    "start": "bun run src/index.ts",
     "type-check": "tsc --noEmit",
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -1,9 +1,8 @@
 import { CatalogService } from "@repo/catalog";
-import type { ModuleId, TargetKind } from "@repo/domain/Catalog";
-import { TargetIdentity } from "@repo/domain/Catalog";
+import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
 import type { Selection } from "@repo/domain/Selection";
-import { Console, Effect, Option, Ref, Schedule } from "effect";
-import { Command, Prompt } from "effect/unstable/cli";
+import { Console, Effect, Option, Schedule } from "effect";
+import { Command, Flag, Prompt } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import { Border } from "../components/Border";
 import { HorizontalRadio } from "../components/HorizontalRadio";
@@ -18,6 +17,21 @@ interface CollectedTarget {
   modules: Array<typeof ModuleId.Type>;
   confirmed: boolean;
 }
+
+const targetFlag = Flag.string("target").pipe(
+  Flag.optional,
+  Flag.withDescription(
+    "Target identity as <targetKind>/<targetName>, e.g. client/web",
+  ),
+);
+
+const modulesFlag = Flag.string("modules").pipe(
+  Flag.atLeast(1),
+  Flag.optional,
+  Flag.withDescription(
+    "Module IDs (repeat --modules or use comma-separated values)",
+  ),
+);
 
 const formatTargetSummary = (
   targets: ReadonlyArray<CollectedTarget>,
@@ -171,6 +185,195 @@ const removeOrphanedImplications = (
     return changed;
   });
 
+const resolveImplicationsNonInteractive = (targets: Array<CollectedTarget>) =>
+  Effect.gen(function* () {
+    const catalog = yield* CatalogService;
+
+    let changed = true;
+    while (changed) {
+      changed = false;
+
+      for (const target of targets) {
+        for (const moduleId of target.modules) {
+          const definition = yield* catalog.getModule(moduleId);
+
+          for (const implication of definition.implies ?? []) {
+            const candidates = targets.filter(
+              (t) => t.kind === implication.targetKind,
+            );
+
+            if (candidates.length === 0) {
+              return yield* Effect.fail(
+                `Module \"${definition.id}\" implies \"${implication.moduleId}\" on target kind \"${implication.targetKind}\". Non-interactive mode requires explicit support for implied targets. Use interactive add or choose modules without cross-target implications.`,
+              );
+            }
+
+            if (candidates.length > 1) {
+              const alreadyPresent = candidates.some((c) =>
+                c.modules.includes(implication.moduleId),
+              );
+              if (!alreadyPresent) {
+                return yield* Effect.fail(
+                  `Module \"${definition.id}\" implies \"${implication.moduleId}\" for target kind \"${implication.targetKind}\", but multiple candidate targets exist. Use interactive add to disambiguate.`,
+                );
+              }
+            }
+
+            const candidate = candidates[0];
+            if (
+              candidate &&
+              !candidate.modules.includes(implication.moduleId)
+            ) {
+              candidate.modules.push(implication.moduleId);
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+
+    return targets;
+  });
+
+const parseTargetIdentity = (targetId: string) =>
+  Effect.gen(function* () {
+    const value = targetId.trim();
+    const separatorIndex = value.indexOf("/");
+
+    if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+      return yield* Effect.fail(
+        "Invalid --target value. Expected format: <targetKind>/<targetName>.",
+      );
+    }
+
+    const kindText = value.slice(0, separatorIndex).trim();
+    const name = value.slice(separatorIndex + 1).trim();
+
+    if (kindText.length === 0 || name.length === 0) {
+      return yield* Effect.fail(
+        "Invalid --target value. targetKind and targetName must both be non-empty.",
+      );
+    }
+
+    const kind = TargetKind.make(kindText);
+    if (kind === "init") {
+      return yield* Effect.fail(
+        'The add command cannot target kind "init". Use stack-effect init for project initialization.',
+      );
+    }
+
+    return {
+      kind: kind as Exclude<typeof TargetKind.Type, "init">,
+      name,
+    };
+  });
+
+const parseModuleInputs = (rawModules: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const parts = rawModules.flatMap((entry) =>
+      entry
+        .split(",")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0),
+    );
+
+    if (parts.length === 0) {
+      return yield* Effect.fail(
+        "At least one module ID is required when using --modules.",
+      );
+    }
+
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+
+    for (const moduleId of parts) {
+      if (seen.has(moduleId)) {
+        duplicates.add(moduleId);
+      } else {
+        seen.add(moduleId);
+      }
+    }
+
+    if (duplicates.size > 0) {
+      return yield* Effect.fail(
+        `Duplicate module IDs provided: ${Array.from(duplicates).join(", ")}`,
+      );
+    }
+
+    return parts.map((moduleId) => ModuleId.make(moduleId));
+  });
+
+const collectTargetsFromFlags = (
+  targetId: string,
+  rawModules: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const catalog = yield* CatalogService;
+
+    const parsedTarget = yield* parseTargetIdentity(targetId);
+    const targetIdentity = new TargetIdentity({
+      kind: parsedTarget.kind,
+      name: parsedTarget.name,
+    });
+
+    yield* catalog
+      .getTarget(targetIdentity.kind)
+      .pipe(
+        Effect.mapError(
+          () =>
+            `Unknown target kind \"${targetIdentity.kind}\" in --target value \"${targetId}\".`,
+        ),
+      );
+
+    const moduleIds = yield* parseModuleInputs(rawModules);
+    const unsupported: Array<string> = [];
+
+    for (const moduleId of moduleIds) {
+      yield* catalog
+        .getModule(moduleId)
+        .pipe(
+          Effect.mapError(
+            () => `Unknown module ID \"${moduleId}\" provided via --modules.`,
+          ),
+        );
+
+      const isSupported = yield* catalog.isSupportedOn(
+        moduleId,
+        targetIdentity,
+      );
+      if (!isSupported) {
+        unsupported.push(moduleId);
+      }
+    }
+
+    if (unsupported.length > 0) {
+      return yield* Effect.fail(
+        `Unsupported module(s) for target ${targetIdentity.kind}/${targetIdentity.name}: ${unsupported.join(", ")}`,
+      );
+    }
+
+    const targets: Array<CollectedTarget> = [
+      {
+        kind: parsedTarget.kind,
+        name: parsedTarget.name,
+        modules: moduleIds,
+        confirmed: true,
+      },
+    ];
+
+    yield* resolveImplicationsNonInteractive(targets);
+
+    return targets;
+  });
+
+const isScaffoldAborted = (
+  err: unknown,
+): err is { _tag: "ScaffoldAborted"; retry?: boolean } =>
+  typeof err === "object" &&
+  err !== null &&
+  "_tag" in err &&
+  (err as { _tag?: unknown })._tag === "ScaffoldAborted";
+
 const collectTargetsInteractive = Effect.gen(function* () {
   const catalog = yield* CatalogService;
 
@@ -311,6 +514,8 @@ export const add = Command.make(
   "add",
   {
     root: rootFlag,
+    target: targetFlag,
+    modules: modulesFlag,
     yes: yesFlag,
     dryRun: dryRunFlag,
   },
@@ -324,8 +529,23 @@ export const add = Command.make(
       // Require init
       const config = yield* configure.requireConfig(repoRoot);
 
+      const hasTarget = Option.isSome(flags.target);
+      const hasModules = Option.isSome(flags.modules);
+
+      if (hasTarget !== hasModules) {
+        return yield* Effect.fail(
+          "Use --target and --modules together, or omit both to use interactive mode.",
+        );
+      }
+
       // Collect targets: use flags if provided, otherwise interactive loop
-      const collected = yield* collectTargetsInteractive;
+      const collected =
+        hasTarget && hasModules
+          ? yield* collectTargetsFromFlags(
+              flags.target.value,
+              flags.modules.value,
+            )
+          : yield* collectTargetsInteractive;
 
       // Build selection
       const selection: typeof Selection.Type = {
@@ -344,7 +564,7 @@ export const add = Command.make(
       });
     }).pipe(
       Effect.retry({
-        while: (err) => err._tag === "ScaffoldAborted" && err.retry === true,
+        while: (err) => isScaffoldAborted(err) && err.retry === true,
         schedule: Schedule.forever,
       }),
       Effect.catchTag("ScaffoldAborted", (err) => {

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -92,17 +92,21 @@ export const init = Command.make(
       }
 
       // Project name
+      if (flags.yes && Option.isNone(flags.name)) {
+        return yield* Effect.fail(
+          "When using --yes with init, provide a project name as the positional argument.",
+        );
+      }
+
       const projectName = Option.isSome(flags.name)
         ? flags.name.value
-        : flags.yes
-          ? "my-stack-app"
-          : yield* Prompt.text({
-              message: "Project name:",
-              validate: (v) =>
-                v.trim().length > 0
-                  ? Effect.succeed(v.trim())
-                  : Effect.fail("Name cannot be empty"),
-            });
+        : yield* Prompt.text({
+            message: "Project name:",
+            validate: (v) =>
+              v.trim().length > 0
+                ? Effect.succeed(v.trim())
+                : Effect.fail("Name cannot be empty"),
+          });
 
       // Runtime
       const runtimeChoice = Option.isSome(flags.packageManager)

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -12,5 +12,7 @@ export const dryRunFlag = Flag.boolean("dry-run").pipe(
 
 export const yesFlag = Flag.boolean("yes").pipe(
   Flag.withAlias("y"),
-  Flag.withDescription("Accept all defaults, skip interactive prompts"),
+  Flag.withDescription(
+    "Skip confirmation prompts (uses defaults where available)",
+  ),
 );

--- a/apps/cli/src/service/ConfigureService.ts
+++ b/apps/cli/src/service/ConfigureService.ts
@@ -23,10 +23,10 @@ export class ConfigureService extends Context.Service<ConfigureService>()(
 
       const writeConfig = (repoRoot: string, config: typeof StackConfig.Type) =>
         Effect.gen(function* () {
-          const fs = yield* FileSystem.FileSystem;
           const json = yield* Schema.encodeEffect(
             Schema.fromJsonString(StackConfig),
           )(config);
+          yield* fs.makeDirectory(repoRoot, { recursive: true });
           yield* fs.writeFileString(configPath(repoRoot), json);
         });
 

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -85,17 +85,19 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
 
           yield* Console.log(Box.renderPrettySync(blueprintBox));
 
-          const confirm = yield* Prompt.confirm({
-            message: "Continue with these changes?",
-            initial: true,
-          });
-
-          if (!confirm) {
-            yield* Console.log("Lets try again.\n\n");
-            return yield* new ScaffoldAborted({
-              message: "User aborted the scaffold process.",
-              retry: true,
+          if (!yes) {
+            const confirm = yield* Prompt.confirm({
+              message: "Continue with these changes?",
+              initial: true,
             });
+
+            if (!confirm) {
+              yield* Console.log("Lets try again.\n\n");
+              return yield* new ScaffoldAborted({
+                message: "User aborted the scaffold process.",
+                retry: true,
+              });
+            }
           }
 
           // Plan

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "effect-language-service patch",
     "test": "turbo run test",
     "test:e2e": "playwright test",
+    "start": "bun apps/cli/src/index.ts",
     "type-check": "turbo run type-check",
     "complexity": "bun run scripts/complexity-report.ts"
   },

--- a/packages/catalog/src/registry/content/client.ts
+++ b/packages/catalog/src/registry/content/client.ts
@@ -1,3 +1,51 @@
+export const configTypescriptViteContents = `{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "display": "Vite React",
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "incremental": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["vite/client"]
+  }
+}
+`;
+
+export const clientPackageJsonContents = `{
+  "name": "{{targetName}}",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {},
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "effect": "4.0.0-beta.59",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.1.13"
+  },
+  "devDependencies": {
+    "@effect/language-service": "^0.85.1",
+    "@repo/config-typescript": "workspace:*",
+    "@tailwindcss/vite": "^4.1.13",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.1.0",
+    "typescript": "6.0.2",
+    "vite": "^8.0.10",
+    "vitest": "^4.1.4"
+  }
+}
+`;
+
 export const clientTsconfigContents = `{
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@repo/config-typescript/vite.json",
@@ -78,9 +126,6 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
-  },
-  optimizeDeps: {
-    include: ["@repo/domain"],
   },
   server: {
     strictPort: true,

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -34,6 +34,7 @@ test-results
 export const rootPackageJsonContents = `{
   "name": "{{targetName}}",
   "private": true,
+  "packageManager": "{{packageManagerSpec}}",
   "scripts": {},
   "devDependencies": {
     "@effect/language-service": "^0.85.1",

--- a/packages/catalog/src/registry/moduleRegistry.ts
+++ b/packages/catalog/src/registry/moduleRegistry.ts
@@ -22,6 +22,7 @@ import {
   domainChatRpcContents,
   serverChatContents,
 } from "./content/chat";
+import { configTypescriptViteContents } from "./content/client";
 import {
   clientHelloAtomContents,
   clientRestCardContents,
@@ -208,6 +209,37 @@ export const moduleRegistry: ReadonlyArray<typeof ModuleDefinition.Type> = [
           value: "turbo run test",
         },
       ],
+      barrelExports: [],
+      tsconfigs: [],
+    },
+  },
+  {
+    id: ModuleId.make("config-typescript-vite"),
+    title: "Config TypeScript Vite",
+    description: "Vite TypeScript preset for client applications",
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client") }],
+    dependencies: [],
+    contributions: {
+      files: [
+        {
+          path: "packages/config-typescript/vite.json",
+          contents: configTypescriptViteContents,
+        },
+      ],
+      exports: [
+        {
+          path: "packages/config-typescript/package.json",
+          name: "./base.json",
+          value: "./base.json",
+        },
+        {
+          path: "packages/config-typescript/package.json",
+          name: "./vite.json",
+          value: "./vite.json",
+        },
+      ],
+      dependencies: [],
+      scripts: [],
       barrelExports: [],
       tsconfigs: [],
     },

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -1,4 +1,8 @@
-import { type TargetDefinition, TargetKind } from "@repo/domain/Catalog";
+import {
+  ModuleId,
+  type TargetDefinition,
+  TargetKind,
+} from "@repo/domain/Catalog";
 import { emptyDesiredContributions } from "@repo/domain/Scaffold";
 import {
   clientAppTsxContents,
@@ -6,6 +10,7 @@ import {
   clientIndexCssContents,
   clientIndexHtmlContents,
   clientMainTsxContents,
+  clientPackageJsonContents,
   clientTsconfigConfigContents,
   clientTsconfigContents,
   clientUtilsContents,
@@ -27,6 +32,7 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     title: "Project Initialization",
     description:
       "Set up a new project with recommended structure and configuration",
+    requiredModules: [],
     contributions: {
       ...emptyDesiredContributions(),
       files: [
@@ -55,9 +61,14 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     kind: TargetKind.make("client"),
     title: "Client Application",
     description: "A frontend application, such as one built with React or Vue",
+    requiredModules: [ModuleId.make("config-typescript-vite")],
     contributions: {
       ...emptyDesiredContributions(),
       files: [
+        {
+          path: "{{targetPath}}/package.json",
+          contents: clientPackageJsonContents,
+        },
         {
           path: "{{targetPath}}/index.html",
           contents: clientIndexHtmlContents,
@@ -136,6 +147,7 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     kind: TargetKind.make("server"),
     title: "Server Application",
     description: "A backend application, such as an API server",
+    requiredModules: [],
     contributions: {
       ...emptyDesiredContributions(),
       files: [
@@ -189,6 +201,7 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     kind: TargetKind.make("cli"),
     title: "CLI Application",
     description: "A command-line interface application",
+    requiredModules: [],
     contributions: emptyDesiredContributions(),
   },
 
@@ -196,6 +209,7 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     kind: TargetKind.make("package"),
     title: "Shared Package",
     description: "A shared library package for code reuse across targets",
+    requiredModules: [],
     contributions: {
       ...emptyDesiredContributions(),
       scripts: [

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -166,6 +166,10 @@ export const TargetDefinition = Schema.Struct({
   kind: TargetKind,
   title: Schema.String,
   description: Schema.String,
+  requiredModules: Schema.Array(ModuleId).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
   contributions: DesiredContributions,
   scripts: Schema.Array(ScriptDefinition).pipe(
     Schema.optionalKey,

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -29,6 +29,7 @@ export const ContributionTokenContext = Schema.Struct({
   targetName: Schema.NonEmptyString,
   runtime: Schema.NonEmptyString,
   packageManager: Schema.NonEmptyString,
+  packageManagerSpec: Schema.NonEmptyString,
   projectName: Schema.NonEmptyString,
 });
 
@@ -48,16 +49,27 @@ export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   test: Schema.optional(Schema.Literals(["vitest"])),
   monorepo: Schema.optional(Schema.Literals(["turbo"])),
 }) {
-  get runtimeName(): string {
+  get runtimeName(): "bun" | "node" {
     return this.runtime._tag;
   }
 
-  get packageManagerName(): string {
+  get packageManagerName(): "bun" | "npm" | "pnpm" {
     switch (this.runtime._tag) {
       case "bun":
         return "bun";
       case "node":
         return this.runtime.packageManager;
+    }
+  }
+
+  get packageManagerSpec(): string {
+    switch (this.packageManagerName) {
+      case "bun":
+        return "bun@1.2.21";
+      case "npm":
+        return "npm@10.9.0";
+      case "pnpm":
+        return "pnpm@10.17.0";
     }
   }
 }

--- a/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
@@ -259,6 +259,71 @@ describe("BlueprintService", () => {
             ).toEqual(["apps/client-api", "apps/server-api"]);
           }),
       );
+
+      it.effect(
+        "should resolve the config-typescript-vite module on client selections",
+        () =>
+          Effect.gen(function* () {
+            const blueprintService = yield* BlueprintService;
+            const blueprint = yield* blueprintService.resolve({
+              targets: [
+                {
+                  identity: new TargetIdentity({
+                    kind: TargetKind.make("client"),
+                    name: "app",
+                  }),
+                  modules: [{ id: ModuleId.make("config-typescript-vite") }],
+                },
+              ],
+            });
+
+            expect(
+              getNode(
+                blueprint,
+                toAttachedModuleNodeId(
+                  new TargetIdentity({
+                    kind: TargetKind.make("client"),
+                    name: "app",
+                  }).toKey(),
+                  ModuleId.make("config-typescript-vite"),
+                ),
+              ),
+            ).toMatchObject({
+              _tag: "attached-module",
+              targetId: "apps/client-app",
+              moduleId: "config-typescript-vite",
+            });
+          }),
+      );
+
+      it.effect(
+        "should attach target-required modules for client even when none are selected",
+        () =>
+          Effect.gen(function* () {
+            const blueprintService = yield* BlueprintService;
+            const identity = new TargetIdentity({
+              kind: TargetKind.make("client"),
+              name: "required",
+            });
+            const blueprint = yield* blueprintService.resolve({
+              targets: [{ identity, modules: [] }],
+            });
+
+            expect(
+              getNode(
+                blueprint,
+                toAttachedModuleNodeId(
+                  identity.toKey(),
+                  ModuleId.make("config-typescript-vite"),
+                ),
+              ),
+            ).toMatchObject({
+              _tag: "attached-module",
+              targetId: "apps/client-required",
+              moduleId: "config-typescript-vite",
+            });
+          }),
+      );
     });
   });
 });

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -86,7 +86,7 @@ const validateSelection = Effect.fn("BlueprintService.validateSelection")(
       }
 
       selectedTargetKeys.add(targetKey);
-      yield* catalog.getTarget(target.identity.kind);
+      const targetDefinition = yield* catalog.getTarget(target.identity.kind);
 
       const selectedModuleIds = new Set<typeof ModuleId.Type>();
 
@@ -98,15 +98,24 @@ const validateSelection = Effect.fn("BlueprintService.validateSelection")(
         }
 
         selectedModuleIds.add(moduleSelection.id);
+      }
 
+      const moduleIds = Arr.fromIterable(
+        new Set([
+          ...Arr.map(target.modules, (moduleSelection) => moduleSelection.id),
+          ...(targetDefinition.requiredModules ?? []),
+        ]),
+      );
+
+      for (const moduleId of moduleIds) {
         const isSupported = yield* catalog.isSupportedOn(
-          moduleSelection.id,
+          moduleId,
           target.identity,
         );
 
         if (!isSupported) {
           throw new BlueprintFailure({
-            message: `Unsupported target-module combination: ${targetKey} requires module ${moduleSelection.id}`,
+            message: `Unsupported target-module combination: ${targetKey} requires module ${moduleId}`,
           });
         }
       }
@@ -248,8 +257,16 @@ const resolveSelection = Effect.fn("BlueprintService.resolveSelection")(
     for (const target of selection.targets) {
       yield* ensureTarget(target.identity);
 
-      for (const moduleSelection of target.modules) {
-        yield* ensureAttachedModule(target.identity, moduleSelection.id);
+      const targetDefinition = yield* catalog.getTarget(target.identity.kind);
+      const moduleIds = Arr.fromIterable(
+        new Set([
+          ...Arr.map(target.modules, (moduleSelection) => moduleSelection.id),
+          ...(targetDefinition.requiredModules ?? []),
+        ]),
+      );
+
+      for (const moduleId of moduleIds) {
+        yield* ensureAttachedModule(target.identity, moduleId);
       }
     }
 

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -140,6 +140,7 @@ const makeTokenContext = (
   targetName: identity.name,
   runtime: config.config.runtimeName,
   packageManager: config.config.packageManagerName,
+  packageManagerSpec: config.config.packageManagerSpec,
   projectName: config.config.name,
 });
 

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -41,6 +41,7 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
                 targetName: node.identity.name,
                 runtime: config.runtimeName,
                 packageManager: config.packageManagerName,
+                packageManagerSpec: config.packageManagerSpec,
                 projectName: config.name,
               };
 
@@ -106,15 +107,22 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
 export const resolveTokenString = (
   value: string,
   context: typeof ContributionTokenContext.Type,
-): string =>
-  value
+): string => {
+  const resolvedTargetName =
+    context.targetName.trim().length > 0
+      ? context.targetName
+      : context.targetKind;
+
+  return value
     .replaceAll("{{targetPath}}", context.targetPath)
     .replaceAll("{{targetDir}}", context.targetPath)
     .replaceAll("{{targetKind}}", context.targetKind)
-    .replaceAll("{{targetName}}", context.targetName)
+    .replaceAll("{{targetName}}", resolvedTargetName)
     .replaceAll("{{runtime}}", context.runtime)
     .replaceAll("{{packageManager}}", context.packageManager)
+    .replaceAll("{{packageManagerSpec}}", context.packageManagerSpec)
     .replaceAll("{{projectName}}", context.projectName);
+};
 
 const resolveContributionTokens = (
   contributions: typeof DesiredContributions.Type,


### PR DESCRIPTION
## Goals/Scope

Add LLM mode for CLI with improved configuration and non-interactive capabilities.

## Description

- Simplified CLI start scripts and config setup
- Added config-typescript-vite module for client
- Implemented non-interactive mode with CLI flags