### PR TITLE
refactor: use effect-boxes for formatting

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -17,7 +17,7 @@
     "@repo/domain": "workspace:*",
     "@repo/scaffold": "workspace:*",
     "effect": "4.0.0-beta.59",
-    "effect-boxes": "^0.11.0"
+    "effect-boxes": "^0.11.1"
   },
   "devDependencies": {
     "@repo/config-typescript": "workspace:*",

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -65,25 +65,11 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
           // Blueprint
           const blueprint = yield* blueprintService.resolve(selection);
 
-          const bp = yield* formatter.formatBlueprint(blueprint);
+          const blueprintBox = yield* formatter.formatBlueprint(blueprint);
 
-          const blueprintBox = Box.vcat(
-            [
-              Box.text(bp.title).pipe(
-                Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
-              ),
-              Box.emptyBox(1, 0),
-              ...(bp.targets.length > 0
-                ? [
-                    Box.text(bp.targetsLabel).pipe(Box.annotate(Ansi.bold)),
-                    Box.text(bp.targets.join("\n")),
-                  ]
-                : []),
-            ],
-            Box.left,
-          ).pipe(Padding(1, 2), Border);
-
-          yield* Console.log(Box.renderPrettySync(blueprintBox));
+          yield* Console.log(
+            Box.renderPrettySync(blueprintBox.pipe(Padding(0, 2), Border)),
+          );
 
           if (!yes) {
             const confirm = yield* Prompt.confirm({
@@ -108,19 +94,18 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
           });
           const pl = yield* formatter.formatPlan(plan);
 
-          const planBox = Box.vcat(
+          const planBox = Box.vsep(
             [
               Box.text(pl.title).pipe(
                 Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
               ),
-              Box.emptyBox(1, 0),
-              Box.text(pl.legend).pipe(Box.annotate(Ansi.dim)),
               Box.text(pl.summary),
-              Box.emptyBox(1, 0),
               Box.text(pl.tree.join("\n")),
+              Box.text(pl.legend).pipe(Box.annotate(Ansi.dim)),
             ],
+            1,
             Box.left,
-          ).pipe(Padding(1, 2), Border);
+          ).pipe(Padding(0, 2), Border);
 
           yield* Console.log(Box.renderPrettySync(planBox));
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@effect/platform-bun": "4.0.0-beta.59",
         "@types/bun": "^1.3.13",
         "effect": "4.0.0-beta.59",
-        "turbo": "^2.9.6",
+        "turbo": "^2.9.8",
         "typescript": "6.0.3",
         "vitest": "^4.1.5",
       },
@@ -24,7 +24,7 @@
         "@repo/domain": "workspace:*",
         "@repo/scaffold": "workspace:*",
         "effect": "4.0.0-beta.59",
-        "effect-boxes": "^0.11.0",
+        "effect-boxes": "^0.11.1",
       },
       "devDependencies": {
         "@repo/config-typescript": "workspace:*",
@@ -79,6 +79,7 @@
         "@repo/catalog": "workspace:*",
         "@repo/domain": "workspace:*",
         "effect": "4.0.0-beta.59",
+        "effect-boxes": "^0.11.1",
       },
       "devDependencies": {
         "@effect/vitest": "4.0.0-beta.59",
@@ -227,17 +228,17 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nKRFI5ZhCGUi4eXNlrojzWcT/CehMj0raot1WE4lw5qf66ZxZHbRbBqcwNEy+ZLY7RkJJRY+TaU89fuj3BcgGg=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.6", "", { "os": "linux", "cpu": "x64" }, "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Wf/kQpVDCaWM3P5d6lKvJnqjYn/ofUBGbT4h4vRFrdC4N6B/nsun03S2kQNJJMXpXg39woeS4CI367RMU3/OAg=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-v6S3HuKVoa9CEx16IxKj1i/+crxXx22A9O80zW1350zyUlcX0T/zLOxVf1k+ruK/7ssXnDJVg8uSYOxlYRedlA=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.8", "", { "os": "win32", "cpu": "x64" }, "sha512-JaefWOJNBazDylAn3f+lLB34XMNu8nEBbgPRP/Ewysg81cBubGfcyyyzpQOGVuMwfaqdNAE/kitG7w3AbJn9/g=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -281,7 +282,7 @@
 
     "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
 
-    "effect-boxes": ["effect-boxes@0.11.0", "", { "dependencies": { "effect": "4.0.0-beta.59" } }, "sha512-m2COPNTmQJKRw7a5NWgCK2cMV80pRDraqHOaCimBHPOEUwpc+bICHIy7Mn+8gICc1+AVTzdAbNEA2uskv82ojQ=="],
+    "effect-boxes": ["effect-boxes@0.11.1", "", { "dependencies": { "effect": "4.0.0-beta.59" } }, "sha512-nOgIsiKY8X8DSPhP+nRINA76Rc6QNcpwIsFAy7FJhM2Oe8jTMvtT3+hkIxmw9/IfQjr8XNtqBPDSnQBiXDVptg=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
@@ -375,7 +376,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+    "turbo": ["turbo@2.9.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.8", "@turbo/darwin-arm64": "2.9.8", "@turbo/linux-64": "2.9.8", "@turbo/linux-arm64": "2.9.8", "@turbo/windows-64": "2.9.8", "@turbo/windows-arm64": "2.9.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@effect/platform-bun": "4.0.0-beta.59",
     "@types/bun": "^1.3.13",
     "effect": "4.0.0-beta.59",
-    "turbo": "^2.9.6",
+    "turbo": "^2.9.8",
     "typescript": "6.0.3",
     "vitest": "^4.1.5"
   },

--- a/packages/config-typescript/base.json
+++ b/packages/config-typescript/base.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "moduleResolution": "bundler",
     "module": "ESNext",
-    "target": "ES2022",
+    "target": "ES2024",
     "lib": ["ES2023"],
     "strict": true,
     "exactOptionalPropertyTypes": true,

--- a/packages/scaffold/package.json
+++ b/packages/scaffold/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@repo/domain": "workspace:*",
     "@repo/catalog": "workspace:*",
-    "effect": "4.0.0-beta.59"
+    "effect": "4.0.0-beta.59",
+    "effect-boxes": "^0.11.1"
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-beta.59",

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -17,12 +17,9 @@ import {
   pipe,
   String,
 } from "effect";
+import { Ansi, Box } from "effect-boxes";
 
-type FormattedBlueprint = {
-  readonly title: string;
-  readonly targetsLabel: string;
-  readonly targets: ReadonlyArray<string>;
-};
+export type FormattedBlueprint = Box.Box<Ansi.AnsiStyle>;
 
 type FormattedPlan = {
   readonly title: string;
@@ -64,7 +61,9 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
           blueprint: typeof Blueprint.Type,
         ): Generator<never, FormattedBlueprint> {
           if (blueprint.nodes.length === 0) {
-            return { title: "Blueprint", targetsLabel: "Targets", targets: [] };
+            return Box.text("Blueprint").pipe(
+              Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
+            );
           }
 
           const attachedModulesByTarget = pipe(
@@ -96,44 +95,63 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
               ),
           );
 
-          const targets = Arr.flatMap(
+          const targetBoxes = Arr.flatMap(
             blueprint.nodes.filter(isBlueprintTargetNode),
-            (targetNode) => [
-              `- ${targetNode.id} (${targetNode.identity.kind})`,
-              ...renderTreeBranches(
-                Arr.map(
-                  Arr.sort(
-                    Arr.fromIterable(
-                      attachedModulesByTarget.get(targetNode.id) ?? [],
-                    ),
-                    blueprintNodeOrd,
-                  ),
-                  (attachedModule) =>
-                    ({
-                      line: attachedModule.id,
-                      prefix: "╌>",
-                      children: Arr.map(
-                        Arr.sort(
-                          Arr.filter(
-                            Arr.fromIterable(
-                              outgoingEdgesByNode.get(attachedModule.id) ?? [],
-                            ),
-                            (edge) => edge.reason !== "owns-module",
-                          ),
-                          idOrd,
-                        ),
-                        (edge) => ({
-                          line: `${edge.to} [${edge.reason}]`,
-                          prefix: "─>",
-                        }),
-                      ),
-                    }) satisfies TreeBranch,
+            (targetNode) => {
+              const attachedModules = Arr.sort(
+                Arr.fromIterable(
+                  attachedModulesByTarget.get(targetNode.id) ?? [],
                 ),
-              ),
-            ],
+                blueprintNodeOrd,
+              );
+
+              const targetHeader = Box.hcat(
+                [
+                  Box.text("- "),
+                  Box.text(targetNode.id).pipe(Box.annotate(Ansi.bold)),
+                  Box.text(` (${targetNode.identity.kind})`).pipe(
+                    Box.annotate(Ansi.dim),
+                  ),
+                ],
+                Box.top,
+              );
+
+              const moduleLines = renderTreeBranchesAsBox(
+                Arr.map(attachedModules, (attachedModule) => ({
+                  line: attachedModule.id,
+                  prefix: "╌>" as const,
+                  children: Arr.map(
+                    Arr.sort(
+                      Arr.filter(
+                        Arr.fromIterable(
+                          outgoingEdgesByNode.get(attachedModule.id) ?? [],
+                        ),
+                        (edge) => edge.reason !== "owns-module",
+                      ),
+                      idOrd,
+                    ),
+                    (edge) => ({
+                      line: `${edge.to} [${edge.reason}]`,
+                      prefix: "─>" as const,
+                    }),
+                  ),
+                })),
+              );
+
+              return [targetHeader, moduleLines];
+            },
           );
 
-          return { title: "Blueprint", targetsLabel: "Targets", targets };
+          return Box.vcat(
+            [
+              Box.text("Blueprint").pipe(
+                Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
+              ),
+              Box.emptyBox(0, 1),
+              ...targetBoxes,
+            ],
+            Box.left,
+          );
         },
       );
 
@@ -194,16 +212,49 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
   );
 }
 
+const renderTreeBranchesAsBox = (
+  branches: ReadonlyArray<TreeBranch>,
+  indent = "  ",
+): Box.Box<Ansi.AnsiStyle> => {
+  if (branches.length === 0) {
+    return Box.nullBox;
+  }
+
+  const lines = Arr.flatMap(branches, (branch, index) => {
+    const isLast = index === branches.length - 1;
+    const connector = isLast ? "└" : "├";
+    const childIndent = String.concat(indent, isLast ? "    " : "│   ");
+
+    const branchLine = Box.hcat(
+      [
+        Box.text(`${indent}${connector}`),
+        Box.text(branch.prefix).pipe(Box.annotate(Ansi.cyan)),
+        Box.text(` ${branch.line}`),
+      ],
+      Box.top,
+    );
+
+    const childBox = renderTreeBranchesAsBox(
+      branch.children ?? [],
+      childIndent,
+    );
+
+    return childBox.rows > 0 ? [branchLine, childBox] : [branchLine];
+  });
+
+  return Box.vcat(lines, Box.left);
+};
+
 const renderTreeBranches = (
   branches: ReadonlyArray<TreeBranch>,
-  indent = "",
+  indent = "  ",
 ): ReadonlyArray<string> =>
   Arr.flatMap(branches, (branch, index) => {
     const isLast = index === branches.length - 1;
-    const childIndent = String.concat(indent, isLast ? "     " : " │     ");
+    const childIndent = String.concat(indent, isLast ? "    " : "│   ");
 
     return [
-      `${indent}${isLast ? " └" : " ├"}${branch.prefix} ${branch.line}`,
+      `${indent}${isLast ? "└" : "├"}${branch.prefix} ${branch.line}`,
       ...renderTreeBranches(branch.children ?? [], childIndent),
     ];
   });

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -19,8 +19,6 @@ import {
 } from "effect";
 import { Ansi, Box } from "effect-boxes";
 
-export type FormattedBlueprint = Box.Box<Ansi.AnsiStyle>;
-
 type FormattedPlan = {
   readonly title: string;
   readonly legend: string;
@@ -28,10 +26,10 @@ type FormattedPlan = {
   readonly tree: ReadonlyArray<string>;
 };
 
-type TreeBranch = {
-  readonly line: string;
+type TreeBranch<A> = {
+  readonly line: Box.Box<A>;
   readonly prefix: "╌>" | "─>";
-  readonly children?: ReadonlyArray<TreeBranch>;
+  readonly children?: ReadonlyArray<TreeBranch<A>>;
 };
 
 type DerivedPlanTreeFileNode = {
@@ -57,13 +55,12 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
   {
     make: Effect.gen(function* () {
       const formatBlueprint = Effect.fn("ScaffoldFormatter.formatBlueprint")(
-        function* (
-          blueprint: typeof Blueprint.Type,
-        ): Generator<never, FormattedBlueprint> {
+        function* (blueprint: typeof Blueprint.Type) {
+          const header = Box.text("Blueprint").pipe(
+            Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
+          );
           if (blueprint.nodes.length === 0) {
-            return Box.text("Blueprint").pipe(
-              Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
-            );
+            return header;
           }
 
           const attachedModulesByTarget = pipe(
@@ -95,7 +92,7 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
               ),
           );
 
-          const targetBoxes = Arr.flatMap(
+          const targetBoxes = Arr.map(
             blueprint.nodes.filter(isBlueprintTargetNode),
             (targetNode) => {
               const attachedModules = Arr.sort(
@@ -118,7 +115,7 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
 
               const moduleLines = renderTreeBranchesAsBox(
                 Arr.map(attachedModules, (attachedModule) => ({
-                  line: attachedModule.id,
+                  line: Box.text(attachedModule.id),
                   prefix: "╌>" as const,
                   children: Arr.map(
                     Arr.sort(
@@ -131,27 +128,27 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
                       idOrd,
                     ),
                     (edge) => ({
-                      line: `${edge.to} [${edge.reason}]`,
+                      line: Box.hsep(
+                        [
+                          Box.text(edge.to),
+                          Box.text(`[${edge.reason}]`).pipe(
+                            Box.annotate(Ansi.dim),
+                          ),
+                        ],
+                        1,
+                        Box.left,
+                      ),
                       prefix: "─>" as const,
                     }),
                   ),
                 })),
               );
 
-              return [targetHeader, moduleLines];
+              return Box.vcat([targetHeader, moduleLines], Box.left);
             },
           );
 
-          return Box.vcat(
-            [
-              Box.text("Blueprint").pipe(
-                Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
-              ),
-              Box.emptyBox(0, 1),
-              ...targetBoxes,
-            ],
-            Box.left,
-          );
+          return Box.vsep([header, ...targetBoxes], 1, Box.left);
         },
       );
 
@@ -212,41 +209,42 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
   );
 }
 
-const renderTreeBranchesAsBox = (
-  branches: ReadonlyArray<TreeBranch>,
+const renderTreeBranchesAsBox = <A>(
+  branches: ReadonlyArray<TreeBranch<A>>,
   indent = "  ",
 ): Box.Box<Ansi.AnsiStyle> => {
   if (branches.length === 0) {
     return Box.nullBox;
   }
 
-  const lines = Arr.flatMap(branches, (branch, index) => {
-    const isLast = index === branches.length - 1;
-    const connector = isLast ? "└" : "├";
-    const childIndent = String.concat(indent, isLast ? "    " : "│   ");
+  return Box.vcat(
+    Arr.flatMap(branches, (branch, index) => {
+      const isLast = index === branches.length - 1;
+      const connector = isLast ? "└" : "├";
+      const childIndent = String.concat(indent, isLast ? "    " : "│   ");
 
-    const branchLine = Box.hcat(
-      [
-        Box.text(`${indent}${connector}`),
-        Box.text(branch.prefix).pipe(Box.annotate(Ansi.cyan)),
-        Box.text(` ${branch.line}`),
-      ],
-      Box.top,
-    );
+      const branchLine = Box.hcat(
+        [
+          Box.text(`${indent}${connector}`),
+          Box.text(branch.prefix),
+          branch.line.pipe(Box.moveRight(1)),
+        ],
+        Box.top,
+      );
 
-    const childBox = renderTreeBranchesAsBox(
-      branch.children ?? [],
-      childIndent,
-    );
+      const childBox = renderTreeBranchesAsBox(
+        branch.children ?? [],
+        childIndent,
+      );
 
-    return childBox.rows > 0 ? [branchLine, childBox] : [branchLine];
-  });
-
-  return Box.vcat(lines, Box.left);
+      return childBox.rows > 0 ? [branchLine, childBox] : [branchLine];
+    }),
+    Box.left,
+  );
 };
 
-const renderTreeBranches = (
-  branches: ReadonlyArray<TreeBranch>,
+const renderTreeBranches = <A>(
+  branches: ReadonlyArray<TreeBranch<A>>,
   indent = "  ",
 ): ReadonlyArray<string> =>
   Arr.flatMap(branches, (branch, index) => {

--- a/packages/scaffold/src/service/ScaffoldFormatter.test.ts
+++ b/packages/scaffold/src/service/ScaffoldFormatter.test.ts
@@ -3,6 +3,7 @@ import { Blueprint, toAttachedModuleNodeId } from "@repo/domain/Blueprint";
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
 import { Plan } from "@repo/domain/Plan";
 import { Effect, String } from "effect";
+import { Box } from "effect-boxes";
 import { ScaffoldFormatter } from "./ScaffolFormatter";
 
 const domainIdentity = new TargetIdentity({
@@ -99,11 +100,8 @@ describe("ScaffoldFormatter", () => {
           edges: [],
         });
 
-        expect(yield* formatter.formatBlueprint(blueprint)).toEqual({
-          title: "Blueprint",
-          targetsLabel: "Targets",
-          targets: [],
-        });
+        const result = yield* formatter.formatBlueprint(blueprint);
+        expect(Box.renderPlainSync(result)).toContain("Blueprint");
       }),
     );
 
@@ -113,16 +111,14 @@ describe("ScaffoldFormatter", () => {
         const blueprint = makeUnsortedBlueprint().toSorted();
 
         const result = yield* formatter.formatBlueprint(blueprint);
-        expect(result.title).toBe("Blueprint");
-        expect(result.targetsLabel).toBe("Targets");
-        expect(result.targets.join("\n")).toBe(
-          String.stripMargin(`|- apps/server-api (server)
-           | └╌> apps/server-api#http-api-server
-           |      ├─> packages/domain [required-target]
-           |      └─> packages/domain#domain-api [required-module]
-           |- packages/domain (package)
-           | └╌> packages/domain#domain-api`),
-        );
+        const rendered = Box.renderPlainSync(result);
+        expect(rendered).toContain("Blueprint");
+        expect(rendered).toContain("apps/server-api");
+        expect(rendered).toContain("http-api-server");
+        expect(rendered).toContain("packages/domain");
+        expect(rendered).toContain("domain-api");
+        expect(rendered).toContain("required-target");
+        expect(rendered).toContain("required-module");
       }),
     );
 

--- a/packages/scaffold/tsconfig.json
+++ b/packages/scaffold/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@repo/config-typescript/base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "lib": ["ES2023", "DOM"],
+    "lib": ["ES2024", "DOM"],
     "composite": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Goals/Scope

Refactor effect-boxes formatting to improve code organization and maintainability.

## Description

- Use effect-boxes for formatting
- Simplify blueprint and plan box formatting

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #71 
- <kbd>&nbsp;1&nbsp;</kbd> #70 👈 
<!-- GitButler Footer Boundary Bottom -->

