### PR TITLE
refactor: add Viewport abstraction

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -41,16 +41,16 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },
   "devDependencies": {
-    "@effect/platform-bun": "4.0.0-beta.64",
-    "@effect/platform-node": "4.0.0-beta.64",
-    "@effect/vitest": "4.0.0-beta.64",
+    "@effect/platform-bun": "4.0.0-beta.65",
+    "@effect/platform-node": "4.0.0-beta.65",
+    "@effect/vitest": "4.0.0-beta.65",
     "@repo/catalog": "workspace:*",
     "@repo/config-typescript": "workspace:*",
     "@repo/domain": "workspace:*",
     "@repo/scaffold": "workspace:*",
-    "@types/bun": "1.3.13",
-    "effect": "4.0.0-beta.64",
-    "effect-boxes": "^0.13.0",
-    "vitest": "^4.0.0"
+    "@types/bun": "1.3.14",
+    "effect": "4.0.0-beta.65",
+    "effect-boxes": "^0.14.0",
+    "vitest": "^4.1.6"
   }
 }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -234,7 +234,7 @@ export const init = Command.make(
         ],
         1,
         Box.left,
-      ).pipe(Box.pad(0, 2), Box.border("rounded", { annotation: Ansi.dim }));
+      );
 
       if (!flags.yes) {
         const proceed = yield* Confirm({

--- a/apps/cli/src/components/Confirm.ts
+++ b/apps/cli/src/components/Confirm.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect";
+import { Data, Effect, Match } from "effect";
 import { has } from "effect/Filter";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
@@ -72,11 +72,14 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
       Box.center1,
     );
 
-  const renderChildrenViewport = (scrollOffset: number) =>
-    Box.vcat(
+  const renderChildrenViewport = Effect.fnUntraced(function* (
+    scrollOffset: number,
+  ) {
+    const terminalRows = process.stdout.rows ?? 24;
+    return Box.vcat(
       childrenRenderedLines.slice(
         scrollOffset,
-        scrollOffset + viewportHeight(process.stdout.rows ?? 24),
+        scrollOffset + viewportHeight(terminalRows),
       ),
       Box.left,
     ).pipe(
@@ -84,6 +87,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
       Box.maxWidth((process.stdout.columns ?? 80) - 10),
       Box.border("rounded", { annotation: Ansi.dim }),
     );
+  });
 
   const renderHint = () => {
     return Box.punctuateH(
@@ -98,11 +102,13 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
   };
 
-  const renderActive = (state: ConfirmState) => {
+  const renderActive = Effect.fnUntraced(function* (state: ConfirmState) {
     const content = Box.vsep(
       [
         Box.text(message).pipe(Box.annotate(Ansi.bold)),
-        ...(hasChildren ? [renderChildrenViewport(state.scrollOffset)] : []),
+        ...(hasChildren
+          ? [yield* renderChildrenViewport(state.scrollOffset)]
+          : []),
         renderButtons(state.cursor),
       ],
       1,
@@ -123,10 +129,16 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
       1,
       Box.left,
     ).pipe(Box.moveDown(1));
-  };
+  });
 
-  const renderLayout = (state: ConfirmState, submitted: boolean) =>
-    submitted ? renderSubmitted(state.cursor) : renderActive(state);
+  const renderLayout = Effect.fnUntraced(function* (
+    state: ConfirmState,
+    submitted: boolean,
+  ) {
+    return submitted
+      ? renderSubmitted(state.cursor)
+      : yield* renderActive(state);
+  });
 
   const initialState: ConfirmState = {
     cursor: initialValue ? 0 : 1,
@@ -134,8 +146,8 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
   };
 
   return Prompt.custom<ConfirmState, boolean>(initialState, {
-    render: (state, action) => {
-      const layout = Action.$match(action, {
+    render: Effect.fnUntraced(function* (state, action) {
+      const layout = yield* Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
         NextFrame: ({ state: s }) => renderLayout(s, false),
@@ -147,75 +159,60 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
           ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
           : Cmd.cursorHide;
 
-      return Effect.succeed(
-        Box.renderPrettySync(layout.pipe(Box.combine(cmds))),
-      );
-    },
-    process: (input, state) => {
+      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+    }),
+    process: Effect.fnUntraced(function* (input, state) {
       const maxVisible = viewportHeight(process.stdout.rows ?? 24);
       const maxOffset = Math.max(0, childrenRenderedLines.length - maxVisible);
 
-      switch (input.key.name) {
-        case "up":
-        case "k":
+      return Match.value(input.key.name).pipe(
+        Match.whenOr("up", "k", () => {
           if (hasChildren && state.scrollOffset > 0) {
-            return Effect.succeed(
-              Action.NextFrame({
-                state: { ...state, scrollOffset: state.scrollOffset - 1 },
-              }),
-            );
+            return Action.NextFrame({
+              state: { ...state, scrollOffset: state.scrollOffset - 1 },
+            });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
-        case "down":
-        case "j":
+          return Action.NextFrame({ state });
+        }),
+        Match.whenOr("down", "j", () => {
           if (hasChildren && state.scrollOffset < maxOffset) {
-            return Effect.succeed(
-              Action.NextFrame({
-                state: { ...state, scrollOffset: state.scrollOffset + 1 },
-              }),
-            );
+            return Action.NextFrame({
+              state: { ...state, scrollOffset: state.scrollOffset + 1 },
+            });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
-        case "right":
-        case "l":
-        case "tab":
-          return Effect.succeed(
-            Action.NextFrame({
-              state: {
-                ...state,
-                cursor: (state.cursor + 1) % choices.length,
-              },
-            }),
-          );
-        case "left":
-        case "h":
-          return Effect.succeed(
-            Action.NextFrame({
-              state: {
-                ...state,
-                cursor: (state.cursor - 1 + choices.length) % choices.length,
-              },
-            }),
-          );
-        case "escape":
-          return Effect.succeed(Action.Submit({ value: false }));
-        case "enter":
-        case "return": {
+          return Action.NextFrame({ state });
+        }),
+        Match.whenOr("right", "l", "tab", () =>
+          Action.NextFrame({
+            state: {
+              ...state,
+              cursor: (state.cursor + 1) % choices.length,
+            },
+          }),
+        ),
+        Match.whenOr("left", "h", () =>
+          Action.NextFrame({
+            state: {
+              ...state,
+              cursor: (state.cursor - 1 + choices.length) % choices.length,
+            },
+          }),
+        ),
+        Match.when("escape", () => Action.Submit({ value: false })),
+        Match.whenOr("enter", "return", () => {
           const selected = choices[state.cursor];
           if (selected) {
-            return Effect.succeed(Action.Submit({ value: selected.value }));
+            return Action.Submit({ value: selected.value });
           }
-          return Effect.succeed(Action.Beep());
-        }
-        default:
-          return Effect.succeed(Action.NextFrame({ state }));
-      }
-    },
-    clear: (_state, _action) =>
-      Effect.gen(function* () {
-        return Cmd.clearLines(renderLayout(_state, false).rows).pipe(
-          Box.renderPrettySync,
-        );
-      }),
+          return Action.Beep();
+        }),
+        Match.orElse(() => Action.NextFrame({ state })),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (state) {
+      return yield* Box.renderPretty(
+        Cmd.clearLines((yield* renderLayout(state, false)).rows),
+      );
+    }),
   });
 };

--- a/apps/cli/src/components/Confirm.ts
+++ b/apps/cli/src/components/Confirm.ts
@@ -1,8 +1,8 @@
-import { Data, Effect, Match } from "effect";
-import { has } from "effect/Filter";
+import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import type { AnsiStyle } from "effect-boxes/Ansi";
+import * as Viewport from "../lib/Viewport.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -13,7 +13,7 @@ export interface ConfirmOptions extends Prompt.ConfirmOptions {
 
 interface ConfirmState {
   readonly cursor: number;
-  readonly scrollOffset: number;
+  readonly viewport: Viewport.State;
 }
 
 /** Rows reserved for prompt chrome (margin, message, gaps, buttons, hint). */
@@ -36,9 +36,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
 
   // Pre-render children to lines for viewport scrolling
   const childrenRenderedLines: readonly Box.Box<AnsiStyle>[] = childrenBox
-    ? Box.renderPrettySync(childrenBox)
-        .split("\n")
-        .map((l) => Box.line(l))
+    ? Viewport.linesFromBox(childrenBox)
     : [];
   const hasChildren = childrenRenderedLines.length > 0;
 
@@ -73,16 +71,15 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     );
 
   const renderChildrenViewport = Effect.fnUntraced(function* (
-    scrollOffset: number,
+    viewport: Viewport.State,
   ) {
     const terminalRows = process.stdout.rows ?? 24;
-    return Box.vcat(
-      childrenRenderedLines.slice(
-        scrollOffset,
-        scrollOffset + viewportHeight(terminalRows),
-      ),
-      Box.left,
-    ).pipe(
+    const { items } = Viewport.render(
+      childrenRenderedLines,
+      viewport,
+      viewportHeight(terminalRows),
+    );
+    return Box.vcat(items, Box.left).pipe(
       Box.minWidth(childrenBox?.cols ?? 0),
       Box.maxWidth((process.stdout.columns ?? 80) - 10),
       Box.border("rounded", { annotation: Ansi.dim }),
@@ -106,9 +103,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     const content = Box.vsep(
       [
         Box.text(message).pipe(Box.annotate(Ansi.bold)),
-        ...(hasChildren
-          ? [yield* renderChildrenViewport(state.scrollOffset)]
-          : []),
+        ...(hasChildren ? [yield* renderChildrenViewport(state.viewport)] : []),
         renderButtons(state.cursor),
       ],
       1,
@@ -142,7 +137,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
 
   const initialState: ConfirmState = {
     cursor: initialValue ? 0 : 1,
-    scrollOffset: 0,
+    viewport: Viewport.initial,
   };
 
   return Prompt.custom<ConfirmState, boolean>(initialState, {
@@ -163,22 +158,31 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     }),
     process: Effect.fnUntraced(function* (input, state) {
       const maxVisible = viewportHeight(process.stdout.rows ?? 24);
-      const maxOffset = Math.max(0, childrenRenderedLines.length - maxVisible);
+      const bounds: Viewport.Bounds = {
+        contentHeight: childrenRenderedLines.length,
+        visibleHeight: maxVisible,
+      };
 
       return Match.value(input.key.name).pipe(
         Match.whenOr("up", "k", () => {
-          if (hasChildren && state.scrollOffset > 0) {
-            return Action.NextFrame({
-              state: { ...state, scrollOffset: state.scrollOffset - 1 },
-            });
+          if (hasChildren) {
+            const next = Viewport.scroll(state.viewport, "up", bounds);
+            if (Option.isSome(next)) {
+              return Action.NextFrame({
+                state: { ...state, viewport: next.value },
+              });
+            }
           }
           return Action.NextFrame({ state });
         }),
         Match.whenOr("down", "j", () => {
-          if (hasChildren && state.scrollOffset < maxOffset) {
-            return Action.NextFrame({
-              state: { ...state, scrollOffset: state.scrollOffset + 1 },
-            });
+          if (hasChildren) {
+            const next = Viewport.scroll(state.viewport, "down", bounds);
+            if (Option.isSome(next)) {
+              return Action.NextFrame({
+                state: { ...state, viewport: next.value },
+              });
+            }
           }
           return Action.NextFrame({ state });
         }),

--- a/apps/cli/src/components/HorizontalSelect.ts
+++ b/apps/cli/src/components/HorizontalSelect.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect";
+import { Data, Effect, Match } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 
@@ -76,57 +76,45 @@ export const HorizontalSelect = <A extends string>(
   };
 
   return Prompt.custom<number, A>(0, {
-    render: (cursor, action) => {
+    render: Effect.fnUntraced(function* (cursor, action) {
       const layout = Action.$match(action, {
         Beep: () => renderLayout(cursor, false),
         Submit: () => renderLayout(cursor, true),
         NextFrame: ({ state }) => renderLayout(state, false),
         default: () => renderLayout(cursor, false),
       });
-      return Effect.succeed(
-        Box.renderPrettySync(
-          layout.pipe(
-            Box.combine(
-              action._tag === "Submit"
-                ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-                : Cmd.cursorHide,
-            ),
-          ),
+
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
+
+      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+    }),
+    process: Effect.fnUntraced(function* (input, cursor) {
+      return Match.value(input.key.name).pipe(
+        Match.whenOr("right", "l", "tab", () =>
+          Action.NextFrame({ state: (cursor + 1) % choices.length }),
         ),
-      );
-    },
-    process: (input, cursor) => {
-      switch (input.key.name) {
-        case "right":
-        case "l":
-        case "tab":
-          return Effect.succeed(
-            Action.NextFrame({ state: (cursor + 1) % choices.length }),
-          );
-        case "left":
-        case "h":
-          return Effect.succeed(
-            Action.NextFrame({
-              state: (cursor - 1 + choices.length) % choices.length,
-            }),
-          );
-        case "enter":
-        case "return": {
+        Match.whenOr("left", "h", () =>
+          Action.NextFrame({
+            state: (cursor - 1 + choices.length) % choices.length,
+          }),
+        ),
+        Match.whenOr("enter", "return", () => {
           const selected = choices[cursor];
           if (selected) {
-            return Effect.succeed(Action.Submit({ value: selected.value }));
+            return Action.Submit({ value: selected.value });
           }
-          return Effect.succeed(Action.Beep());
-        }
-        default:
-          return Effect.succeed(Action.NextFrame({ state: cursor }));
-      }
-    },
-    clear: (_state, _action) =>
-      Effect.gen(function* () {
-        return Cmd.clearLines(renderLayout(_state, false).rows).pipe(
-          Box.renderPrettySync,
-        );
-      }),
+          return Action.Beep();
+        }),
+        Match.orElse(() => Action.NextFrame({ state: cursor })),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (state) {
+      return yield* Box.renderPretty(
+        Cmd.clearLines(renderLayout(state, false).rows),
+      );
+    }),
   });
 };

--- a/apps/cli/src/components/MultiSelect.ts
+++ b/apps/cli/src/components/MultiSelect.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect";
+import { Data, Effect, Match } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 
@@ -102,90 +102,72 @@ export const MultiSelect = <A>(
   };
 
   return Prompt.custom<MultiSelectState, Array<A>>(initialState, {
-    render: (state, action) => {
+    render: Effect.fnUntraced(function* (state, action) {
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
         NextFrame: ({ state: s }) => renderLayout(s, false),
         default: () => renderLayout(state, false),
       });
-      return Effect.succeed(
-        Box.renderPrettySync(
-          layout.pipe(
-            Box.combine(
-              action._tag === "Submit"
-                ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-                : Cmd.cursorHide,
-            ),
-          ),
-        ),
-      );
-    },
-    process: (input, state) => {
-      const key = input.key.name;
 
-      switch (key) {
-        case "down":
-        case "j":
-        case "tab":
-          return Effect.succeed(
-            Action.NextFrame({
-              state: {
-                ...state,
-                cursor: (state.cursor + 1) % choices.length,
-              },
-            }),
-          );
-        case "up":
-        case "k":
-          return Effect.succeed(
-            Action.NextFrame({
-              state: {
-                ...state,
-                cursor: (state.cursor - 1 + choices.length) % choices.length,
-              },
-            }),
-          );
-        case "space": {
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
+
+      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+    }),
+    process: Effect.fnUntraced(function* (input, state) {
+      return Match.value(input.key.name).pipe(
+        Match.whenOr("down", "j", "tab", () =>
+          Action.NextFrame({
+            state: {
+              ...state,
+              cursor: (state.cursor + 1) % choices.length,
+            },
+          }),
+        ),
+        Match.whenOr("up", "k", () =>
+          Action.NextFrame({
+            state: {
+              ...state,
+              cursor: (state.cursor - 1 + choices.length) % choices.length,
+            },
+          }),
+        ),
+        Match.when("space", () => {
           const choice = choices[state.cursor];
-          if (choice?.disabled) return Effect.succeed(Action.Beep());
+          if (choice?.disabled) return Action.Beep();
           const next = new Set(state.selected);
           if (next.has(state.cursor)) {
             next.delete(state.cursor);
           } else {
-            if (next.size >= max) return Effect.succeed(Action.Beep());
+            if (next.size >= max) return Action.Beep();
             next.add(state.cursor);
           }
-          return Effect.succeed(
-            Action.NextFrame({ state: { ...state, selected: next } }),
-          );
-        }
-        case "a": {
+          return Action.NextFrame({ state: { ...state, selected: next } });
+        }),
+        Match.when("a", () => {
           const allSelected = state.selected.size === choices.length;
           const next = allSelected
             ? new Set<number>()
             : new Set<number>(choices.map((_, i) => i));
-          return Effect.succeed(
-            Action.NextFrame({ state: { ...state, selected: next } }),
-          );
-        }
-        case "enter":
-        case "return": {
-          if (state.selected.size < min) return Effect.succeed(Action.Beep());
+          return Action.NextFrame({ state: { ...state, selected: next } });
+        }),
+        Match.whenOr("enter", "return", () => {
+          if (state.selected.size < min) return Action.Beep();
           const values = choices
             .filter((_, i) => state.selected.has(i))
             .map((c) => c.value);
-          return Effect.succeed(Action.Submit({ value: values }));
-        }
-        default:
-          return Effect.succeed(Action.NextFrame({ state }));
-      }
-    },
-    clear: (state, _action) =>
-      Effect.gen(function* () {
-        return Cmd.clearLines(renderLayout(state, false).rows).pipe(
-          Box.renderPrettySync,
-        );
-      }),
+          return Action.Submit({ value: values });
+        }),
+        Match.orElse(() => Action.NextFrame({ state })),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (state) {
+      return yield* Box.renderPretty(
+        Cmd.clearLines(renderLayout(state, false).rows),
+      );
+    }),
   });
 };

--- a/apps/cli/src/components/Select.ts
+++ b/apps/cli/src/components/Select.ts
@@ -1,4 +1,4 @@
-import { Array as Arr, Data, Effect, pipe } from "effect";
+import { Data, Effect, Match } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 
@@ -60,57 +60,45 @@ export const Select = <A>(
   };
 
   return Prompt.custom<number, A>(0, {
-    render: (cursor, action) => {
+    render: Effect.fnUntraced(function* (cursor, action) {
       const layout = Action.$match(action, {
         Beep: () => renderLayout(cursor, false),
         Submit: () => renderLayout(cursor, true),
         NextFrame: ({ state }) => renderLayout(state, false),
         default: () => renderLayout(cursor, false),
       });
-      return Effect.succeed(
-        Box.renderPrettySync(
-          layout.pipe(
-            Box.combine(
-              action._tag === "Submit"
-                ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-                : Cmd.cursorHide,
-            ),
-          ),
+
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
+
+      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+    }),
+    process: Effect.fnUntraced(function* (input, cursor) {
+      return Match.value(input.key.name).pipe(
+        Match.whenOr("down", "j", "tab", () =>
+          Action.NextFrame({ state: (cursor + 1) % choices.length }),
         ),
-      );
-    },
-    process: (input, cursor) => {
-      switch (input.key.name) {
-        case "down":
-        case "j":
-        case "tab":
-          return Effect.succeed(
-            Action.NextFrame({ state: (cursor + 1) % choices.length }),
-          );
-        case "up":
-        case "k":
-          return Effect.succeed(
-            Action.NextFrame({
-              state: (cursor - 1 + choices.length) % choices.length,
-            }),
-          );
-        case "enter":
-        case "return": {
+        Match.whenOr("up", "k", () =>
+          Action.NextFrame({
+            state: (cursor - 1 + choices.length) % choices.length,
+          }),
+        ),
+        Match.whenOr("enter", "return", () => {
           const selected = choices[cursor];
           if (selected) {
-            return Effect.succeed(Action.Submit({ value: selected.value }));
+            return Action.Submit({ value: selected.value });
           }
-          return Effect.succeed(Action.Beep());
-        }
-        default:
-          return Effect.succeed(Action.NextFrame({ state: cursor }));
-      }
-    },
-    clear: (_state, _action) =>
-      Effect.gen(function* () {
-        return Cmd.clearLines(renderLayout(_state, false).rows).pipe(
-          Box.renderPrettySync,
-        );
-      }),
+          return Action.Beep();
+        }),
+        Match.orElse(() => Action.NextFrame({ state: cursor })),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (state) {
+      return yield* Box.renderPretty(
+        Cmd.clearLines(renderLayout(state, false).rows),
+      );
+    }),
   });
 };

--- a/apps/cli/src/components/TextArea.ts
+++ b/apps/cli/src/components/TextArea.ts
@@ -1,4 +1,4 @@
-import { Array as Arr, Data, Effect, Option, pipe } from "effect";
+import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 
@@ -164,27 +164,22 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
   };
 
   return Prompt.custom<TextAreaState, string>(initialState, {
-    render: (state, action) => {
+    render: Effect.fnUntraced(function* (state, action) {
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
         NextFrame: ({ state: s }) => renderLayout(s, false),
         default: () => renderLayout(state, false),
       });
-      return Effect.succeed(
-        Box.renderPrettySync(
-          layout.pipe(
-            Box.combine(
-              action._tag === "Submit"
-                ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-                : Cmd.cursorHide,
-            ),
-          ),
-        ),
-      );
-    },
-    process: (input, state) => {
-      const key = input.key.name;
+
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
+
+      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+    }),
+    process: Effect.fnUntraced(function* (input, state) {
       const char = Option.getOrElse(input.input, () => "");
       const currentLine = state.lines[state.row] ?? "";
 
@@ -203,8 +198,8 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         );
       };
 
-      switch (key) {
-        case "left": {
+      return yield* Match.value(input.key.name).pipe(
+        Match.when("left", () => {
           if (state.col > 0) {
             const newCol = state.col - 1;
             return next({ col: newCol, stickyCol: newCol });
@@ -218,8 +213,8 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             });
           }
           return Effect.succeed(Action.NextFrame({ state }));
-        }
-        case "right": {
+        }),
+        Match.when("right", () => {
           if (state.col < currentLine.length) {
             const newCol = state.col + 1;
             return next({ col: newCol, stickyCol: newCol });
@@ -228,22 +223,22 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             return next({ row: state.row + 1, col: 0, stickyCol: 0 });
           }
           return Effect.succeed(Action.NextFrame({ state }));
-        }
-        case "up": {
+        }),
+        Match.when("up", () => {
           if (state.row === 0)
             return Effect.succeed(Action.NextFrame({ state }));
           const targetLine = state.lines[state.row - 1] ?? "";
           const newCol = clampCol(state.stickyCol, targetLine);
           return next({ row: state.row - 1, col: newCol });
-        }
-        case "down": {
+        }),
+        Match.when("down", () => {
           if (state.row >= state.lines.length - 1)
             return Effect.succeed(Action.NextFrame({ state }));
           const targetLine = state.lines[state.row + 1] ?? "";
           const newCol = clampCol(state.stickyCol, targetLine);
           return next({ row: state.row + 1, col: newCol });
-        }
-        case "backspace": {
+        }),
+        Match.when("backspace", () => {
           if (state.col > 0) {
             const newLine =
               currentLine.slice(0, state.col - 1) +
@@ -266,8 +261,8 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             });
           }
           return Effect.succeed(Action.NextFrame({ state }));
-        }
-        case "delete": {
+        }),
+        Match.when("delete", () => {
           if (state.col < currentLine.length) {
             const newLine =
               currentLine.slice(0, state.col) +
@@ -284,28 +279,24 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             return next({ lines: newLines });
           }
           return Effect.succeed(Action.NextFrame({ state }));
-        }
-        case "home": {
-          return next({ col: 0, stickyCol: 0 });
-        }
-        case "end": {
-          return next({
+        }),
+        Match.when("home", () => next({ col: 0, stickyCol: 0 })),
+        Match.when("end", () =>
+          next({
             col: currentLine.length,
             stickyCol: currentLine.length,
-          });
-        }
-        case "escape":
-          return Effect.succeed(Action.Submit({ value: defaultValue }));
-        case "d": {
+          }),
+        ),
+        Match.when("escape", () =>
+          Effect.succeed(Action.Submit({ value: defaultValue })),
+        ),
+        Match.when("d", () => {
           if (input.key.ctrl) {
             const finalValue = joinLines(state.lines) || defaultValue;
             if (options.validate) {
               return options.validate(finalValue).pipe(
                 Effect.map((v) => Action.Submit({ value: v })),
-                Effect.catchIf(
-                  () => true,
-                  () => Effect.succeed(Action.NextFrame({ state })),
-                ),
+                Effect.catch(() => Effect.succeed(Action.NextFrame({ state }))),
               );
             }
             return Effect.succeed(Action.Submit({ value: finalValue }));
@@ -318,11 +309,9 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
           newLines[state.row] = newLine;
           const newCol = state.col + 1;
           return next({ lines: newLines, col: newCol, stickyCol: newCol });
-        }
-        case "enter":
-        case "return":
-        case "j": {
-          if (key === "j" && !input.key.ctrl) {
+        }),
+        Match.whenOr("enter", "return", "j", () => {
+          if (input.key.name === "j" && !input.key.ctrl) {
             const newLine =
               currentLine.slice(0, state.col) +
               "j" +
@@ -342,8 +331,8 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             col: 0,
             stickyCol: 0,
           });
-        }
-        default: {
+        }),
+        Match.orElse(() => {
           if (char && char.length === 1 && !input.key.ctrl && !input.key.meta) {
             const newLine =
               currentLine.slice(0, state.col) +
@@ -355,14 +344,13 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             return next({ lines: newLines, col: newCol, stickyCol: newCol });
           }
           return Effect.succeed(Action.NextFrame({ state }));
-        }
-      }
-    },
-    clear: (state, _action) =>
-      Effect.gen(function* () {
-        return Cmd.clearLines(renderLayout(state, false).rows).pipe(
-          Box.renderPrettySync,
-        );
-      }),
+        }),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (state) {
+      return yield* Box.renderPretty(
+        Cmd.clearLines(renderLayout(state, false).rows),
+      );
+    }),
   });
 };

--- a/apps/cli/src/components/TextArea.ts
+++ b/apps/cli/src/components/TextArea.ts
@@ -1,6 +1,7 @@
 import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
+import * as Viewport from "../lib/Viewport.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -15,7 +16,8 @@ interface TextAreaState {
   readonly row: number;
   readonly col: number;
   readonly stickyCol: number;
-  readonly scrollOffset: number;
+  readonly viewport: Viewport.State;
+  readonly prevRows: number;
 }
 
 const splitLines = (value: string): Array<string> => {
@@ -27,18 +29,6 @@ const joinLines = (lines: ReadonlyArray<string>): string => lines.join("\n");
 
 const clampCol = (col: number, line: string): number =>
   Math.min(col, line.length);
-
-const computeScrollOffset = (
-  row: number,
-  maxRows: number,
-  totalLines: number,
-  currentOffset: number,
-): number => {
-  if (totalLines <= maxRows) return 0;
-  if (row < currentOffset) return row;
-  if (row >= currentOffset + maxRows) return row - maxRows + 1;
-  return currentOffset;
-};
 
 export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
   const message = options.message;
@@ -68,12 +58,11 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
     const isEmpty =
       state.lines.length === 1 && state.lines[0] === "" && placeholder !== "";
 
-    const visibleOffset = computeScrollOffset(
+    const visibleOffset = Viewport.scrollToReveal(
+      state.viewport,
       state.row,
       maxRows,
-      state.lines.length,
-      state.scrollOffset,
-    );
+    ).row;
     const visibleLines = state.lines.slice(
       visibleOffset,
       visibleOffset + maxRows,
@@ -84,18 +73,17 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
       : visibleLines.map((line, visibleIdx) => {
           const actualRow = visibleIdx + visibleOffset;
           const isCursorRow = actualRow === state.row;
-          const rowNummber = Box.text(`${actualRow} `).pipe(
-            Box.minWidth(2),
-            Box.annotate(Ansi.dim),
+          const rowNummber = Box.text(String(actualRow + 1)).pipe(
+            Box.alignHoriz(Box.left, 3),
+            Box.annotate(isCursorRow ? Ansi.white : Ansi.dim),
           );
 
           if (!isCursorRow) {
-            return Box.hsep(
+            return Box.hcat(
               [
                 rowNummber,
                 Box.text(line || " ").pipe(Box.annotate(Ansi.white)),
               ],
-              1,
               Box.left,
             );
           }
@@ -105,7 +93,7 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
           const cursorChar = line[col] ?? " ";
           const after = line.slice(col + 1);
 
-          return Box.hsep(
+          return Box.hcat(
             [
               rowNummber,
               Box.combineAll([
@@ -116,7 +104,7 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
                 Box.text(after).pipe(Box.annotate(Ansi.white)),
               ]),
             ],
-            1,
+
             Box.left,
           );
         });
@@ -160,11 +148,13 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
     row: 0,
     col: 0,
     stickyCol: 0,
-    scrollOffset: 0,
+    viewport: Viewport.initial,
+    prevRows: 0,
   };
 
   return Prompt.custom<TextAreaState, string>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
+      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -172,12 +162,20 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         default: () => renderLayout(state, false),
       });
 
+      // Clear previous output and render new in a single write to avoid flicker
+      const clear =
+        currentState.prevRows > 0
+          ? Cmd.clearLines(currentState.prevRows)
+          : Cmd.cursorHide;
+
       const cmds =
         action._tag === "Submit"
           ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
           : Cmd.cursorHide;
 
-      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+      return yield* Box.renderPretty(
+        Box.combine(clear, layout.pipe(Box.combine(cmds))),
+      );
     }),
     process: Effect.fnUntraced(function* (input, state) {
       const char = Option.getOrElse(input.input, () => "");
@@ -185,15 +183,19 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
 
       const next = (patch: Partial<TextAreaState>) => {
         const newState = { ...state, ...patch };
-        const newOffset = computeScrollOffset(
-          newState.row,
+        const newViewport = Viewport.scrollToReveal(
+          newState.viewport ?? state.viewport,
+          newState.row ?? state.row,
           maxRows,
-          newState.lines.length,
-          newState.scrollOffset,
         );
+        const layout = renderLayout(state, false);
         return Effect.succeed(
           Action.NextFrame({
-            state: { ...newState, scrollOffset: newOffset },
+            state: {
+              ...newState,
+              viewport: newViewport,
+              prevRows: layout.rows,
+            },
           }),
         );
       };
@@ -347,10 +349,8 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         }),
       );
     }),
-    clear: Effect.fnUntraced(function* (state) {
-      return yield* Box.renderPretty(
-        Cmd.clearLines(renderLayout(state, false).rows),
-      );
+    clear: Effect.fnUntraced(function* (_state) {
+      return "";
     }),
   });
 };

--- a/apps/cli/src/components/TextInput.ts
+++ b/apps/cli/src/components/TextInput.ts
@@ -1,4 +1,4 @@
-import { Array as Arr, Data, Effect, Option, pipe } from "effect";
+import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 
@@ -93,46 +93,43 @@ export const TextInput = (
   const initialState: TextState = { value: "", cursor: 0 };
 
   return Prompt.custom<TextState, string>(initialState, {
-    render: (state, action) => {
+    render: Effect.fnUntraced(function* (state, action) {
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
         NextFrame: ({ state: s }) => renderLayout(s, false),
         default: () => renderLayout(state, false),
       });
-      return Effect.succeed(
-        Box.renderPrettySync(
-          layout.pipe(
-            Box.combine(
-              action._tag === "Submit"
-                ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-                : Cmd.cursorHide,
-            ),
-          ),
-        ),
-      );
-    },
-    process: (input, state) => {
-      const key = input.key.name;
+
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
+
+      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+    }),
+    process: Effect.fnUntraced(function* (input, state) {
       const char = Option.getOrElse(input.input, () => "");
 
-      switch (key) {
-        case "left":
-          return Effect.succeed(
+      return yield* Match.value(input.key.name).pipe(
+        Match.when("left", () =>
+          Effect.succeed(
             Action.NextFrame({
               state: { ...state, cursor: Math.max(0, state.cursor - 1) },
             }),
-          );
-        case "right":
-          return Effect.succeed(
+          ),
+        ),
+        Match.when("right", () =>
+          Effect.succeed(
             Action.NextFrame({
               state: {
                 ...state,
                 cursor: Math.min(state.value.length, state.cursor + 1),
               },
             }),
-          );
-        case "backspace": {
+          ),
+        ),
+        Match.when("backspace", () => {
           if (state.cursor === 0) return Effect.succeed(Action.Beep());
           const newValue =
             state.value.slice(0, state.cursor - 1) +
@@ -142,8 +139,8 @@ export const TextInput = (
               state: { value: newValue, cursor: state.cursor - 1 },
             }),
           );
-        }
-        case "delete": {
+        }),
+        Match.when("delete", () => {
           if (state.cursor >= state.value.length)
             return Effect.succeed(Action.Beep());
           const newValue =
@@ -154,34 +151,33 @@ export const TextInput = (
               state: { value: newValue, cursor: state.cursor },
             }),
           );
-        }
-        case "home":
-          return Effect.succeed(
-            Action.NextFrame({ state: { ...state, cursor: 0 } }),
-          );
-        case "end":
-          return Effect.succeed(
+        }),
+        Match.when("home", () =>
+          Effect.succeed(Action.NextFrame({ state: { ...state, cursor: 0 } })),
+        ),
+        Match.when("end", () =>
+          Effect.succeed(
             Action.NextFrame({
               state: { ...state, cursor: state.value.length },
             }),
-          );
-        case "escape":
-          return Effect.succeed(Action.Submit({ value: defaultValue }));
-        case "enter":
-        case "return": {
+          ),
+        ),
+        Match.when("escape", () =>
+          Effect.succeed(Action.Submit({ value: defaultValue })),
+        ),
+        Match.whenOr("enter", "return", () => {
           const finalValue = state.value || defaultValue;
           if (options.validate) {
             return options.validate(finalValue).pipe(
               Effect.map((v) => Action.Submit({ value: v })),
-              Effect.catchIf(
-                () => true,
-                () => Effect.succeed(Action.Beep()),
+              Effect.catch(() =>
+                Effect.succeed(Action.NextFrame({ state })),
               ),
             );
           }
           return Effect.succeed(Action.Submit({ value: finalValue }));
-        }
-        default: {
+        }),
+        Match.orElse(() => {
           if (char && char.length === 1 && !input.key.ctrl && !input.key.meta) {
             const newValue =
               state.value.slice(0, state.cursor) +
@@ -194,14 +190,13 @@ export const TextInput = (
             );
           }
           return Effect.succeed(Action.NextFrame({ state }));
-        }
-      }
-    },
-    clear: (state, _action) =>
-      Effect.gen(function* () {
-        return Cmd.clearLines(renderLayout(state, false).rows).pipe(
-          Box.renderPrettySync,
-        );
-      }),
+        }),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (state) {
+      return yield* Box.renderPretty(
+        Cmd.clearLines(renderLayout(state, false).rows),
+      );
+    }),
   });
 };

--- a/apps/cli/src/components/TextInput.ts
+++ b/apps/cli/src/components/TextInput.ts
@@ -170,9 +170,7 @@ export const TextInput = (
           if (options.validate) {
             return options.validate(finalValue).pipe(
               Effect.map((v) => Action.Submit({ value: v })),
-              Effect.catch(() =>
-                Effect.succeed(Action.NextFrame({ state })),
-              ),
+              Effect.catch(() => Effect.succeed(Action.NextFrame({ state }))),
             );
           }
           return Effect.succeed(Action.Submit({ value: finalValue }));

--- a/apps/cli/src/lib/Viewport.ts
+++ b/apps/cli/src/lib/Viewport.ts
@@ -1,0 +1,147 @@
+/**
+ * Viewport — a pure state machine for windowed content scrolling.
+ *
+ * Provides two modes:
+ * - Active: consumes ScrollAction and returns new state (for dedicated scroll keys)
+ * - Passive: derives scroll offset from cursor position (for cursor-driven scrolling)
+ *
+ * State is 2D (row + col) to support future horizontal scrolling,
+ * but render currently only slices vertically.
+ *
+ * @module
+ */
+import { Option } from "effect";
+import { Box } from "effect-boxes";
+import type { AnsiStyle } from "effect-boxes/Ansi";
+
+// ─── State ───────────────────────────────────────────────────────────────────
+
+export interface State {
+  readonly row: number;
+  readonly col: number;
+}
+
+export const initial: State = { row: 0, col: 0 };
+
+// ─── Actions ─────────────────────────────────────────────────────────────────
+
+export type ScrollAction = "up" | "down" | "left" | "right";
+
+// ─── Bounds ──────────────────────────────────────────────────────────────────
+
+export interface Bounds {
+  readonly contentHeight: number;
+  readonly visibleHeight: number;
+}
+
+// ─── Metadata ────────────────────────────────────────────────────────────────
+
+export interface ViewportMeta {
+  readonly hasAbove: boolean;
+  readonly hasBelow: boolean;
+  readonly hasLeft: boolean;
+  readonly hasRight: boolean;
+  readonly offset: State;
+  readonly contentHeight: number;
+}
+
+// ─── Active mode: consume scroll actions ─────────────────────────────────────
+
+/**
+ * Attempt to scroll in the given direction. Returns `Option.some(newState)` if
+ * the action was consumed (offset changed), or `Option.none()` if the viewport
+ * is already at its boundary.
+ */
+export const scroll = (
+  state: State,
+  action: ScrollAction,
+  bounds: Bounds,
+): Option.Option<State> => {
+  const maxRow = Math.max(0, bounds.contentHeight - bounds.visibleHeight);
+
+  switch (action) {
+    case "up": {
+      if (state.row <= 0) return Option.none();
+      return Option.some({ ...state, row: state.row - 1 });
+    }
+    case "down": {
+      if (state.row >= maxRow) return Option.none();
+      return Option.some({ ...state, row: state.row + 1 });
+    }
+    case "left": {
+      if (state.col <= 0) return Option.none();
+      return Option.some({ ...state, col: state.col - 1 });
+    }
+    case "right": {
+      // No horizontal bounds yet — allow unbounded right scroll
+      return Option.some({ ...state, col: state.col + 1 });
+    }
+  }
+};
+
+// ─── Passive mode: follow cursor ─────────────────────────────────────────────
+
+/**
+ * Adjust the viewport offset so that `cursorRow` is visible within the window.
+ * Does not change state if the cursor is already visible.
+ */
+export const scrollToReveal = (
+  state: State,
+  cursorRow: number,
+  visibleHeight: number,
+): State => {
+  if (cursorRow < state.row) return { ...state, row: cursorRow };
+  if (cursorRow >= state.row + visibleHeight) {
+    return { ...state, row: cursorRow - visibleHeight + 1 };
+  }
+  return state;
+};
+
+// ─── Render ──────────────────────────────────────────────────────────────────
+
+export interface RenderResult {
+  readonly items: ReadonlyArray<Box.Box<AnsiStyle>>;
+  readonly meta: ViewportMeta;
+}
+
+/**
+ * Slice the items array through the viewport window, returning the visible
+ * items and metadata about scroll position.
+ */
+export const render = (
+  items: ReadonlyArray<Box.Box<AnsiStyle>>,
+  state: State,
+  visibleHeight: number,
+): RenderResult => {
+  const contentHeight = items.length;
+  const clampedRow = Math.max(
+    0,
+    Math.min(state.row, Math.max(0, contentHeight - visibleHeight)),
+  );
+
+  return {
+    items: items.slice(clampedRow, clampedRow + visibleHeight),
+    meta: {
+      hasAbove: clampedRow > 0,
+      hasBelow: clampedRow + visibleHeight < contentHeight,
+      hasLeft: state.col > 0,
+      hasRight: false, // horizontal render not yet implemented
+      offset: { row: clampedRow, col: state.col },
+      contentHeight,
+    },
+  };
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Pre-render a Box into an array of single-line Box items suitable for
+ * viewport slicing. Use this when your content is a rich Box (e.g., Confirm's
+ * children) rather than an already-structured list of items.
+ */
+export const linesFromBox = (
+  box: Box.Box<AnsiStyle>,
+): ReadonlyArray<Box.Box<AnsiStyle>> =>
+  Box.renderPrettySync(box)
+    .split("\n")
+    .map((l) => Box.line(l));

--- a/bun.lock
+++ b/bun.lock
@@ -3,38 +3,38 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "base_bevr-stack",
+      "name": "stack-effect",
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
-        "@effect/language-service": "^0.85.1",
-        "@effect/platform-bun": "4.0.0-beta.64",
-        "@types/bun": "^1.3.13",
-        "effect": "4.0.0-beta.64",
+        "@effect/language-service": "^0.86.1",
+        "@effect/platform-bun": "4.0.0-beta.65",
+        "@types/bun": "^1.3.14",
+        "effect": "4.0.0-beta.65",
         "turbo": "^2.9.12",
         "typescript": "6.0.3",
-        "vitest": "^4.1.5",
+        "vitest": "^4.1.6",
       },
     },
     "apps/cli": {
       "name": "stack-effect",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "bin": {
         "stack-effect": "dist/index.js",
       },
       "devDependencies": {
-        "@effect/platform-bun": "4.0.0-beta.64",
-        "@effect/platform-node": "4.0.0-beta.64",
-        "@effect/vitest": "4.0.0-beta.64",
+        "@effect/platform-bun": "4.0.0-beta.65",
+        "@effect/platform-node": "4.0.0-beta.65",
+        "@effect/vitest": "4.0.0-beta.65",
         "@repo/catalog": "workspace:*",
         "@repo/config-typescript": "workspace:*",
         "@repo/domain": "workspace:*",
         "@repo/scaffold": "workspace:*",
-        "@types/bun": "1.3.13",
-        "effect": "4.0.0-beta.64",
-        "effect-boxes": "^0.13.0",
-        "vitest": "^4.0.0",
+        "@types/bun": "1.3.14",
+        "effect": "4.0.0-beta.65",
+        "effect-boxes": "^0.14.0",
+        "vitest": "^4.1.6",
       },
     },
     "packages/catalog": {
@@ -42,13 +42,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@repo/domain": "workspace:*",
-        "effect": "4.0.0-beta.64",
+        "effect": "4.0.0-beta.65",
       },
       "devDependencies": {
-        "@effect/vitest": "4.0.0-beta.64",
+        "@effect/vitest": "4.0.0-beta.65",
         "@repo/config-typescript": "workspace:*",
-        "@types/node": "^25.6.2",
-        "vitest": "^4.1.5",
+        "@types/node": "^25.7.0",
+        "vitest": "^4.1.6",
       },
     },
     "packages/config-typescript": {
@@ -59,7 +59,7 @@
       "name": "@repo/domain",
       "version": "0.0.0",
       "dependencies": {
-        "effect": "4.0.0-beta.64",
+        "effect": "4.0.0-beta.65",
       },
       "devDependencies": {
         "@repo/config-typescript": "workspace:*",
@@ -71,15 +71,15 @@
       "dependencies": {
         "@repo/catalog": "workspace:*",
         "@repo/domain": "workspace:*",
-        "effect": "4.0.0-beta.64",
-        "effect-boxes": "^0.13.0",
+        "effect": "4.0.0-beta.65",
+        "effect-boxes": "^0.14.0",
         "ts-morph": "^28.0.0",
       },
       "devDependencies": {
-        "@effect/vitest": "4.0.0-beta.64",
+        "@effect/vitest": "4.0.0-beta.65",
         "@repo/config-typescript": "workspace:*",
-        "@types/node": "^25.6.2",
-        "vitest": "^4.1.5",
+        "@types/node": "^25.7.0",
+        "vitest": "^4.1.6",
       },
     },
   },
@@ -142,15 +142,15 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@effect/language-service": ["@effect/language-service@0.85.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-EXnJjIy6zQ3nUO/MZ+ynWUb8B895KZPotd1++oTs9JjDkplwM7cb6zo8Zq2zU6piwq+KflO7amXbEfj1UMpHkw=="],
+    "@effect/language-service": ["@effect/language-service@0.86.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-jfUuFdtNPKRZ4ZSrgTnfMHPIVq8L9cM+YGEylQ1lhIgNY23ZvfdPg0cUlWESd4q9aGvOWSA8E79AS0qe3j4ROw=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.64", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.64" }, "peerDependencies": { "effect": "^4.0.0-beta.64" } }, "sha512-rSPECyeN4ab1s+0l5DOXqlG31da3Np6UK/LujAAwBKCkZYAWM6bbh2+7GnKLI71UPG5eeEsNNPQR4epHifcTbg=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.65", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.65" }, "peerDependencies": { "effect": "^4.0.0-beta.65" } }, "sha512-6BgEjVDibeOgGj0pvYRx+mBLSWVBPlvuqa6o4kuyrRIdgn92nbKrbglEiIRe4sn7yYmeKei4N/kd7fRzN3rEwA=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.64", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.64", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.64", "ioredis": "^5.7.0" } }, "sha512-HlY04TBxe1Z2+Jl4dbwG5uHiUpEH6jvasoNtII6oergaHHQbbD8fLgFzHdy09mJTMK5B1O1fSb95Yztu5jwHxw=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.65", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.65", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.65", "ioredis": "^5.7.0" } }, "sha512-QQy3KRcMwP0TngQdfQGl2u1zp03B7k7DuF5SNS8aZhD0dDBpKZpCwFad1ODY5qdY3ycPgMwBwKRRK7y/aw0C9w=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.64", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.64" } }, "sha512-F5hVnPZbgKzxy2TijjhNZKqj7tQi60dx1W/JinnsNxYKGuspvW2gDUeqmNw7sP2bEA5ToeGDPqRCRdpHj3sZxg=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.66", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.66" } }, "sha512-+ymrhBnESv/hmn5SKTe2//IY9Ox/hGPeoogEWhW47ZGyhFI5eMYFxdEUBa+3IAV05rrBzrxON9lynu68n0DM7w=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.64", "", { "peerDependencies": { "effect": "^4.0.0-beta.64", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-BI+ju06iC6adB6evHSIz/HTppp9r8Kg1aaoOR6XVUgquLA9h3DJKmR7NWZLh8EXl5fIBI7VXDGpqJVr7MWBUug=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.65", "", { "peerDependencies": { "effect": "^4.0.0-beta.65", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-dJdZlQhB+AtMlSgrJ0QiprRhDnGVTcKmPe699+f5qkQjCKauogaAKekWV3xEM1envAMntwqeFUD4QHVnE+cFPg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -188,9 +188,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
 
     "@repo/catalog": ["@repo/catalog@workspace:packages/catalog"],
 
@@ -200,37 +198,37 @@
 
     "@repo/scaffold": ["@repo/scaffold@workspace:packages/scaffold"],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0", "", { "os": "linux", "cpu": "arm" }, "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0", "", { "os": "none", "cpu": "arm64" }, "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0", "", {}, "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -248,33 +246,33 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ=="],
 
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
-    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+    "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.6", "", { "dependencies": { "@vitest/utils": "4.1.6", "pathe": "^2.0.3" } }, "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+    "@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+    "@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -290,11 +288,11 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -322,9 +320,9 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
-    "effect": ["effect@4.0.0-beta.64", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xI332I9guVLsqvLg7aO62IuWq9LiCMs+u5dhr4JDyND2ndYXAk5eaR8KMqtYLoJg1Ie28VQToYPM+xBLEBU3pQ=="],
+    "effect": ["effect@4.0.0-beta.65", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
 
-    "effect-boxes": ["effect-boxes@0.13.0", "", { "peerDependencies": { "effect": ">=4.0.0-beta.59" } }, "sha512-AkOtLPIvIoZmC998pqyXGmpHGLFvTOF+O7/+QUZOrouwVlp4ueQj5I/d6cD6lN7deX0fzJaezHVi+LW4cSHngg=="],
+    "effect-boxes": ["effect-boxes@0.14.0", "", { "peerDependencies": { "effect": ">=4.0.0-beta.59" } }, "sha512-SYTvARCRxz1uI+uXFuO3e7mr1h/9irEOSuFNakLTG16+ph03DoibynjzdOoEh3CmnheaJ8CnrhfvXjbucvR8QA=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -338,7 +336,7 @@
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
-    "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -436,13 +434,13 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@1.11.10", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA=="],
+    "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
     "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -480,7 +478,7 @@
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
-    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
@@ -500,13 +498,13 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+    "rolldown": ["rolldown@1.0.0", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@rolldown/pluginutils": "1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0", "@rolldown/binding-darwin-arm64": "1.0.0", "@rolldown/binding-darwin-x64": "1.0.0", "@rolldown/binding-freebsd-x64": "1.0.0", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0", "@rolldown/binding-linux-arm64-gnu": "1.0.0", "@rolldown/binding-linux-arm64-musl": "1.0.0", "@rolldown/binding-linux-ppc64-gnu": "1.0.0", "@rolldown/binding-linux-s390x-gnu": "1.0.0", "@rolldown/binding-linux-x64-gnu": "1.0.0", "@rolldown/binding-linux-x64-musl": "1.0.0", "@rolldown/binding-openharmony-arm64": "1.0.0", "@rolldown/binding-wasm32-wasi": "1.0.0", "@rolldown/binding-win32-arm64-msvc": "1.0.0", "@rolldown/binding-win32-x64-msvc": "1.0.0" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -562,15 +560,15 @@
 
     "undici": ["undici@8.2.0", "", {}, "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
-    "uuid": ["uuid@13.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw=="],
+    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
 
-    "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
+    "vite": ["vite@8.0.12", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg=="],
 
-    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+    "vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -580,9 +578,9 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -591,10 +589,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@types/ws/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
-    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "@biomejs/biome": "2.4.15",
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
-    "@effect/language-service": "^0.85.1",
-    "@effect/platform-bun": "4.0.0-beta.64",
-    "@types/bun": "^1.3.13",
-    "effect": "4.0.0-beta.64",
+    "@effect/language-service": "^0.86.1",
+    "@effect/platform-bun": "4.0.0-beta.65",
+    "@types/bun": "^1.3.14",
+    "effect": "4.0.0-beta.65",
     "turbo": "^2.9.12",
     "typescript": "6.0.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=24"

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -16,12 +16,12 @@
   },
   "dependencies": {
     "@repo/domain": "workspace:*",
-    "effect": "4.0.0-beta.64"
+    "effect": "4.0.0-beta.65"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.64",
-    "@types/node": "^25.6.2",
+    "@effect/vitest": "4.0.0-beta.65",
+    "@types/node": "^25.7.0",
     "@repo/config-typescript": "workspace:*",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -8,8 +8,8 @@ export const cliPackageJsonContents = `{
   },
   "scripts": {},
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.64",
-    "effect": "4.0.0-beta.64"
+    "@effect/platform-bun": "4.0.0-beta.65",
+    "effect": "4.0.0-beta.65"
   },
   "devDependencies": {
     "@effect/language-service": "^0.85.1",

--- a/packages/catalog/src/registry/content/client.ts
+++ b/packages/catalog/src/registry/content/client.ts
@@ -26,10 +26,10 @@ export const clientPackageJsonContents = `{
   "scripts": {},
   "dependencies": {
     "@base-ui/react": "^1.3.0",
-    "@effect/atom-react": "4.0.0-beta.64",
+    "@effect/atom-react": "4.0.0-beta.65",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.65",
     "lucide-react": "^1.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -5,8 +5,8 @@ export const serverPackageJsonContents = `{
   "type": "module",
   "scripts": {},
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.64",
-    "effect": "4.0.0-beta.64"
+    "@effect/platform-bun": "4.0.0-beta.65",
+    "effect": "4.0.0-beta.65"
   },
   "devDependencies": {
     "@effect/language-service": "^0.85.1",

--- a/packages/catalog/src/registry/content/shared.ts
+++ b/packages/catalog/src/registry/content/shared.ts
@@ -5,7 +5,7 @@ export const packagePackageJsonContents = `{
   "type": "module",
   "scripts": {},
   "dependencies": {
-    "effect": "4.0.0-beta.64"
+    "effect": "4.0.0-beta.65"
   },
   "devDependencies": {
     "@effect/language-service": "^0.85.1",

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -204,7 +204,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "dependencies",
         name: "@effect/platform-browser",
-        value: "4.0.0-beta.64",
+        value: "4.0.0-beta.65",
       },
     ],
   },

--- a/packages/catalog/src/registry/modules/packages.ts
+++ b/packages/catalog/src/registry/modules/packages.ts
@@ -67,14 +67,14 @@ export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "dependencies",
         name: "@effect/ai-anthropic",
-        value: "4.0.0-beta.64",
+        value: "4.0.0-beta.65",
       },
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
         field: "dependencies",
         name: "effect",
-        value: "4.0.0-beta.64",
+        value: "4.0.0-beta.65",
       },
       {
         _tag: "pkg-json-entry",
@@ -242,7 +242,7 @@ export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "dependencies",
         name: "effect",
-        value: "4.0.0-beta.64",
+        value: "4.0.0-beta.65",
       },
       {
         _tag: "pkg-json-entry",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -25,7 +25,7 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.64"
+    "effect": "4.0.0-beta.65"
   },
   "devDependencies": {
     "@repo/config-typescript": "workspace:*"

--- a/packages/scaffold/package.json
+++ b/packages/scaffold/package.json
@@ -17,14 +17,14 @@
   "dependencies": {
     "@repo/domain": "workspace:*",
     "@repo/catalog": "workspace:*",
-    "effect": "4.0.0-beta.64",
-    "effect-boxes": "^0.13.0",
+    "effect": "4.0.0-beta.65",
+    "effect-boxes": "^0.14.0",
     "ts-morph": "^28.0.0"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.64",
-    "@types/node": "^25.6.2",
+    "@effect/vitest": "4.0.0-beta.65",
+    "@types/node": "^25.7.0",
     "@repo/config-typescript": "workspace:*",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.6"
   }
 }


### PR DESCRIPTION
## Goals/Scope

Going to explore how the state machine in Prompt can be composed to build more complex systems.  To do this I've try introduce a reusable `Viewport` abstraction to centralize viewport-related logic.

## Description

- Simplified prompt component implementation by using effects.
- Added a `Viewport` abstraction to standardize how viewports are handled.
- Bumped project dependencies.

```mermaid
stateDiagram-v2

    [*] --> Idle
    Idle --> Process
    Process --> Render
    Process --> [*]
    Render --> Idle

    state "Process" as Process {

        state input_choice <<choice>>
        [*] --> input_choice
        input_choice --> Domain
        input_choice --> Viewport
        input_choice --> [*] : Submit
        Domain --> [*] : NextFrame


        state "Viewport" as Viewport {
            [*] --> Up
            [*] --> Down
            Up --> [*]
            Down --> [*]
        }
        Viewport --> [*] : NextFrame
    }
```