### PR TITLE
fix: add missing domain-chat dependency to ai module and ai dep to ai-chat-service

### DIFF
--- a/packages/catalog/src/registry/modules/packages.ts
+++ b/packages/catalog/src/registry/modules/packages.ts
@@ -36,7 +36,16 @@ export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         }),
       },
     ],
-    dependencies: [],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "domain",
+        }),
+        moduleId: ModuleId.make("domain-chat"),
+      },
+    ],
     contributions: [
       {
         _tag: "file",
@@ -66,6 +75,13 @@ export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         field: "dependencies",
         name: "effect",
         value: "4.0.0-beta.59",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "@repo/domain",
+        value: "workspace:*",
       },
     ],
   },
@@ -126,6 +142,14 @@ export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
           name: "ai",
         }),
         moduleId: ModuleId.make("ai-sample-toolkit"),
+      },
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "ai",
+        }),
+        moduleId: ModuleId.make("ai"),
       },
     ],
     contributions: [


### PR DESCRIPTION
## Goals/Scope

Fix missing dependencies that were causing module resolution issues.

## Description

- Added missing `domain-chat` dependency to `ai` module
- Added missing `ai` dependency to `ai-chat-service`

---

- [x] closes #77
