### PR TITLE
fix: resolve TargetNotFoundError by making AllRouters a top-level composable variable

### DIFF
--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -73,6 +73,9 @@ const ApiRouter = HttpApiBuilder.layer(Api).pipe(
   Layer.provide([HealthGroupLive, HelloGroupLive]),
 );
 
+// All Routers - modules append additional routers here via Layer.mergeAll
+const AllRouters = Layer.mergeAll(ApiRouter);
+
 // ============================================================================
 // Server Launch
 // ============================================================================
@@ -94,7 +97,7 @@ const HttpLive = Effect.gen(function* () {
   yield* Effect.logInfo("Starting server with:");
   yield* Effect.logInfo("  - HTTP API at /");
 
-  const AllRouters = Layer.mergeAll(ApiRouter).pipe(
+  const CorsRouters = AllRouters.pipe(
     Layer.provide(
       HttpRouter.cors({
         allowedOrigins,
@@ -105,7 +108,7 @@ const HttpLive = Effect.gen(function* () {
     ),
   );
 
-  return HttpRouter.serve(AllRouters).pipe(
+  return HttpRouter.serve(CorsRouters).pipe(
     HttpServer.withLogAddress,
     Layer.provideMerge(DevToolsLive),
     Layer.provideMerge(BunHttpServer.layerConfig(ServerConfig)),

--- a/packages/catalog/src/registry/modules/server.ts
+++ b/packages/catalog/src/registry/modules/server.ts
@@ -124,8 +124,8 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       {
         _tag: "ts-call-arg",
         path: "{{targetPath}}/src/index.ts",
-        targetVariable: "HttpRpcRouter",
-        functionName: "Layer.provide",
+        targetVariable: "AllRouters",
+        functionName: "Layer.mergeAll",
         argument: "ChatServiceLive",
         import: {
           moduleSpecifier: "@repo/ai",
@@ -135,8 +135,8 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       {
         _tag: "ts-call-arg",
         path: "{{targetPath}}/src/index.ts",
-        targetVariable: "HttpRpcRouter",
-        functionName: "Layer.provide",
+        targetVariable: "AllRouters",
+        functionName: "Layer.mergeAll",
         argument: "SampleToolkitLive",
         import: {
           moduleSpecifier: "@repo/ai",
@@ -146,8 +146,8 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       {
         _tag: "ts-call-arg",
         path: "{{targetPath}}/src/index.ts",
-        targetVariable: "HttpRpcRouter",
-        functionName: "Layer.provide",
+        targetVariable: "AllRouters",
+        functionName: "Layer.mergeAll",
         argument: "FastModelLive",
         import: {
           moduleSpecifier: "@repo/ai",
@@ -202,8 +202,8 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       {
         _tag: "ts-call-arg",
         path: "{{targetPath}}/src/index.ts",
-        targetVariable: "WebSocketRpcRouter",
-        functionName: "Layer.provide",
+        targetVariable: "AllRouters",
+        functionName: "Layer.mergeAll",
         argument: "PresenceServiceLive",
         import: {
           moduleSpecifier: "@repo/presence",


### PR DESCRIPTION
## Goals/Scope

Resolve TargetNotFoundError by refactoring AllRouters into a top-level composable variable.

## Description

### Important Changes

- Made `AllRouters` a top-level composable variable to fix TargetNotFoundError

---
- [x] closes #76
