### PR TITLE
fix: scaffold type-check failures

### DIFF
--- a/packages/catalog/src/registry/content/client.ts
+++ b/packages/catalog/src/registry/content/client.ts
@@ -26,6 +26,7 @@ export const clientPackageJsonContents = `{
   "scripts": {},
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@effect/atom-react": "4.0.0-beta.59",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "effect": "4.0.0-beta.59",

--- a/packages/catalog/src/registry/content/presence.ts
+++ b/packages/catalog/src/registry/content/presence.ts
@@ -121,4 +121,6 @@ export class PresenceService extends Context.Service<PresenceService>()(
 ) {
   static layer = Layer.effect(PresenceService)(PresenceService.make);
 }
+
+export const PresenceServiceLive = PresenceService.layer;
 `;

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -204,7 +204,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "dependencies",
         name: "@effect/platform-browser",
-        value: "workspace:*",
+        value: "4.0.0-beta.59",
       },
     ],
   },


### PR DESCRIPTION
## Goals/Scope

Fix type check failures in scaffold modules by ensuring all necessary exports and dependencies are properly configured.

## Description

- Added missing exports and re-exports to catalog modules
- Added `PresenceServiceLive` re-export
- Added `@effect/atom-react` dependency
- Fixed `platform-browser` version