### PR TITLE
docs: add JSDoc comments to domain types

### DIFF
--- a/packages/domain/src/Apply.ts
+++ b/packages/domain/src/Apply.ts
@@ -2,11 +2,28 @@ import { Schema } from "effect";
 import { pathOrd, pathStrOrd } from "./Order";
 import { Plan } from "./Plan";
 
+/**
+ * A user's resolution for a conflicted path: override existing content or
+ * skip the file entirely.
+ *
+ * @category Apply
+ * @since 1.0.0
+ */
 export const ApplyDecision = Schema.Struct({
   path: Schema.String,
   value: Schema.Literals(["override", "skip"]),
 });
 
+/**
+ * Combines a Plan with user decisions for all conflicted paths, forming the
+ * complete execution intent.
+ *
+ * An Apply is valid only when every conflict in the Plan has a corresponding
+ * ApplyDecision — missing or extra decisions are invalid.
+ *
+ * @category Apply
+ * @since 1.0.0
+ */
 export class Apply extends Schema.Class<Apply>("Apply")({
   plan: Plan,
   decisions: Schema.Array(ApplyDecision),
@@ -36,6 +53,16 @@ export const ApplyFailedPath = Schema.Struct({
   reason: Schema.String,
 });
 
+/**
+ * The outcome of executing an Apply against the filesystem.
+ *
+ * Categorizes every path by what happened: created, modified, skipped (by
+ * user decision), or failed (due to execution errors). Provides a complete
+ * audit trail for the FinalizeReport.
+ *
+ * @category Apply
+ * @since 1.0.0
+ */
 export class ApplyResult extends Schema.Class<ApplyResult>("ApplyResult")({
   created: Schema.Array(Schema.String),
   modified: Schema.Array(Schema.String),

--- a/packages/domain/src/Blueprint.ts
+++ b/packages/domain/src/Blueprint.ts
@@ -14,11 +14,24 @@ export class BlueprintFailure extends Data.TaggedError("BlueprintFailure")<{
   cause?: unknown;
 }> {}
 
+/**
+ * Represents a resolved target workspace in the blueprint graph.
+ *
+ * @category Blueprint
+ * @since 1.0.0
+ */
 export const BlueprintTargetNode = Schema.TaggedStruct("target", {
   id: TargetKey,
   identity: TargetIdentity,
 });
 
+/**
+ * Represents a module attached to a specific target in the blueprint graph.
+ * The composite ID encodes both the owning target and the module identity.
+ *
+ * @category Blueprint
+ * @since 1.0.0
+ */
 export const BlueprintAttachedModuleNode = Schema.TaggedStruct(
   "attached-module",
   {
@@ -41,6 +54,20 @@ export const blueprintNodeOrd = Order.mapInput(
   (node: typeof BlueprintNode.Type) => node,
 );
 
+/**
+ * The resolved dependency closure for a Selection.
+ *
+ * A Blueprint expands user intent into a complete directed graph of targets
+ * and their attached modules, including all transitive dependencies (required
+ * targets and required modules). It is deterministic: identical Selections
+ * always produce identical Blueprints.
+ *
+ * The graph is policy-free — it does not consider the current repo state.
+ * That concern belongs to the Plan stage.
+ *
+ * @category Blueprint
+ * @since 1.0.0
+ */
 export class Blueprint extends Schema.Class<Blueprint>("Blueprint")({
   nodes: Schema.Array(BlueprintNode),
   edges: Schema.Array(

--- a/packages/domain/src/Finalize.ts
+++ b/packages/domain/src/Finalize.ts
@@ -1,5 +1,15 @@
 import { Schema } from "effect";
 
+/**
+ * Aggregated results of post-apply finalization scripts (install, format, etc.).
+ *
+ * The FinalizeReport is the terminal output of the scaffold pipeline. It
+ * records which scripts succeeded and which failed, enabling the CLI to
+ * present a summary to the user.
+ *
+ * @category Finalize
+ * @since 1.0.0
+ */
 export class FinalizeReport extends Schema.Class<FinalizeReport>(
   "FinalizeReport",
 )({

--- a/packages/domain/src/Plan.ts
+++ b/packages/domain/src/Plan.ts
@@ -157,6 +157,20 @@ export const PlanConflict = Schema.TaggedUnion({
   },
 });
 
+/**
+ * The repo-aware outcome of applying a Blueprint to the current filesystem.
+ *
+ * A Plan pairs each contributed file path with a classification (create,
+ * modify, unchanged, or conflict) and its resolved contents or composition
+ * operations. It also surfaces detected conflicts that require user decisions
+ * before execution.
+ *
+ * The Plan is policy-free: it records what *would* happen but does not make
+ * apply decisions. Those belong to the Apply stage via ApplyDecision entries.
+ *
+ * @category Plan
+ * @since 1.0.0
+ */
 export class Plan extends Schema.Class<Plan>("Plan")({
   outcomes: Schema.Array(PlanOutcome),
   conflicts: Schema.Array(PlanConflict),

--- a/packages/domain/src/Selection.ts
+++ b/packages/domain/src/Selection.ts
@@ -1,6 +1,16 @@
 import { Schema } from "effect";
 import { ModuleId, TargetIdentity } from "./Catalog";
 
+/**
+ * Captures the user's explicit intent: which targets to scaffold and which
+ * modules to attach to each target.
+ *
+ * A Selection is the entry point of the scaffold pipeline. It contains no
+ * dependency resolution — that is the responsibility of the Blueprint stage.
+ *
+ * @category Selection
+ * @since 1.0.0
+ */
 export const Selection = Schema.Struct({
   targets: Schema.Array(
     Schema.Struct({


### PR DESCRIPTION
## Goals/Scope

Add comprehensive JSDoc comments to domain types for improved code documentation and IDE support.

## Description

- Added JSDoc comments to domain type definitions
- Improved code documentation for better developer experience
- Enhanced IDE autocomplete and type hints