### PR TITLE
refactor: extract tagged unions to simplify types

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,5 +1,4 @@
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
-import type { Runtime } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
 import { Console, Effect, Option, Schema } from "effect";
 import { Argument, Command, Flag, Prompt } from "effect/unstable/cli";

--- a/packages/domain/src/Blueprint.ts
+++ b/packages/domain/src/Blueprint.ts
@@ -28,18 +28,21 @@ export const BlueprintAttachedModuleNode = Schema.TaggedStruct(
   },
 );
 
+export const BlueprintNode = Schema.Union([
+  BlueprintTargetNode,
+  BlueprintAttachedModuleNode,
+]).pipe(Schema.toTaggedUnion("_tag"));
+
 export const blueprintNodeOrd = Order.mapInput(
-  Order.combineAll<(typeof Blueprint.fields.nodes.Type)[0]>([
+  Order.combineAll<typeof BlueprintNode.Type>([
     Order.mapInput(Order.String, (node) => node._tag),
     Order.mapInput(Order.String, (node) => node.id),
   ]),
-  (node: (typeof Blueprint.fields.nodes.Type)[0]) => node,
+  (node: typeof BlueprintNode.Type) => node,
 );
 
 export class Blueprint extends Schema.Class<Blueprint>("Blueprint")({
-  nodes: Schema.Array(
-    Schema.Union([BlueprintTargetNode, BlueprintAttachedModuleNode]),
-  ),
+  nodes: Schema.Array(BlueprintNode),
   edges: Schema.Array(
     Schema.Struct({
       id: Schema.NonEmptyString,
@@ -63,26 +66,17 @@ export class Blueprint extends Schema.Class<Blueprint>("Blueprint")({
   hasTarget(targetId: string): boolean {
     return this.nodes.some(
       (node): node is typeof BlueprintTargetNode.Type =>
-        isBlueprintTargetNode(node) && node.id === targetId,
+        BlueprintNode.guards.target(node) && node.id === targetId,
     );
   }
 
   getTarget(targetId: string): typeof BlueprintTargetNode.Type | undefined {
     return this.nodes.find(
       (node): node is typeof BlueprintTargetNode.Type =>
-        isBlueprintTargetNode(node) && node.id === targetId,
+        BlueprintNode.guards.target(node) && node.id === targetId,
     );
   }
 }
-
-export const isBlueprintTargetNode = (
-  node: (typeof Blueprint.fields.nodes.Type)[0],
-): node is typeof BlueprintTargetNode.Type => node._tag === "target";
-
-export const isBlueprintAttachedModuleNode = (
-  node: (typeof Blueprint.fields.nodes.Type)[0],
-): node is typeof BlueprintAttachedModuleNode.Type =>
-  node._tag === "attached-module";
 
 export const toAttachedModuleNodeId = (
   targetId: typeof TargetKey.Type,

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -50,23 +50,21 @@ export class TargetIdentity extends Schema.Class<TargetIdentity>(
   }
 
   matches(supportedOn: typeof SupportedOn.Type): boolean {
-    switch (supportedOn._tag) {
-      case "identity":
-        return supportedOn.identity.toKey() === this.toKey();
-      case "kind":
-        return supportedOn.kind === this.kind;
-    }
+    return SupportedOn.match(supportedOn, {
+      identity: (s) => s.identity.toKey() === this.toKey(),
+      kind: (s) => s.kind === this.kind,
+    });
   }
 }
 
-export const SupportedOn = Schema.Union([
-  Schema.TaggedStruct("kind", {
+export const SupportedOn = Schema.TaggedUnion({
+  kind: {
     kind: TargetKind,
-  }),
-  Schema.TaggedStruct("identity", {
+  },
+  identity: {
     identity: TargetIdentity,
-  }),
-]);
+  },
+});
 
 export const ScriptPhase = Schema.Literals(["post", "finalize"]);
 
@@ -212,14 +210,14 @@ export const TargetDefinition = Schema.Struct({
   ),
 });
 
-export const CatalogNode = Schema.Union([
-  Schema.TaggedStruct("target", {
+export const CatalogNode = Schema.TaggedUnion({
+  target: {
     definition: TargetDefinition,
-  }),
-  Schema.TaggedStruct("module", {
+  },
+  module: {
     definition: ModuleDefinition,
-  }),
-]);
+  },
+});
 
 export const CatalogEdge = Schema.Literals([
   "supportedOn",

--- a/packages/domain/src/Plan.ts
+++ b/packages/domain/src/Plan.ts
@@ -1,21 +1,25 @@
 import { Order, Schema } from "effect";
 import { pathOrd } from "./Order";
 
+// =============================================================================
+// RepoSnapshot Path States
+// =============================================================================
+
+export const RepoSnapshotPath = Schema.TaggedUnion({
+  missing: {
+    path: Schema.String,
+  },
+  directory: {
+    path: Schema.String,
+  },
+  file: {
+    path: Schema.String,
+    contents: Schema.String,
+  },
+});
+
 export const RepoSnapshot = Schema.Struct({
-  paths: Schema.Array(
-    Schema.Union([
-      Schema.TaggedStruct("missing", {
-        path: Schema.String,
-      }),
-      Schema.TaggedStruct("directory", {
-        path: Schema.String,
-      }),
-      Schema.TaggedStruct("file", {
-        path: Schema.String,
-        contents: Schema.String,
-      }),
-    ]),
-  ),
+  paths: Schema.Array(RepoSnapshotPath),
 });
 
 export class PlanFailure extends Schema.TaggedErrorClass<PlanFailure>()(
@@ -108,54 +112,54 @@ export const PlanEntryClassification = Schema.Literals([
   "conflict",
 ]);
 
+export const PlanOutcome = Schema.TaggedUnion({
+  complete: {
+    path: Schema.String,
+    classification: PlanEntryClassification,
+    contents: Schema.String,
+  },
+  composed: {
+    path: Schema.String,
+    classification: PlanEntryClassification,
+    seedContents: Schema.optional(Schema.String),
+    operations: Schema.Array(CompositionOperation),
+  },
+});
+
+export const PlanConflict = Schema.TaggedUnion({
+  exports: {
+    path: Schema.String,
+    name: Schema.String,
+  },
+  dependencies: {
+    path: Schema.String,
+    section: Schema.String,
+    name: Schema.String,
+  },
+  scripts: {
+    path: Schema.String,
+    name: Schema.String,
+  },
+  barrelExport: {
+    path: Schema.String,
+    exportPath: Schema.String,
+  },
+  tsconfig: {
+    path: Schema.String,
+  },
+  completeFile: {
+    path: Schema.String,
+  },
+  compositionTargetNotFound: {
+    path: Schema.String,
+    targetVariable: Schema.String,
+    functionName: Schema.String,
+  },
+});
+
 export class Plan extends Schema.Class<Plan>("Plan")({
-  outcomes: Schema.Array(
-    Schema.Union([
-      Schema.TaggedStruct("complete", {
-        path: Schema.String,
-        classification: PlanEntryClassification,
-        contents: Schema.String,
-      }),
-      Schema.TaggedStruct("composed", {
-        path: Schema.String,
-        classification: PlanEntryClassification,
-        seedContents: Schema.optional(Schema.String),
-        operations: Schema.Array(CompositionOperation),
-      }),
-    ]),
-  ),
-  conflicts: Schema.Array(
-    Schema.Union([
-      Schema.TaggedStruct("exports", {
-        path: Schema.String,
-        name: Schema.String,
-      }),
-      Schema.TaggedStruct("dependencies", {
-        path: Schema.String,
-        section: Schema.String,
-        name: Schema.String,
-      }),
-      Schema.TaggedStruct("scripts", {
-        path: Schema.String,
-        name: Schema.String,
-      }),
-      Schema.TaggedStruct("barrelExport", {
-        path: Schema.String,
-        exportPath: Schema.String,
-      }),
-      Schema.TaggedStruct("tsconfig", {
-        path: Schema.String,
-      }),
-      Schema.TaggedStruct("completeFile", {
-        path: Schema.String,
-      }),
-      Schema.TaggedStruct("compositionTargetNotFound", {
-        path: Schema.String,
-        targetVariable: Schema.String,
-        functionName: Schema.String,
-      }),
-    ]),
-  ),
+  outcomes: Schema.Array(PlanOutcome),
+  conflicts: Schema.Array(PlanConflict),
 }) {
   toSorted(): Plan {
     return new Plan({
@@ -163,24 +167,18 @@ export class Plan extends Schema.Class<Plan>("Plan")({
       conflicts: [...this.conflicts].sort(
         Order.mapInput(
           Order.String,
-          (conflict: typeof Plan.fields.conflicts.schema.Type): string => {
-            switch (conflict._tag) {
-              case "exports":
-                return `exports:${conflict.path}:${conflict.name}`;
-              case "dependencies":
-                return `dependencies:${conflict.path}:${conflict.section}:${conflict.name}`;
-              case "scripts":
-                return `scripts:${conflict.path}:${conflict.name}`;
-              case "barrelExport":
-                return `barrelExport:${conflict.path}:${conflict.exportPath}`;
-              case "tsconfig":
-                return `tsconfig:${conflict.path}`;
-              case "completeFile":
-                return `completeFile:${conflict.path}`;
-              case "compositionTargetNotFound":
-                return `compositionTargetNotFound:${conflict.path}:${conflict.targetVariable}:${conflict.functionName}`;
-            }
-          },
+          (conflict: typeof PlanConflict.Type): string =>
+            PlanConflict.match(conflict, {
+              exports: (c) => `exports:${c.path}:${c.name}`,
+              dependencies: (c) =>
+                `dependencies:${c.path}:${c.section}:${c.name}`,
+              scripts: (c) => `scripts:${c.path}:${c.name}`,
+              barrelExport: (c) => `barrelExport:${c.path}:${c.exportPath}`,
+              tsconfig: (c) => `tsconfig:${c.path}`,
+              completeFile: (c) => `completeFile:${c.path}`,
+              compositionTargetNotFound: (c) =>
+                `compositionTargetNotFound:${c.path}:${c.targetVariable}:${c.functionName}`,
+            }),
         ),
       ),
     });

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -33,13 +33,12 @@ export const ContributionTokenContext = Schema.Struct({
   projectName: Schema.NonEmptyString,
 });
 
-const Runtime = Schema.Union([
-  Schema.TaggedStruct("bun", {}),
-  Schema.TaggedStruct("node", {
+const Runtime = Schema.TaggedUnion({
+  bun: {},
+  node: {
     packageManager: Schema.Literals(["pnpm", "npm"]),
-  }),
-]);
-export type Runtime = Schema.Schema.Type<typeof Runtime>;
+  },
+});
 
 export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   name: Schema.NonEmptyString,
@@ -54,12 +53,10 @@ export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   }
 
   get packageManagerName(): "bun" | "npm" | "pnpm" {
-    switch (this.runtime._tag) {
-      case "bun":
-        return "bun";
-      case "node":
-        return this.runtime.packageManager;
-    }
+    return Runtime.match(this.runtime, {
+      bun: () => "bun" as const,
+      node: (r) => r.packageManager,
+    });
   }
 
   get packageManagerSpec(): string {

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -1,12 +1,16 @@
 import {
   type Blueprint,
   type BlueprintAttachedModuleNode,
+  BlueprintNode,
   blueprintNodeOrd,
-  isBlueprintAttachedModuleNode,
-  isBlueprintTargetNode,
 } from "@repo/domain/Blueprint";
 import { idOrd } from "@repo/domain/Order";
-import type { Plan, PlanEntryClassification } from "@repo/domain/Plan";
+import type {
+  Plan,
+  PlanConflict,
+  PlanEntryClassification,
+  PlanOutcome,
+} from "@repo/domain/Plan";
 import {
   Array as Arr,
   Context,
@@ -65,7 +69,7 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
 
           const attachedModulesByTarget = pipe(
             blueprint.nodes,
-            Arr.filter(isBlueprintAttachedModuleNode),
+            Arr.filter(BlueprintNode.guards["attached-module"]),
             Arr.reduce(
               new Map<
                 string,
@@ -93,7 +97,7 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
           );
 
           const targetBoxes = Arr.map(
-            blueprint.nodes.filter(isBlueprintTargetNode),
+            blueprint.nodes.filter(BlueprintNode.guards.target),
             (targetNode) => {
               const attachedModules = Arr.sort(
                 Arr.fromIterable(
@@ -171,10 +175,7 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
 
         const conflictsByPath = Arr.reduce(
           plan.conflicts,
-          new Map<
-            string,
-            ReadonlyArray<typeof Plan.fields.conflicts.schema.Type>
-          >(),
+          new Map<string, ReadonlyArray<typeof PlanConflict.Type>>(),
           (groups, conflict) =>
             groups.set(
               conflict.path,
@@ -259,10 +260,7 @@ const renderTreeBranches = <A>(
 
 const renderPlanTreeChildren = (
   nodes: ReadonlyArray<DerivedPlanTreeNode>,
-  conflictsByPath: ReadonlyMap<
-    string,
-    ReadonlyArray<typeof Plan.fields.conflicts.schema.Type>
-  >,
+  conflictsByPath: ReadonlyMap<string, ReadonlyArray<typeof PlanConflict.Type>>,
   indent = "",
 ): ReadonlyArray<string> =>
   Arr.flatMap(nodes, (node, index) => {
@@ -293,7 +291,7 @@ const renderPlanTreeChildren = (
 
 const appendOutcomeToDirectoryNode = (
   root: DerivedPlanTreeDirectoryNode,
-  outcome: typeof Plan.fields.outcomes.schema.Type,
+  outcome: typeof PlanOutcome.Type,
 ): DerivedPlanTreeDirectoryNode =>
   appendNodeAtPath(root, String.split(outcome.path, "/"), {
     _tag: "file",
@@ -381,9 +379,7 @@ const formatPlanClassificationBadge = (
     Match.exhaustive,
   );
 
-const formatConflictLine = (
-  conflict: typeof Plan.fields.conflicts.schema.Type,
-): string =>
+const formatConflictLine = (conflict: typeof PlanConflict.Type): string =>
   Match.value(conflict).pipe(
     Match.tags({
       completeFile: () => "merge: complete file",

--- a/packages/scaffold/src/service/apply/ApplyService.test.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.test.ts
@@ -6,6 +6,7 @@ import {
   CompositionOperation,
   Plan,
   type PlanEntryClassification,
+  type PlanOutcome,
 } from "@repo/domain/Plan";
 import {
   Cause,
@@ -193,7 +194,7 @@ const completeOutcome = ({
   path: string;
   classification: typeof PlanEntryClassification.Type;
   contents: string;
-}): typeof Plan.fields.outcomes.schema.Type => ({
+}): typeof PlanOutcome.Type => ({
   _tag: "complete",
   path,
   classification,
@@ -208,7 +209,7 @@ const partialOutcome = ({
   path: string;
   classification: typeof PlanEntryClassification.Type;
   operations: ReadonlyArray<typeof CompositionOperation.Type>;
-}): typeof Plan.fields.outcomes.schema.Type => ({
+}): typeof PlanOutcome.Type => ({
   _tag: "composed",
   path,
   classification,

--- a/packages/scaffold/src/service/apply/TypeScriptComposer.ts
+++ b/packages/scaffold/src/service/apply/TypeScriptComposer.ts
@@ -41,20 +41,18 @@ export class TypeScriptComposer extends Context.Service<TypeScriptComposer>()(
         yield* Effect.forEach(
           operations,
           (op) =>
-            Effect.gen(function* () {
-              yield* Match.value(op).pipe(
-                Match.tag("ts-add-import", (importOp) =>
-                  Effect.sync(() => applyTsAddImport(sourceFile, importOp)),
-                ),
-                Match.tag("ts-add-reexport", (reexportOp) =>
-                  Effect.sync(() => applyTsAddReexport(sourceFile, reexportOp)),
-                ),
-                Match.tag("ts-append-call-arg", (appendOp) =>
-                  applyTsAppendCallArg(sourceFile, appendOp),
-                ),
-                Match.exhaustive,
-              );
-            }),
+            Match.value(op).pipe(
+              Match.tag("ts-add-import", (importOp) =>
+                Effect.sync(() => applyTsAddImport(sourceFile, importOp)),
+              ),
+              Match.tag("ts-add-reexport", (reexportOp) =>
+                Effect.sync(() => applyTsAddReexport(sourceFile, reexportOp)),
+              ),
+              Match.tag("ts-append-call-arg", (appendOp) =>
+                applyTsAppendCallArg(sourceFile, appendOp),
+              ),
+              Match.exhaustive,
+            ),
           { discard: true },
         );
 

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -1,9 +1,5 @@
 import { CatalogService } from "@repo/catalog";
-import {
-  type Blueprint,
-  isBlueprintAttachedModuleNode,
-  isBlueprintTargetNode,
-} from "@repo/domain/Blueprint";
+import { type Blueprint, BlueprintNode } from "@repo/domain/Blueprint";
 import type {
   ScriptDefinition,
   TargetIdentity,
@@ -42,9 +38,12 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
       )(function* (blueprint: typeof Blueprint.Type, config: FinalizeConfig) {
         const moduleNodes = Arr.filter(
           blueprint.nodes,
-          isBlueprintAttachedModuleNode,
+          BlueprintNode.guards["attached-module"],
         );
-        const targetNodes = Arr.filter(blueprint.nodes, isBlueprintTargetNode);
+        const targetNodes = Arr.filter(
+          blueprint.nodes,
+          BlueprintNode.guards.target,
+        );
 
         const sorted = topologicalSort(
           moduleNodes.map((n) => n.id),

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -1,9 +1,5 @@
 import { CatalogService } from "@repo/catalog";
-import {
-  type Blueprint,
-  isBlueprintAttachedModuleNode,
-  isBlueprintTargetNode,
-} from "@repo/domain/Blueprint";
+import { type Blueprint, BlueprintNode } from "@repo/domain/Blueprint";
 import type { DesiredContributions } from "@repo/domain/Catalog";
 import {
   type ContributionTokenContext,
@@ -30,7 +26,7 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
         config: typeof StackConfig.Type,
       ) {
         const targetResults = yield* Effect.forEach(
-          Arr.filter(blueprint.nodes, isBlueprintTargetNode),
+          Arr.filter(blueprint.nodes, BlueprintNode.guards.target),
           (node) =>
             Effect.gen(function* () {
               const definition = yield* catalog.getTarget(node.identity.kind);
@@ -63,7 +59,7 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
         );
 
         const moduleContributions = yield* pipe(
-          Arr.filter(blueprint.nodes, isBlueprintAttachedModuleNode),
+          Arr.filter(blueprint.nodes, BlueprintNode.guards["attached-module"]),
           Arr.filterMap((node) =>
             Result.map(
               Result.fromNullishOr(

--- a/packages/scaffold/src/service/plan/PlanAssessor.ts
+++ b/packages/scaffold/src/service/plan/PlanAssessor.ts
@@ -3,6 +3,7 @@ import {
   Plan,
   type PlanEntryClassification,
   PlanFailure,
+  type PlanOutcome,
   type RepoSnapshot,
 } from "@repo/domain/Plan";
 import {
@@ -69,7 +70,7 @@ function toPlannedFileOutcome({
 }: {
   planningPath: PlanningIntentPath;
   classification: typeof PlanEntryClassification.Type;
-}): typeof Plan.fields.outcomes.schema.Type {
+}): typeof PlanOutcome.Type {
   const operations = toCompositionOperations(planningPath);
   const hasOperations = operations.length > 0;
   const contents =

--- a/packages/scaffold/src/service/plan/PlanService.test.ts
+++ b/packages/scaffold/src/service/plan/PlanService.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { describe, expect, it } from "@effect/vitest";
 import { Blueprint, toAttachedModuleNodeId } from "@repo/domain/Blueprint";
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
-import type { Plan, PlanFailure, RepoSnapshot } from "@repo/domain/Plan";
+import type {
+  Plan,
+  PlanFailure,
+  PlanOutcome,
+  RepoSnapshot,
+} from "@repo/domain/Plan";
 import { StackConfig } from "@repo/domain/Scaffold";
 import { Cause, Effect, Exit, Layer } from "effect";
 import { ContributionResolver } from "./ContributionResolver";
@@ -148,7 +153,7 @@ const makeServerApiBlueprint = () =>
 const getOutcome = (
   plan: typeof Plan.Type,
   path: string,
-): typeof Plan.fields.outcomes.schema.Type => {
+): typeof PlanOutcome.Type => {
   const outcome = plan.outcomes.find((candidate) => candidate.path === path);
   expect(outcome).toBeDefined();
   assert(


### PR DESCRIPTION
## Goals/Scope

Refactor and simplify type structure by extracting tagged unions to top level and reducing complexity in type references.

## Description

- Extract tagged unions to top level for better organization
- Simplify type references to domain types