### PR TITLE
test: add e2e for cli

### DIFF
--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -1,0 +1,215 @@
+import { describe, layer } from "@effect/vitest";
+import { Effect } from "effect";
+import { CLI } from "./harness";
+
+/**
+ * Acceptance tests for `stack-effect add`.
+ *
+ * Each test scaffolds a project first, then adds modules and verifies
+ * the result is a working project.
+ */
+describe("add", () => {
+  layer(CLI.layer)("layer", (it) => {
+    it.effect(
+      "adds a domain-api module to a package target",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/add-test`;
+
+          yield* cli.run("init", "add-test", "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "package/domain",
+            "--modules",
+            "domain-api",
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("add-test", function* (project) {
+            yield* project.expectFileExists("packages/domain/package.json");
+            yield* project.expectTypeCheckPasses();
+          });
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 90_000 },
+    );
+
+    it.effect(
+      "rejects cross-target implications in non-interactive mode",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/impl-test`;
+
+          yield* cli.run("init", "impl-test", "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          // http-api-client implies http-api-server on server — rejected non-interactively
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "client/web",
+            "--modules",
+            "http-api-client",
+          );
+          yield* cli.expectExitCode(1);
+          yield* cli.expectOutputContaining("implies");
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
+      "dry-run add previews without writing",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/dry-add`;
+
+          yield* cli.run("init", "dry-add", "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "package/domain",
+            "--modules",
+            "domain-api",
+            "--dry-run",
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.expectFileNotExists(
+            "dry-add/packages/domain/package.json",
+          );
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
+      "allows client module when implied server target already exists (issue #78)",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/impl-exists`;
+
+          yield* cli.run("init", "impl-exists", "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          // First add domain-api (required by server)
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "package/domain",
+            "--modules",
+            "domain-api",
+          );
+          yield* cli.expectExitCode(0);
+
+          // Add server module first
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "server/api",
+            "--modules",
+            "http-api-server",
+          );
+          yield* cli.expectExitCode(0);
+
+          // Now add client module — should succeed since server already exists
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "client/web",
+            "--modules",
+            "http-api-client",
+            "--dry-run",
+          );
+          yield* cli.expectExitCode(0);
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 90_000 },
+    );
+
+    it.effect(
+      "adding server module with required-module dep on package/domain succeeds (issue #76)",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/dep-test`;
+
+          yield* cli.run("init", "dep-test", "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          // Add chat-server which depends on domain-chat on package/domain
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "server/api",
+            "--modules",
+            "chat-server",
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("dep-test", function* (project) {
+            yield* project.expectFileExists("packages/domain/package.json");
+            yield* project.expectFileExists("apps/server-api/package.json");
+          });
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 90_000 },
+    );
+
+    it.effect(
+      "ai module scaffolds with correct domain-chat dependency (issue #77)",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/ai-test`;
+
+          yield* cli.run("init", "ai-test", "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "package/ai",
+            "--modules",
+            "ai",
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("ai-test", function* (project) {
+            yield* project.expectFileExists("packages/ai/package.json");
+            yield* project.expectFileExists("packages/domain/package.json");
+            yield* project.expectTypeCheckPasses();
+          });
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 90_000 },
+    );
+  });
+});

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -1,0 +1,373 @@
+/**
+ * CLI Acceptance Test Harness
+ *
+ * A BDD-style DSL for testing the stack-effect CLI end-to-end.
+ * Uses a "test container" pattern where each scenario gets an isolated
+ * workspace that is automatically cleaned up via Effect scoping.
+ *
+ * @example
+ * ```typescript
+ * it.effect("init creates a buildable project", () =>
+ *   Effect.gen(function* () {
+ *     const cli = yield* CLI
+ *
+ *     yield* cli.run("init", "my-app", "--yes")
+ *     yield* cli.expectExitCode(0)
+ *
+ *     yield* cli.withinProject("my-app", function* (project) {
+ *       yield* project.install()
+ *       yield* project.expectBuildSucceeds()
+ *       yield* project.expectLintPasses()
+ *     })
+ *   }).pipe(Effect.provide(CLI.Live))
+ * )
+ * ```
+ */
+
+import { NodeServices } from "@effect/platform-node";
+import {
+  Context,
+  Effect,
+  FileSystem,
+  Layer,
+  Path,
+  Scope,
+  Stream,
+} from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+
+// ---------------------------------------------------------------------------
+// Helpers – process spawning via Effect ChildProcess
+// ---------------------------------------------------------------------------
+
+export interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * Spawn a command capturing stdout, stderr, and exit code.
+ * Requires ChildProcessSpawner in context.
+ */
+const spawnCommand = (
+  spawner: ChildProcessSpawner["Service"],
+  args: ReadonlyArray<string>,
+  cwd: string,
+) => {
+  const command = ChildProcess.make(args.join(" "), [], { cwd, shell: true });
+
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const handle = yield* spawner.spawn(command);
+      const [stdout, stderr, exitCode] = yield* Effect.all([
+        Stream.mkString(Stream.decodeText(handle.stdout)),
+        Stream.mkString(Stream.decodeText(handle.stderr)),
+        handle.exitCode,
+      ]);
+      return { exitCode: exitCode, stdout, stderr };
+    }),
+  ).pipe(Effect.orDie);
+};
+
+// ---------------------------------------------------------------------------
+// WorkspaceContainer – isolated temp directory with lifecycle
+// ---------------------------------------------------------------------------
+
+export class WorkspaceContainer extends Context.Service<WorkspaceContainer>()(
+  "e2e/WorkspaceContainer",
+  {
+    make: Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const scope = yield* Scope.Scope;
+      const dir = yield* fs.makeTempDirectory({
+        prefix: "stack-effect-e2e-",
+      });
+      yield* Scope.addFinalizer(
+        scope,
+        fs.remove(dir, { recursive: true }).pipe(
+          Effect.tap(() => Effect.log(`Cleaned workspace: ${dir}`)),
+          Effect.orDie,
+        ),
+      );
+      yield* Effect.log(`Created workspace: ${dir}`);
+      return { dir };
+    }).pipe(Effect.orDie),
+  },
+) {
+  static readonly layer = Layer.effect(
+    WorkspaceContainer,
+    WorkspaceContainer.make,
+  ).pipe(Layer.provide(NodeServices.layer));
+}
+
+// ---------------------------------------------------------------------------
+// ProjectContext – assertions within a generated project
+// ---------------------------------------------------------------------------
+
+export interface ProjectContext {
+  readonly dir: string;
+  readonly install: () => Effect.Effect<CommandResult>;
+  readonly exec: (
+    ...args: ReadonlyArray<string>
+  ) => Effect.Effect<CommandResult>;
+  readonly expectBuildSucceeds: () => Effect.Effect<void>;
+  readonly expectLintPasses: () => Effect.Effect<void>;
+  readonly expectFormatPasses: () => Effect.Effect<void>;
+  readonly expectTypeCheckPasses: () => Effect.Effect<void>;
+  readonly expectTestsPasses: () => Effect.Effect<void>;
+  readonly expectFileExists: (relativePath: string) => Effect.Effect<void>;
+  readonly expectFileContaining: (
+    relativePath: string,
+    pattern: string | RegExp,
+  ) => Effect.Effect<void>;
+  readonly expectDirectoryContains: (
+    relativePath: string,
+    entries: ReadonlyArray<string>,
+  ) => Effect.Effect<void>;
+}
+
+const makeProjectContext = (
+  projectDir: string,
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  spawner: ChildProcessSpawner["Service"],
+): ProjectContext => {
+  const run = (args: ReadonlyArray<string>) =>
+    spawnCommand(spawner, args, projectDir);
+
+  const assertCommand = (label: string, ...args: ReadonlyArray<string>) =>
+    run(args).pipe(
+      Effect.flatMap((r) =>
+        r.exitCode === 0
+          ? Effect.void
+          : Effect.die(
+              new Error(
+                `${label} failed (exit ${r.exitCode})\nstdout: ${r.stdout.slice(0, 500)}\nstderr: ${r.stderr.slice(0, 500)}`,
+              ),
+            ),
+      ),
+    );
+
+  return {
+    dir: projectDir,
+    install: () => run(["bun", "install"]),
+    exec: (...args) => run(args),
+    expectBuildSucceeds: () => assertCommand("Build", "bun", "run", "build"),
+    expectLintPasses: () => assertCommand("Lint", "bun", "lint"),
+    expectFormatPasses: () => assertCommand("Format", "bun", "format:check"),
+    expectTypeCheckPasses: () =>
+      assertCommand("TypeCheck", "bun", "run", "type-check"),
+    expectTestsPasses: () => assertCommand("Tests", "bun", "run", "test"),
+
+    expectFileExists: (relativePath) =>
+      fs.exists(path.join(projectDir, relativePath)).pipe(
+        Effect.flatMap((exists) =>
+          exists
+            ? Effect.void
+            : Effect.die(new Error(`Expected file to exist: ${relativePath}`)),
+        ),
+        Effect.orDie,
+      ),
+
+    expectFileContaining: (relativePath, pattern) =>
+      fs.readFileString(path.join(projectDir, relativePath)).pipe(
+        Effect.flatMap((content) => {
+          const matches =
+            typeof pattern === "string"
+              ? content.includes(pattern)
+              : pattern.test(content);
+          return matches
+            ? Effect.void
+            : Effect.die(
+                new Error(
+                  `File ${relativePath} does not match pattern: ${pattern}`,
+                ),
+              );
+        }),
+        Effect.orDie,
+      ),
+
+    expectDirectoryContains: (relativePath, entries) =>
+      fs.readDirectory(path.join(projectDir, relativePath)).pipe(
+        Effect.flatMap((dirEntries) => {
+          for (const entry of entries) {
+            if (!dirEntries.includes(entry)) {
+              return Effect.die(
+                new Error(
+                  `Directory ${relativePath} missing entry: ${entry}. Found: ${dirEntries.join(", ")}`,
+                ),
+              );
+            }
+          }
+          return Effect.void;
+        }),
+        Effect.orDie,
+      ),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// CLI Service – the primary DSL interface
+// ---------------------------------------------------------------------------
+
+const cliEntrypoint = new URL("../src/index.ts", import.meta.url).pathname;
+
+export class CLI extends Context.Service<CLI>()("e2e/CLI", {
+  make: Effect.gen(function* () {
+    const container = yield* WorkspaceContainer;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const spawner = yield* ChildProcessSpawner;
+    const workdir = container.dir;
+
+    const run = (args: ReadonlyArray<string>) =>
+      spawnCommand(spawner, args, workdir);
+
+    let lastResult: CommandResult = { exitCode: -1, stdout: "", stderr: "" };
+
+    return {
+      workdir,
+
+      run: (...args: ReadonlyArray<string>) =>
+        run(["bun", "run", cliEntrypoint, ...args]).pipe(
+          Effect.tap((r) =>
+            Effect.sync(() => {
+              lastResult = r;
+            }),
+          ),
+        ),
+
+      expectExitCode: (code: number) =>
+        Effect.suspend(() =>
+          lastResult.exitCode === code
+            ? Effect.void
+            : Effect.die(
+                new Error(
+                  `Expected exit code ${code}, got ${lastResult.exitCode}\nstdout: ${lastResult.stdout.slice(0, 1000)}\nstderr: ${lastResult.stderr.slice(0, 1000)}`,
+                ),
+              ),
+        ),
+
+      expectOutputContaining: (text: string) =>
+        Effect.suspend(() =>
+          lastResult.stdout.includes(text)
+            ? Effect.void
+            : Effect.die(
+                new Error(
+                  `Expected output to contain "${text}"\nGot: ${lastResult.stdout.slice(0, 1000)}`,
+                ),
+              ),
+        ),
+
+      expectErrorContaining: (text: string) =>
+        Effect.suspend(() =>
+          lastResult.stderr.includes(text)
+            ? Effect.void
+            : Effect.die(
+                new Error(
+                  `Expected stderr to contain "${text}"\nGot: ${lastResult.stderr.slice(0, 1000)}`,
+                ),
+              ),
+        ),
+
+      expectFileExists: (relativePath: string) =>
+        fs.exists(path.join(workdir, relativePath)).pipe(
+          Effect.flatMap((exists) =>
+            exists
+              ? Effect.void
+              : Effect.die(
+                  new Error(`Expected file to exist: ${relativePath}`),
+                ),
+          ),
+          Effect.orDie,
+        ),
+
+      expectFileNotExists: (relativePath: string) =>
+        fs.exists(path.join(workdir, relativePath)).pipe(
+          Effect.flatMap((exists) =>
+            exists
+              ? Effect.die(
+                  new Error(`Expected file NOT to exist: ${relativePath}`),
+                )
+              : Effect.void,
+          ),
+          Effect.orDie,
+        ),
+
+      expectFileContaining: (relativePath: string, pattern: string | RegExp) =>
+        fs.readFileString(path.join(workdir, relativePath)).pipe(
+          Effect.flatMap((content) => {
+            const matches =
+              typeof pattern === "string"
+                ? content.includes(pattern)
+                : pattern.test(content);
+            return matches
+              ? Effect.void
+              : Effect.die(
+                  new Error(`File ${relativePath} does not match: ${pattern}`),
+                );
+          }),
+          Effect.orDie,
+        ),
+
+      expectJsonFile: (
+        relativePath: string,
+        keyPath: string,
+        value?: unknown,
+      ) =>
+        fs.readFileString(path.join(workdir, relativePath)).pipe(
+          Effect.flatMap((content) => {
+            const json = JSON.parse(content);
+            const keys = keyPath.split(".");
+            let current: unknown = json;
+            for (const key of keys) {
+              if (current == null || typeof current !== "object") {
+                return Effect.die(
+                  new Error(
+                    `Key path "${keyPath}" not found in ${relativePath}`,
+                  ),
+                );
+              }
+              current = (current as Record<string, unknown>)[key];
+            }
+            if (current === undefined) {
+              return Effect.die(
+                new Error(`Key path "${keyPath}" not found in ${relativePath}`),
+              );
+            }
+            if (value !== undefined && current !== value) {
+              return Effect.die(
+                new Error(
+                  `Expected ${relativePath}[${keyPath}] = ${JSON.stringify(value)}, got ${JSON.stringify(current)}`,
+                ),
+              );
+            }
+            return Effect.void;
+          }),
+          Effect.orDie,
+        ),
+
+      withinProject: (
+        projectName: string,
+        fn: (
+          project: ProjectContext,
+        ) => Generator<Effect.Effect<any>, void, any>,
+      ) => {
+        const projectDir = path.join(workdir, projectName);
+        const project = makeProjectContext(projectDir, fs, path, spawner);
+        return Effect.gen(() => fn(project));
+      },
+    };
+  }),
+}) {
+  /**
+   * Full test layer – provides CLI with workspace container lifecycle.
+   * Each test gets a fresh temp directory that is cleaned up on completion.
+   */
+  static readonly layer = Layer.effect(CLI, CLI.make).pipe(
+    Layer.provide(WorkspaceContainer.layer),
+    Layer.provide(NodeServices.layer),
+  );
+}

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -1,0 +1,166 @@
+import { describe, layer } from "@effect/vitest";
+import { Effect } from "effect";
+import { CLI } from "./harness";
+
+/**
+ * Acceptance tests for `stack-effect init`.
+ *
+ * Each test reads like a user story:
+ * "When I init a project with --yes, then I expect it to build/lint/type-check."
+ */
+describe("init", () => {
+  layer(CLI.layer)("layer", (it) => {
+    it.effect(
+      "creates a project with default options",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "my-app",
+            "--yes",
+            "--root",
+            `${cli.workdir}/my-app`,
+          );
+
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileExists("my-app/package.json");
+          yield* cli.expectFileExists("my-app/tsconfig.json");
+          yield* cli.expectJsonFile("my-app/package.json", "name", "my-app");
+        }),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
+      "scaffolds expected monorepo structure",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "mono-app",
+            "--yes",
+            "--root",
+            `${cli.workdir}/mono-app`,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.expectFileExists("mono-app/turbo.json");
+          yield* cli.expectFileExists("mono-app/biome.jsonc");
+          yield* cli.expectFileExists("mono-app/package.json");
+        }),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
+      "dry-run does not write files",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "ghost-app",
+            "--yes",
+            "--dry-run",
+            "--root",
+            `${cli.workdir}/ghost-app`,
+          );
+
+          yield* cli.expectExitCode(1);
+          yield* cli.expectFileNotExists("ghost-app/package.json");
+        }),
+      { timeout: 15_000 },
+    );
+
+    it.effect(
+      "created project passes lint",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "lint-app",
+            "--yes",
+            "--root",
+            `${cli.workdir}/lint-app`,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("lint-app", function* (project) {
+            yield* project.expectLintPasses();
+          });
+        }),
+      { timeout: 60_000 },
+    );
+
+    it.effect(
+      "created project passes format check",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "format-app",
+            "--yes",
+            "--root",
+            `${cli.workdir}/format-app`,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("format-app", function* (project) {
+            yield* project.expectFormatPasses();
+          });
+        }),
+      { timeout: 60_000 },
+    );
+
+    it.effect(
+      "created project type-checks",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "typecheck-app",
+            "--yes",
+            "--root",
+            `${cli.workdir}/typecheck-app`,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("typecheck-app", function* (project) {
+            yield* project.expectTypeCheckPasses();
+          });
+        }),
+      { timeout: 60_000 },
+    );
+
+    it.effect(
+      "init --yes --runtime node does not prompt (issue #66)",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "node-app",
+            "--yes",
+            "--runtime",
+            "node",
+            "--root",
+            `${cli.workdir}/node-app`,
+          );
+
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileExists("node-app/package.json");
+        }),
+      { timeout: 30_000 },
+    );
+  });
+});

--- a/apps/cli/e2e/matrix.test.ts
+++ b/apps/cli/e2e/matrix.test.ts
@@ -1,0 +1,296 @@
+import { describe, layer } from "@effect/vitest";
+import { CatalogService } from "@repo/catalog";
+import { TargetKind } from "@repo/domain/Catalog";
+import { Array as Arr, Effect } from "effect";
+import { CLI } from "./harness";
+
+// ---------------------------------------------------------------------------
+// Matrix generation – derives valid combos from CatalogService at import time
+// ---------------------------------------------------------------------------
+
+/**
+ * Target identity used in CLI --target flag (kind/name).
+ * Modules that use identity-based supportedOn dictate the target name.
+ * For kind-based modules (server, client), we use a conventional name.
+ */
+interface MatrixEntry {
+  readonly target: string; // "kind/name" for --target
+  readonly modules: ReadonlyArray<string>; // module IDs for --modules
+  readonly label: string; // human-readable test name
+}
+
+/**
+ * Canonical target names per kind. Identity-based modules override this
+ * with their specific name (e.g., "package/domain", "package/ai").
+ */
+const defaultTargetNames = new Map([
+  ["server", "api"],
+  ["client", "web"],
+  ["cli", "app"],
+  ["package", "domain"], // fallback; overridden by identity modules
+]);
+
+/**
+ * Groups modules by their actual target identity (kind/name).
+ * For identity-based supportedOn, uses the identity's name.
+ * For kind-based supportedOn, uses the default name.
+ */
+function groupModulesByTarget(
+  modules: ReadonlyArray<{
+    id: string;
+    supportedOn: ReadonlyArray<
+      | { _tag: "kind"; kind: string }
+      | { _tag: "identity"; identity: { kind: string; name: string } }
+    >;
+    implies?: ReadonlyArray<{ targetKind: string; moduleId: string }>;
+  }>,
+): Map<string, ReadonlyArray<string>> {
+  const groups = new Map<string, Array<string>>();
+
+  for (const mod of modules) {
+    for (const s of mod.supportedOn) {
+      const target =
+        s._tag === "identity"
+          ? `${s.identity.kind}/${s.identity.name}`
+          : `${s.kind}/${defaultTargetNames.get(s.kind) ?? s.kind}`;
+
+      if (!groups.has(target)) groups.set(target, []);
+      groups.get(target)!.push(mod.id);
+    }
+  }
+
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Build the matrix using CatalogService
+// ---------------------------------------------------------------------------
+
+const buildMatrix = Effect.gen(function* () {
+  const catalog = yield* CatalogService;
+  const entries: Array<MatrixEntry> = [];
+
+  // For each non-init target kind, get supported modules and group by identity
+  for (const kind of catalog.targetKinds) {
+    const modules = yield* catalog.getSupportedModules(kind);
+    const grouped = groupModulesByTarget(modules as any);
+
+    for (const [target, moduleIds] of grouped) {
+      // Individual module tests
+      for (const moduleId of moduleIds) {
+        entries.push({
+          target,
+          modules: [moduleId],
+          label: `${target} + ${moduleId}`,
+        });
+      }
+
+      // All modules together (only if > 1 module)
+      if (moduleIds.length > 1) {
+        entries.push({
+          target,
+          modules: moduleIds,
+          label: `${target} + [all: ${moduleIds.join(", ")}]`,
+        });
+      }
+    }
+  }
+
+  return entries;
+});
+
+const matrix = Effect.runSync(
+  buildMatrix.pipe(Effect.provide(CatalogService.layer)),
+);
+
+// Separate entries that have cross-target implications (client modules)
+const singleTargetEntries = matrix.filter(
+  (e) => !e.target.startsWith("client"),
+);
+
+// ---------------------------------------------------------------------------
+// Full-stack combos: pair each client combo with its required server modules
+// ---------------------------------------------------------------------------
+
+const buildFullStackMatrix = Effect.gen(function* () {
+  const catalog = yield* CatalogService;
+
+  const clientModules = yield* catalog.getSupportedModules(
+    TargetKind.make("client"),
+  );
+
+  return Arr.map(clientModules, (clientMod) => {
+    const implies = clientMod.implies ?? [];
+    if (implies.length === 0) return null;
+
+    const serverModuleIds = implies
+      .filter((imp) => imp.targetKind === "server")
+      .map((imp) => imp.moduleId);
+
+    if (serverModuleIds.length > 0) {
+      return {
+        label: `full-stack: ${clientMod.id} → server [${serverModuleIds.join(", ")}]`,
+        serverTarget: `server/${defaultTargetNames.get("server")}`,
+        serverModules: serverModuleIds,
+        clientTarget: `client/${defaultTargetNames.get("client")}`,
+        clientModules: [clientMod.id],
+      };
+    }
+    return null;
+  }).filter((entry) => entry !== null);
+});
+
+const fullStackMatrix = Effect.runSync(
+  buildFullStackMatrix.pipe(Effect.provide(CatalogService.layer)),
+);
+
+/**
+ * Acceptance tests for various module combinations in the matrix.
+ *
+ * The matrix is generated dynamically from the CatalogService, ensuring that
+ * all supported module combinations are tested. Each test scaffolds a project,
+ * adds the specified modules, and verifies that the resulting project is valid
+ * (e.g., type checks successfully).
+ */
+describe("matrix", () => {
+  layer(CLI.layer)("single-target modules", (it) => {
+    for (const entry of singleTargetEntries) {
+      it.effect(
+        entry.label,
+        () =>
+          Effect.gen(function* () {
+            const cli = yield* CLI;
+            const name = `matrix-${entry.target.replace("/", "-")}-${entry.modules.join("-")}`;
+            const root = `${cli.workdir}/${name}`;
+
+            // Init project
+            yield* cli.run("init", name, "--yes", "--root", root);
+            yield* cli.expectExitCode(0);
+
+            // Add modules to target
+            yield* cli.run(
+              "add",
+              "--yes",
+              "--root",
+              root,
+              "--target",
+              entry.target,
+              "--modules",
+              entry.modules.join(","),
+            );
+            yield* cli.expectExitCode(0);
+
+            // Validate
+            yield* cli.withinProject(name, function* (project) {
+              yield* project.expectTypeCheckPasses();
+            });
+          }).pipe(Effect.provide(CLI.layer)),
+        { timeout: 120_000 },
+      );
+    }
+  });
+
+  layer(CLI.layer)("full-stack (client + server)", (it) => {
+    for (const entry of fullStackMatrix) {
+      it.effect(
+        entry.label,
+        () =>
+          Effect.gen(function* () {
+            const cli = yield* CLI;
+            const name = `matrix-fullstack-${entry.clientModules.join("-")}`;
+            const root = `${cli.workdir}/${name}`;
+
+            // Init project
+            yield* cli.run("init", name, "--yes", "--root", root);
+            yield* cli.expectExitCode(0);
+
+            // Add server modules first (satisfies implications)
+            yield* cli.run(
+              "add",
+              "--yes",
+              "--root",
+              root,
+              "--target",
+              entry.serverTarget,
+              "--modules",
+              entry.serverModules.join(","),
+            );
+            yield* cli.expectExitCode(0);
+
+            // Add client modules
+            yield* cli.run(
+              "add",
+              "--yes",
+              "--root",
+              root,
+              "--target",
+              entry.clientTarget,
+              "--modules",
+              entry.clientModules.join(","),
+            );
+            yield* cli.expectExitCode(0);
+
+            // Validate full project
+            yield* cli.withinProject(name, function* (project) {
+              yield* project.expectTypeCheckPasses();
+            });
+          }).pipe(Effect.provide(CLI.layer)),
+        { timeout: 120_000 },
+      );
+    }
+  });
+
+  layer(CLI.layer)("full-stack all client modules together", (it) => {
+    it.effect(
+      "all client modules with all server dependencies",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const name = "matrix-fullstack-all";
+          const root = `${cli.workdir}/${name}`;
+
+          // Init
+          yield* cli.run("init", name, "--yes", "--root", root);
+          yield* cli.expectExitCode(0);
+
+          // Add all server modules
+          const allServerModules = [
+            ...new Set(fullStackMatrix.flatMap((e) => e.serverModules)),
+          ];
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            `server/${defaultTargetNames.get("server")}`,
+            "--modules",
+            allServerModules.join(","),
+          );
+          yield* cli.expectExitCode(0);
+
+          // Add all client modules
+          const allClientModules = [
+            ...new Set(fullStackMatrix.flatMap((e) => e.clientModules)),
+          ];
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            `client/${defaultTargetNames.get("client")}`,
+            "--modules",
+            allClientModules.join(","),
+          );
+          yield* cli.expectExitCode(0);
+
+          // Validate
+          yield* cli.withinProject(name, function* (project) {
+            yield* project.expectTypeCheckPasses();
+          });
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 180_000 },
+    );
+  });
+});

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,6 +8,7 @@
     "build:types": "tsc --emitDeclarationOnly",
     "dev": "bun --watch run src/index.ts",
     "start": "bun run src/index.ts",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "type-check": "tsc --noEmit",
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },
@@ -20,7 +21,10 @@
     "effect-boxes": "^0.11.2"
   },
   "devDependencies": {
+    "@effect/platform-node": "4.0.0-beta.59",
+    "@effect/vitest": "4.0.0-beta.59",
     "@repo/config-typescript": "workspace:*",
-    "@types/bun": "1.3.13"
+    "@types/bun": "1.3.13",
+    "vitest": "^4.0.0"
   }
 }

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -5,6 +5,6 @@
     "noEmit": true,
     "types": ["@types/bun"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "e2e/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/cli/vitest.e2e.config.ts
+++ b/apps/cli/vitest.e2e.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["e2e/**/*.test.ts"],
+    testTimeout: 120_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -27,8 +27,11 @@
         "effect-boxes": "^0.11.2",
       },
       "devDependencies": {
+        "@effect/platform-node": "4.0.0-beta.59",
+        "@effect/vitest": "4.0.0-beta.59",
         "@repo/config-typescript": "workspace:*",
         "@types/bun": "1.3.13",
+        "vitest": "^4.0.0",
       },
     },
     "packages/catalog": {
@@ -115,6 +118,8 @@
 
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-1jXCIx34X80ojiK9ACO9Q7RST9CXudRmlAbsP4kPqjUo6aqOuGSWXq9ueBO4LbaIZiioRxtTciom35U9ldfTkQ=="],
 
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.59", "ioredis": "^5.7.0" } }, "sha512-jHRW0l953FjYNhQHexr48jFiBu5iGEZH5nmKD6Ha+lPtm1MrKG2V4njfWA3Fv0nUmd3VN87eBJ557wU0twN1Hg=="],
+
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.59", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-fGwFJuG0Te9U/ZeqeDZ2HcSKZBhX5wLjX2/Rxb5+yaOkvvFAN9MvIh05R0QQK5DCcERvnbhHSl1CjSIAN4aEwQ=="],
 
     "@effect/vitest": ["@effect/vitest@4.0.0-beta.59", "", { "peerDependencies": { "effect": "^4.0.0-beta.59", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-jhpJbpDs1ED58SmFzcfmqLXxle84fiexaMEhV8SBl8WC2GM3FT5DW0WJYFjbZIH5/735brp3iGdjY5/uAxS7Bg=="],
@@ -124,6 +129,8 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
@@ -291,9 +298,15 @@
 
     "cli": ["cli@workspace:apps/cli"],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -324,6 +337,8 @@
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -357,6 +372,10 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -365,7 +384,11 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@1.11.10", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA=="],
 
@@ -395,6 +418,10 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
@@ -406,6 +433,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
@@ -428,6 +457,8 @@
     "turbo": ["turbo@2.9.9", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.9", "@turbo/darwin-arm64": "2.9.9", "@turbo/linux-64": "2.9.9", "@turbo/linux-arm64": "2.9.9", "@turbo/windows-64": "2.9.9", "@turbo/windows-arm64": "2.9.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-3xfzXE/yTjhh0S5dIWlE+3E+J9A09REpLI1ZqVh2+HrNZoVzZn0pkvjiRgVK/Ev3PF9XnaTwCntTx+CADWXcyA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici": ["undici@8.2.0", "", {}, "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/packages/scaffold/src/service/plan/PlanService.test.ts
+++ b/packages/scaffold/src/service/plan/PlanService.test.ts
@@ -341,7 +341,7 @@ const HttpRpcRouter = Layer.empty;
             ]),
           );
 
-          // Should have ts-append-call-arg operations for Layer.provide
+          // Should have ts-append-call-arg operations for Layer.mergeAll
           const appendOps = serverOutcome.operations.filter(
             (op) => op._tag === "ts-append-call-arg",
           );
@@ -349,20 +349,20 @@ const HttpRpcRouter = Layer.empty;
             expect.arrayContaining([
               expect.objectContaining({
                 _tag: "ts-append-call-arg",
-                targetVariable: "HttpRpcRouter",
-                functionName: "Layer.provide",
+                targetVariable: "AllRouters",
+                functionName: "Layer.mergeAll",
                 argument: "ChatServiceLive",
               }),
               expect.objectContaining({
                 _tag: "ts-append-call-arg",
-                targetVariable: "HttpRpcRouter",
-                functionName: "Layer.provide",
+                targetVariable: "AllRouters",
+                functionName: "Layer.mergeAll",
                 argument: "SampleToolkitLive",
               }),
               expect.objectContaining({
                 _tag: "ts-append-call-arg",
-                targetVariable: "HttpRpcRouter",
-                functionName: "Layer.provide",
+                targetVariable: "AllRouters",
+                functionName: "Layer.mergeAll",
                 argument: "FastModelLive",
               }),
             ]),


### PR DESCRIPTION
## Goals/Scope

Add comprehensive end-to-end tests for the add command and update existing tests to match current composition patterns.

## Description

- Add e2e tests for add command
- Add matrix e2e tests covering all target/module combinations
- Update PlanService test to align with AllRouters/Layer.mergeAll composition pattern