### PR TITLE
feat: add key-bindings and validation

### DIFF
--- a/.changeset/cute-flies-beg.md
+++ b/.changeset/cute-flies-beg.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+add a KeyBinding abstraction to ensure input processing and hints align

--- a/apps/cli/src/components/Confirm.ts
+++ b/apps/cli/src/components/Confirm.ts
@@ -2,7 +2,9 @@ import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import type { AnsiStyle } from "effect-boxes/Ansi";
+import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import * as Viewport from "../lib/Viewport.js";
+import { Hint } from "./Hint.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -14,6 +16,7 @@ export interface ConfirmOptions extends Prompt.ConfirmOptions {
 interface ConfirmState {
   readonly cursor: number;
   readonly viewport: Viewport.State;
+  readonly prevRows: number;
 }
 
 /** Rows reserved for prompt chrome (margin, message, gaps, buttons, hint). */
@@ -21,6 +24,30 @@ const CHROME_ROWS = 10;
 
 /** Minimum rows for the children viewport. */
 const MIN_VIEWPORT_ROWS = 3;
+
+const ConfirmKeys = (hasChildren: boolean) => ({
+  Scroll: new KeyBinding({
+    keys: ["up", "down", "k", "j"],
+    label: "↑/↓",
+    action: "scroll",
+    enabled: hasChildren,
+  }),
+  Toggle: new KeyBinding({
+    keys: ["right", "left", "l", "h", "tab"],
+    label: "←/→",
+    action: "toggle",
+  }),
+  Submit: new KeyBinding({
+    keys: ["enter", "return"],
+    label: "enter",
+    action: "next",
+  }),
+  Cancel: new KeyBinding({
+    keys: ["escape"],
+    label: "esc",
+    action: "cancel",
+  }),
+});
 
 export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
   const message = options.message;
@@ -86,19 +113,6 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     );
   });
 
-  const renderHint = () => {
-    return Box.punctuateH(
-      [
-        ...(hasChildren ? [Box.text("↑/↓ scroll")] : []),
-        Box.text("←/→ Toggle"),
-        Box.text("enter next"),
-        Box.text("esc cancel"),
-      ],
-      Box.left,
-      Box.text(" • "),
-    ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
-  };
-
   const renderActive = Effect.fnUntraced(function* (state: ConfirmState) {
     const content = Box.vsep(
       [
@@ -119,7 +133,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        renderHint(),
+        Hint(ConfirmKeys(hasChildren)),
       ],
       1,
       Box.left,
@@ -138,10 +152,12 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
   const initialState: ConfirmState = {
     cursor: initialValue ? 0 : 1,
     viewport: Viewport.initial,
+    prevRows: 0,
   };
 
   return Prompt.custom<ConfirmState, boolean>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
+      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = yield* Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -149,12 +165,20 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
         default: () => renderLayout(state, false),
       });
 
+      // Clear previous output and render new in a single write to avoid flicker
+      const clear =
+        currentState.prevRows > 0
+          ? Cmd.clearLines(currentState.prevRows)
+          : Cmd.cursorHide;
+
       const cmds =
         action._tag === "Submit"
           ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
           : Cmd.cursorHide;
 
-      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+      return yield* Box.renderPretty(
+        Box.combine(clear, layout.pipe(Box.combine(cmds))),
+      );
     }),
     process: Effect.fnUntraced(function* (input, state) {
       const maxVisible = viewportHeight(process.stdout.rows ?? 24);
@@ -162,61 +186,46 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
         contentHeight: childrenRenderedLines.length,
         visibleHeight: maxVisible,
       };
+      const prevRows = (yield* renderActive(state)).rows;
 
-      return Match.value(input.key.name).pipe(
-        Match.whenOr("up", "k", () => {
+      const next = (patch: Partial<ConfirmState>) =>
+        Action.NextFrame({ state: { ...state, prevRows, ...patch } });
+
+      return Match.value(input).pipe(
+        whenBinding(ConfirmKeys(hasChildren).Scroll, (i) => {
           if (hasChildren) {
-            const next = Viewport.scroll(state.viewport, "up", bounds);
-            if (Option.isSome(next)) {
-              return Action.NextFrame({
-                state: { ...state, viewport: next.value },
-              });
+            const direction =
+              i.key.name === "up" || i.key.name === "k" ? "up" : "down";
+            const nextVp = Viewport.scroll(state.viewport, direction, bounds);
+            if (Option.isSome(nextVp)) {
+              return next({ viewport: nextVp.value });
             }
           }
-          return Action.NextFrame({ state });
+          return next({});
         }),
-        Match.whenOr("down", "j", () => {
-          if (hasChildren) {
-            const next = Viewport.scroll(state.viewport, "down", bounds);
-            if (Option.isSome(next)) {
-              return Action.NextFrame({
-                state: { ...state, viewport: next.value },
-              });
-            }
-          }
-          return Action.NextFrame({ state });
+        whenBinding(ConfirmKeys(hasChildren).Toggle, (i) => {
+          const direction =
+            i.key.name === "left" || i.key.name === "h" ? -1 : 1;
+          return next({
+            cursor:
+              (state.cursor + direction + choices.length) % choices.length,
+          });
         }),
-        Match.whenOr("right", "l", "tab", () =>
-          Action.NextFrame({
-            state: {
-              ...state,
-              cursor: (state.cursor + 1) % choices.length,
-            },
-          }),
+        whenBinding(ConfirmKeys(hasChildren).Cancel, () =>
+          Action.Submit({ value: false }),
         ),
-        Match.whenOr("left", "h", () =>
-          Action.NextFrame({
-            state: {
-              ...state,
-              cursor: (state.cursor - 1 + choices.length) % choices.length,
-            },
-          }),
-        ),
-        Match.when("escape", () => Action.Submit({ value: false })),
-        Match.whenOr("enter", "return", () => {
+        whenBinding(ConfirmKeys(hasChildren).Submit, () => {
           const selected = choices[state.cursor];
           if (selected) {
             return Action.Submit({ value: selected.value });
           }
           return Action.Beep();
         }),
-        Match.orElse(() => Action.NextFrame({ state })),
+        Match.orElse(() => next({})),
       );
     }),
-    clear: Effect.fnUntraced(function* (state) {
-      return yield* Box.renderPretty(
-        Cmd.clearLines((yield* renderLayout(state, false)).rows),
-      );
+    clear: Effect.fnUntraced(function* (_state) {
+      return "";
     }),
   });
 };

--- a/apps/cli/src/components/Confirm.ts
+++ b/apps/cli/src/components/Confirm.ts
@@ -16,7 +16,6 @@ export interface ConfirmOptions extends Prompt.ConfirmOptions {
 interface ConfirmState {
   readonly cursor: number;
   readonly viewport: Viewport.State;
-  readonly prevRows: number;
 }
 
 /** Rows reserved for prompt chrome (margin, message, gaps, buttons, hint). */
@@ -152,12 +151,12 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
   const initialState: ConfirmState = {
     cursor: initialValue ? 0 : 1,
     viewport: Viewport.initial,
-    prevRows: 0,
   };
+
+  let hasRendered = false;
 
   return Prompt.custom<ConfirmState, boolean>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
-      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = yield* Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -165,11 +164,11 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
         default: () => renderLayout(state, false),
       });
 
-      // Clear previous output and render new in a single write to avoid flicker
-      const clear =
-        currentState.prevRows > 0
-          ? Cmd.clearLines(currentState.prevRows)
-          : Cmd.cursorHide;
+      // Compute previous frame height from old state; skip on initial render
+      const clear = hasRendered
+        ? Cmd.clearLines((yield* renderActive(state)).rows)
+        : Cmd.cursorHide;
+      hasRendered = true;
 
       const cmds =
         action._tag === "Submit"
@@ -186,10 +185,9 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
         contentHeight: childrenRenderedLines.length,
         visibleHeight: maxVisible,
       };
-      const prevRows = (yield* renderActive(state)).rows;
 
       const next = (patch: Partial<ConfirmState>) =>
-        Action.NextFrame({ state: { ...state, prevRows, ...patch } });
+        Action.NextFrame({ state: { ...state, ...patch } });
 
       return Match.value(input).pipe(
         whenBinding(ConfirmKeys(hasChildren).Scroll, (i) => {

--- a/apps/cli/src/components/Hint.ts
+++ b/apps/cli/src/components/Hint.ts
@@ -1,0 +1,47 @@
+/**
+ * Hint — shared hint bar rendering for prompt components.
+ *
+ * Renders a horizontal list of key bindings as a dim hint bar below prompt
+ * content. Keys are rendered bold to visually distinguish them from action text.
+ *
+ * @module
+ */
+import { Ansi, Box } from "effect-boxes";
+import type { AnsiStyle } from "effect-boxes/Ansi";
+import type { KeyBinding, KeyMap } from "../lib/KeyBinding.js";
+
+// ─── Kbd ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Render a single key binding as `**key** action` (bold key, normal action).
+ */
+export const Kbd = (binding: KeyBinding): Box.Box<AnsiStyle> =>
+  Box.hcat(
+    [
+      Box.text(binding["label"]).pipe(Box.annotate(Ansi.bold)),
+      Box.text(` ${binding["action"]}`),
+    ],
+    Box.left,
+  );
+
+// ─── Hint ────────────────────────────────────────────────────────────────────
+
+/**
+ * Render a keymap as a horizontal hint bar.
+ *
+ * Only enabled bindings are shown. The bar is indented and dimmed to sit below
+ * prompt content.
+ *
+ * ```ts
+ * const hint = Hint(SelectKeys);
+ * // => "↑ up • ↓ down • enter select"  (dimmed, indented)
+ * ```
+ */
+export const Hint = (keymap: KeyMap): Box.Box<AnsiStyle> =>
+  Box.punctuateH(
+    Object.values(keymap)
+      .filter((b) => b["enabled"] ?? true)
+      .map(Kbd),
+    Box.left,
+    Box.text(" • "),
+  ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));

--- a/apps/cli/src/components/HorizontalSelect.ts
+++ b/apps/cli/src/components/HorizontalSelect.ts
@@ -1,8 +1,34 @@
 import { Data, Effect, Match } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
+import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
+import { Hint } from "./Hint.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
+
+const HorizontalSelectKeys = {
+  Right: new KeyBinding({
+    keys: ["right", "l", "tab"],
+    label: "←/→",
+    action: "toggle",
+  }),
+  Left: new KeyBinding({
+    keys: ["left", "h"],
+    label: "←/→",
+    action: "toggle",
+    enabled: false,
+  }),
+  Submit: new KeyBinding({
+    keys: ["enter", "return"],
+    label: "enter",
+    action: "select",
+  }),
+  Cancel: new KeyBinding({
+    keys: ["escape"],
+    label: "esc",
+    action: "cancel",
+  }),
+};
 
 export const HorizontalSelect = <A extends string>(
   options: Prompt.SelectOptions<A>,
@@ -49,16 +75,6 @@ export const HorizontalSelect = <A extends string>(
       Box.left,
     );
 
-    const hint = Box.punctuateH(
-      [
-        Box.text("←/→ Toggle"),
-        Box.text("enter select"),
-        Box.text("esc cancel"),
-      ],
-      Box.left,
-      Box.text(" • "),
-    ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
-
     return Box.vsep(
       [
         content.pipe(
@@ -68,53 +84,78 @@ export const HorizontalSelect = <A extends string>(
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        hint,
+        Hint(HorizontalSelectKeys),
       ],
       1,
       Box.left,
     ).pipe(Box.moveDown(1));
   };
 
-  return Prompt.custom<number, A>(0, {
-    render: Effect.fnUntraced(function* (cursor, action) {
-      const layout = Action.$match(action, {
-        Beep: () => renderLayout(cursor, false),
-        Submit: () => renderLayout(cursor, true),
-        NextFrame: ({ state }) => renderLayout(state, false),
-        default: () => renderLayout(cursor, false),
-      });
+  return Prompt.custom<{ cursor: number; prevRows: number }, A>(
+    { cursor: 0, prevRows: 0 },
+    {
+      render: Effect.fnUntraced(function* (state, action) {
+        const currentState = action._tag === "NextFrame" ? action.state : state;
+        const layout = Action.$match(action, {
+          Beep: () => renderLayout(state.cursor, false),
+          Submit: () => renderLayout(state.cursor, true),
+          NextFrame: ({ state: s }) => renderLayout(s.cursor, false),
+          default: () => renderLayout(state.cursor, false),
+        });
 
-      const cmds =
-        action._tag === "Submit"
-          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-          : Cmd.cursorHide;
+        // Clear previous output and render new in a single write to avoid flicker
+        const clear =
+          currentState.prevRows > 0
+            ? Cmd.clearLines(currentState.prevRows)
+            : Cmd.cursorHide;
 
-      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
-    }),
-    process: Effect.fnUntraced(function* (input, cursor) {
-      return Match.value(input.key.name).pipe(
-        Match.whenOr("right", "l", "tab", () =>
-          Action.NextFrame({ state: (cursor + 1) % choices.length }),
-        ),
-        Match.whenOr("left", "h", () =>
-          Action.NextFrame({
-            state: (cursor - 1 + choices.length) % choices.length,
+        const cmds =
+          action._tag === "Submit"
+            ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+            : Cmd.cursorHide;
+
+        return yield* Box.renderPretty(
+          Box.combine(clear, layout.pipe(Box.combine(cmds))),
+        );
+      }),
+      process: Effect.fnUntraced(function* (input, state) {
+        const prevRows = renderLayout(state.cursor, false).rows;
+
+        return Match.value(input).pipe(
+          whenBinding(HorizontalSelectKeys.Right, () =>
+            Action.NextFrame({
+              state: {
+                cursor: (state.cursor + 1) % choices.length,
+                prevRows,
+              },
+            }),
+          ),
+          whenBinding(HorizontalSelectKeys.Left, () =>
+            Action.NextFrame({
+              state: {
+                cursor: (state.cursor - 1 + choices.length) % choices.length,
+                prevRows,
+              },
+            }),
+          ),
+          whenBinding(HorizontalSelectKeys.Submit, () => {
+            const selected = choices[state.cursor];
+            if (selected) {
+              return Action.Submit({ value: selected.value });
+            }
+            return Action.Beep();
           }),
-        ),
-        Match.whenOr("enter", "return", () => {
-          const selected = choices[cursor];
-          if (selected) {
-            return Action.Submit({ value: selected.value });
-          }
-          return Action.Beep();
-        }),
-        Match.orElse(() => Action.NextFrame({ state: cursor })),
-      );
-    }),
-    clear: Effect.fnUntraced(function* (state) {
-      return yield* Box.renderPretty(
-        Cmd.clearLines(renderLayout(state, false).rows),
-      );
-    }),
-  });
+          whenBinding(HorizontalSelectKeys.Cancel, () =>
+            Action.Submit({ value: choices[0]!.value }),
+          ),
+          Match.orElse(() =>
+            Action.NextFrame({ state: { ...state, prevRows } }),
+          ),
+        );
+      }),
+      clear: Effect.fnUntraced(function* (_state) {
+        return "";
+      }),
+    },
+  );
 };

--- a/apps/cli/src/components/HorizontalSelect.ts
+++ b/apps/cli/src/components/HorizontalSelect.ts
@@ -91,71 +91,57 @@ export const HorizontalSelect = <A extends string>(
     ).pipe(Box.moveDown(1));
   };
 
-  return Prompt.custom<{ cursor: number; prevRows: number }, A>(
-    { cursor: 0, prevRows: 0 },
-    {
-      render: Effect.fnUntraced(function* (state, action) {
-        const currentState = action._tag === "NextFrame" ? action.state : state;
-        const layout = Action.$match(action, {
-          Beep: () => renderLayout(state.cursor, false),
-          Submit: () => renderLayout(state.cursor, true),
-          NextFrame: ({ state: s }) => renderLayout(s.cursor, false),
-          default: () => renderLayout(state.cursor, false),
-        });
+  let hasRendered = false;
 
-        // Clear previous output and render new in a single write to avoid flicker
-        const clear =
-          currentState.prevRows > 0
-            ? Cmd.clearLines(currentState.prevRows)
-            : Cmd.cursorHide;
+  return Prompt.custom<number, A>(0, {
+    render: Effect.fnUntraced(function* (cursor, action) {
+      const layout = Action.$match(action, {
+        Beep: () => renderLayout(cursor, false),
+        Submit: () => renderLayout(cursor, true),
+        NextFrame: ({ state }) => renderLayout(state, false),
+        default: () => renderLayout(cursor, false),
+      });
 
-        const cmds =
-          action._tag === "Submit"
-            ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-            : Cmd.cursorHide;
+      // Compute previous frame height from old state; skip on initial render
+      const clear = hasRendered
+        ? Cmd.clearLines(renderLayout(cursor, false).rows)
+        : Cmd.cursorHide;
+      hasRendered = true;
 
-        return yield* Box.renderPretty(
-          Box.combine(clear, layout.pipe(Box.combine(cmds))),
-        );
-      }),
-      process: Effect.fnUntraced(function* (input, state) {
-        const prevRows = renderLayout(state.cursor, false).rows;
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
 
-        return Match.value(input).pipe(
-          whenBinding(HorizontalSelectKeys.Right, () =>
-            Action.NextFrame({
-              state: {
-                cursor: (state.cursor + 1) % choices.length,
-                prevRows,
-              },
-            }),
-          ),
-          whenBinding(HorizontalSelectKeys.Left, () =>
-            Action.NextFrame({
-              state: {
-                cursor: (state.cursor - 1 + choices.length) % choices.length,
-                prevRows,
-              },
-            }),
-          ),
-          whenBinding(HorizontalSelectKeys.Submit, () => {
-            const selected = choices[state.cursor];
-            if (selected) {
-              return Action.Submit({ value: selected.value });
-            }
-            return Action.Beep();
+      return yield* Box.renderPretty(
+        Box.combine(clear, layout.pipe(Box.combine(cmds))),
+      );
+    }),
+    process: Effect.fnUntraced(function* (input, cursor) {
+      return Match.value(input).pipe(
+        whenBinding(HorizontalSelectKeys.Right, () =>
+          Action.NextFrame({ state: (cursor + 1) % choices.length }),
+        ),
+        whenBinding(HorizontalSelectKeys.Left, () =>
+          Action.NextFrame({
+            state: (cursor - 1 + choices.length) % choices.length,
           }),
-          whenBinding(HorizontalSelectKeys.Cancel, () =>
-            Action.Submit({ value: choices[0]!.value }),
-          ),
-          Match.orElse(() =>
-            Action.NextFrame({ state: { ...state, prevRows } }),
-          ),
-        );
-      }),
-      clear: Effect.fnUntraced(function* (_state) {
-        return "";
-      }),
-    },
-  );
+        ),
+        whenBinding(HorizontalSelectKeys.Submit, () => {
+          const selected = choices[cursor];
+          if (selected) {
+            return Action.Submit({ value: selected.value });
+          }
+          return Action.Beep();
+        }),
+        whenBinding(HorizontalSelectKeys.Cancel, () =>
+          Action.Submit({ value: choices[0]!.value }),
+        ),
+        Match.orElse(() => Action.NextFrame({ state: cursor })),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (_state) {
+      return "";
+    }),
+  });
 };

--- a/apps/cli/src/components/MultiSelect.ts
+++ b/apps/cli/src/components/MultiSelect.ts
@@ -9,7 +9,6 @@ const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 interface MultiSelectState {
   readonly cursor: number;
   readonly selected: ReadonlySet<number>;
-  readonly prevRows: number;
 }
 
 const MultiSelectKeys = {
@@ -127,12 +126,12 @@ export const MultiSelect = <A>(
   const initialState: MultiSelectState = {
     cursor: 0,
     selected: initialSelected,
-    prevRows: 0,
   };
+
+  let hasRendered = false;
 
   return Prompt.custom<MultiSelectState, Array<A>>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
-      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -140,11 +139,11 @@ export const MultiSelect = <A>(
         default: () => renderLayout(state, false),
       });
 
-      // Clear previous output and render new in a single write to avoid flicker
-      const clear =
-        currentState.prevRows > 0
-          ? Cmd.clearLines(currentState.prevRows)
-          : Cmd.cursorHide;
+      // Compute previous frame height from old state; skip on initial render
+      const clear = hasRendered
+        ? Cmd.clearLines(renderLayout(state, false).rows)
+        : Cmd.cursorHide;
+      hasRendered = true;
 
       const cmds =
         action._tag === "Submit"
@@ -156,10 +155,8 @@ export const MultiSelect = <A>(
       );
     }),
     process: Effect.fnUntraced(function* (input, state) {
-      const prevRows = renderLayout(state, false).rows;
-
       const next = (patch: Partial<MultiSelectState>) =>
-        Action.NextFrame({ state: { ...state, prevRows, ...patch } });
+        Action.NextFrame({ state: { ...state, ...patch } });
 
       return Match.value(input).pipe(
         whenBinding(MultiSelectKeys.Down, () =>

--- a/apps/cli/src/components/MultiSelect.ts
+++ b/apps/cli/src/components/MultiSelect.ts
@@ -1,13 +1,52 @@
 import { Data, Effect, Match } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
+import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
+import { Hint } from "./Hint.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
 interface MultiSelectState {
   readonly cursor: number;
   readonly selected: ReadonlySet<number>;
+  readonly prevRows: number;
 }
+
+const MultiSelectKeys = {
+  Down: new KeyBinding({
+    keys: ["down", "j", "tab"],
+    label: "↑/↓",
+    action: "navigate",
+  }),
+  Up: new KeyBinding({
+    keys: ["up", "k"],
+    label: "↑/↓",
+    action: "navigate",
+  }),
+  Toggle: new KeyBinding({
+    keys: ["space"],
+    label: "space",
+    action: "toggle",
+  }),
+  ToggleAll: new KeyBinding({
+    keys: ["a"],
+    label: "a",
+    action: "toggle all",
+  }),
+  Submit: new KeyBinding({
+    keys: ["enter", "return"],
+    label: "enter",
+    action: "submit",
+  }),
+};
+
+/** Hint shows deduplicated labels — Up/Down share the same label. */
+const MultiSelectHintKeys = {
+  Navigate: MultiSelectKeys.Down,
+  Toggle: MultiSelectKeys.Toggle,
+  ToggleAll: MultiSelectKeys.ToggleAll,
+  Submit: MultiSelectKeys.Submit,
+};
 
 export const MultiSelect = <A>(
   options: Prompt.SelectOptions<A> & Prompt.MultiSelectOptions,
@@ -65,17 +104,6 @@ export const MultiSelect = <A>(
       Box.left,
     );
 
-    const hint = Box.punctuateH(
-      [
-        Box.text("↑/↓ navigate"),
-        Box.text("space toggle"),
-        Box.text("a toggle all"),
-        Box.text("enter submit"),
-      ],
-      Box.left,
-      Box.text(" • "),
-    ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
-
     return Box.vsep(
       [
         content.pipe(
@@ -85,7 +113,7 @@ export const MultiSelect = <A>(
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        hint,
+        Hint(MultiSelectHintKeys),
       ],
       1,
       Box.left,
@@ -99,10 +127,12 @@ export const MultiSelect = <A>(
   const initialState: MultiSelectState = {
     cursor: 0,
     selected: initialSelected,
+    prevRows: 0,
   };
 
   return Prompt.custom<MultiSelectState, Array<A>>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
+      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -110,64 +140,67 @@ export const MultiSelect = <A>(
         default: () => renderLayout(state, false),
       });
 
+      // Clear previous output and render new in a single write to avoid flicker
+      const clear =
+        currentState.prevRows > 0
+          ? Cmd.clearLines(currentState.prevRows)
+          : Cmd.cursorHide;
+
       const cmds =
         action._tag === "Submit"
           ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
           : Cmd.cursorHide;
 
-      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+      return yield* Box.renderPretty(
+        Box.combine(clear, layout.pipe(Box.combine(cmds))),
+      );
     }),
     process: Effect.fnUntraced(function* (input, state) {
-      return Match.value(input.key.name).pipe(
-        Match.whenOr("down", "j", "tab", () =>
-          Action.NextFrame({
-            state: {
-              ...state,
-              cursor: (state.cursor + 1) % choices.length,
-            },
+      const prevRows = renderLayout(state, false).rows;
+
+      const next = (patch: Partial<MultiSelectState>) =>
+        Action.NextFrame({ state: { ...state, prevRows, ...patch } });
+
+      return Match.value(input).pipe(
+        whenBinding(MultiSelectKeys.Down, () =>
+          next({ cursor: (state.cursor + 1) % choices.length }),
+        ),
+        whenBinding(MultiSelectKeys.Up, () =>
+          next({
+            cursor: (state.cursor - 1 + choices.length) % choices.length,
           }),
         ),
-        Match.whenOr("up", "k", () =>
-          Action.NextFrame({
-            state: {
-              ...state,
-              cursor: (state.cursor - 1 + choices.length) % choices.length,
-            },
-          }),
-        ),
-        Match.when("space", () => {
+        whenBinding(MultiSelectKeys.Toggle, () => {
           const choice = choices[state.cursor];
           if (choice?.disabled) return Action.Beep();
-          const next = new Set(state.selected);
-          if (next.has(state.cursor)) {
-            next.delete(state.cursor);
+          const nextSet = new Set(state.selected);
+          if (nextSet.has(state.cursor)) {
+            nextSet.delete(state.cursor);
           } else {
-            if (next.size >= max) return Action.Beep();
-            next.add(state.cursor);
+            if (nextSet.size >= max) return Action.Beep();
+            nextSet.add(state.cursor);
           }
-          return Action.NextFrame({ state: { ...state, selected: next } });
+          return next({ selected: nextSet });
         }),
-        Match.when("a", () => {
+        whenBinding(MultiSelectKeys.ToggleAll, () => {
           const allSelected = state.selected.size === choices.length;
-          const next = allSelected
+          const nextSet = allSelected
             ? new Set<number>()
             : new Set<number>(choices.map((_, i) => i));
-          return Action.NextFrame({ state: { ...state, selected: next } });
+          return next({ selected: nextSet });
         }),
-        Match.whenOr("enter", "return", () => {
+        whenBinding(MultiSelectKeys.Submit, () => {
           if (state.selected.size < min) return Action.Beep();
           const values = choices
             .filter((_, i) => state.selected.has(i))
             .map((c) => c.value);
           return Action.Submit({ value: values });
         }),
-        Match.orElse(() => Action.NextFrame({ state })),
+        Match.orElse(() => next({})),
       );
     }),
-    clear: Effect.fnUntraced(function* (state) {
-      return yield* Box.renderPretty(
-        Cmd.clearLines(renderLayout(state, false).rows),
-      );
+    clear: Effect.fnUntraced(function* (_state) {
+      return "";
     }),
   });
 };

--- a/apps/cli/src/components/Select.ts
+++ b/apps/cli/src/components/Select.ts
@@ -69,68 +69,54 @@ export const Select = <A>(
     ).pipe(Box.moveDown(1));
   };
 
-  return Prompt.custom<{ cursor: number; prevRows: number }, A>(
-    { cursor: 0, prevRows: 0 },
-    {
-      render: Effect.fnUntraced(function* (state, action) {
-        const currentState = action._tag === "NextFrame" ? action.state : state;
-        const layout = Action.$match(action, {
-          Beep: () => renderLayout(state.cursor, false),
-          Submit: () => renderLayout(state.cursor, true),
-          NextFrame: ({ state: s }) => renderLayout(s.cursor, false),
-          default: () => renderLayout(state.cursor, false),
-        });
+  let hasRendered = false;
 
-        // Clear previous output and render new in a single write to avoid flicker
-        const clear =
-          currentState.prevRows > 0
-            ? Cmd.clearLines(currentState.prevRows)
-            : Cmd.cursorHide;
+  return Prompt.custom<number, A>(0, {
+    render: Effect.fnUntraced(function* (cursor, action) {
+      const layout = Action.$match(action, {
+        Beep: () => renderLayout(cursor, false),
+        Submit: () => renderLayout(cursor, true),
+        NextFrame: ({ state }) => renderLayout(state, false),
+        default: () => renderLayout(cursor, false),
+      });
 
-        const cmds =
-          action._tag === "Submit"
-            ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-            : Cmd.cursorHide;
+      // Compute previous frame height from old state; skip on initial render
+      const clear = hasRendered
+        ? Cmd.clearLines(renderLayout(cursor, false).rows)
+        : Cmd.cursorHide;
+      hasRendered = true;
 
-        return yield* Box.renderPretty(
-          Box.combine(clear, layout.pipe(Box.combine(cmds))),
-        );
-      }),
-      process: Effect.fnUntraced(function* (input, state) {
-        const prevRows = renderLayout(state.cursor, false).rows;
+      const cmds =
+        action._tag === "Submit"
+          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+          : Cmd.cursorHide;
 
-        return Match.value(input).pipe(
-          whenBinding(SelectKeys.Down, () =>
-            Action.NextFrame({
-              state: {
-                cursor: (state.cursor + 1) % choices.length,
-                prevRows,
-              },
-            }),
-          ),
-          whenBinding(SelectKeys.Up, () =>
-            Action.NextFrame({
-              state: {
-                cursor: (state.cursor - 1 + choices.length) % choices.length,
-                prevRows,
-              },
-            }),
-          ),
-          whenBinding(SelectKeys.Submit, () => {
-            const selected = choices[state.cursor];
-            if (selected) {
-              return Action.Submit({ value: selected.value });
-            }
-            return Action.Beep();
+      return yield* Box.renderPretty(
+        Box.combine(clear, layout.pipe(Box.combine(cmds))),
+      );
+    }),
+    process: Effect.fnUntraced(function* (input, cursor) {
+      return Match.value(input).pipe(
+        whenBinding(SelectKeys.Down, () =>
+          Action.NextFrame({ state: (cursor + 1) % choices.length }),
+        ),
+        whenBinding(SelectKeys.Up, () =>
+          Action.NextFrame({
+            state: (cursor - 1 + choices.length) % choices.length,
           }),
-          Match.orElse(() =>
-            Action.NextFrame({ state: { ...state, prevRows } }),
-          ),
-        );
-      }),
-      clear: Effect.fnUntraced(function* (_state) {
-        return "";
-      }),
-    },
-  );
+        ),
+        whenBinding(SelectKeys.Submit, () => {
+          const selected = choices[cursor];
+          if (selected) {
+            return Action.Submit({ value: selected.value });
+          }
+          return Action.Beep();
+        }),
+        Match.orElse(() => Action.NextFrame({ state: cursor })),
+      );
+    }),
+    clear: Effect.fnUntraced(function* (_state) {
+      return "";
+    }),
+  });
 };

--- a/apps/cli/src/components/Select.ts
+++ b/apps/cli/src/components/Select.ts
@@ -1,8 +1,24 @@
 import { Data, Effect, Match } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
+import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
+import { Hint } from "./Hint.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
+
+const SelectKeys = {
+  Down: new KeyBinding({
+    keys: ["down", "j", "tab"],
+    label: "↓",
+    action: "down",
+  }),
+  Up: new KeyBinding({ keys: ["up", "k"], label: "↑", action: "up" }),
+  Submit: new KeyBinding({
+    keys: ["enter", "return"],
+    label: "enter",
+    action: "select",
+  }),
+};
 
 export const Select = <A>(
   options: Prompt.SelectOptions<A>,
@@ -37,12 +53,6 @@ export const Select = <A>(
 
     const content = Box.vcat([label, Box.vcat(items, Box.left)], Box.left);
 
-    const hint = Box.punctuateH(
-      [Box.text("↑ up"), Box.text("↓ down"), Box.text("enter select")],
-      Box.left,
-      Box.text(" • "),
-    ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
-
     return Box.vsep(
       [
         content.pipe(
@@ -52,53 +62,75 @@ export const Select = <A>(
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        hint,
+        Hint(SelectKeys),
       ],
       1,
       Box.left,
     ).pipe(Box.moveDown(1));
   };
 
-  return Prompt.custom<number, A>(0, {
-    render: Effect.fnUntraced(function* (cursor, action) {
-      const layout = Action.$match(action, {
-        Beep: () => renderLayout(cursor, false),
-        Submit: () => renderLayout(cursor, true),
-        NextFrame: ({ state }) => renderLayout(state, false),
-        default: () => renderLayout(cursor, false),
-      });
+  return Prompt.custom<{ cursor: number; prevRows: number }, A>(
+    { cursor: 0, prevRows: 0 },
+    {
+      render: Effect.fnUntraced(function* (state, action) {
+        const currentState = action._tag === "NextFrame" ? action.state : state;
+        const layout = Action.$match(action, {
+          Beep: () => renderLayout(state.cursor, false),
+          Submit: () => renderLayout(state.cursor, true),
+          NextFrame: ({ state: s }) => renderLayout(s.cursor, false),
+          default: () => renderLayout(state.cursor, false),
+        });
 
-      const cmds =
-        action._tag === "Submit"
-          ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
-          : Cmd.cursorHide;
+        // Clear previous output and render new in a single write to avoid flicker
+        const clear =
+          currentState.prevRows > 0
+            ? Cmd.clearLines(currentState.prevRows)
+            : Cmd.cursorHide;
 
-      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
-    }),
-    process: Effect.fnUntraced(function* (input, cursor) {
-      return Match.value(input.key.name).pipe(
-        Match.whenOr("down", "j", "tab", () =>
-          Action.NextFrame({ state: (cursor + 1) % choices.length }),
-        ),
-        Match.whenOr("up", "k", () =>
-          Action.NextFrame({
-            state: (cursor - 1 + choices.length) % choices.length,
+        const cmds =
+          action._tag === "Submit"
+            ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
+            : Cmd.cursorHide;
+
+        return yield* Box.renderPretty(
+          Box.combine(clear, layout.pipe(Box.combine(cmds))),
+        );
+      }),
+      process: Effect.fnUntraced(function* (input, state) {
+        const prevRows = renderLayout(state.cursor, false).rows;
+
+        return Match.value(input).pipe(
+          whenBinding(SelectKeys.Down, () =>
+            Action.NextFrame({
+              state: {
+                cursor: (state.cursor + 1) % choices.length,
+                prevRows,
+              },
+            }),
+          ),
+          whenBinding(SelectKeys.Up, () =>
+            Action.NextFrame({
+              state: {
+                cursor: (state.cursor - 1 + choices.length) % choices.length,
+                prevRows,
+              },
+            }),
+          ),
+          whenBinding(SelectKeys.Submit, () => {
+            const selected = choices[state.cursor];
+            if (selected) {
+              return Action.Submit({ value: selected.value });
+            }
+            return Action.Beep();
           }),
-        ),
-        Match.whenOr("enter", "return", () => {
-          const selected = choices[cursor];
-          if (selected) {
-            return Action.Submit({ value: selected.value });
-          }
-          return Action.Beep();
-        }),
-        Match.orElse(() => Action.NextFrame({ state: cursor })),
-      );
-    }),
-    clear: Effect.fnUntraced(function* (state) {
-      return yield* Box.renderPretty(
-        Cmd.clearLines(renderLayout(state, false).rows),
-      );
-    }),
-  });
+          Match.orElse(() =>
+            Action.NextFrame({ state: { ...state, prevRows } }),
+          ),
+        );
+      }),
+      clear: Effect.fnUntraced(function* (_state) {
+        return "";
+      }),
+    },
+  );
 };

--- a/apps/cli/src/components/TextArea.ts
+++ b/apps/cli/src/components/TextArea.ts
@@ -1,7 +1,9 @@
 import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
+import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import * as Viewport from "../lib/Viewport.js";
+import { Hint } from "./Hint.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -29,6 +31,44 @@ const joinLines = (lines: ReadonlyArray<string>): string => lines.join("\n");
 
 const clampCol = (col: number, line: string): number =>
   Math.min(col, line.length);
+
+const TextAreaKeys = {
+  NewLine: new KeyBinding({
+    keys: ["enter", "return"],
+    label: "enter",
+    action: "new line",
+  }),
+  Submit: new KeyBinding({
+    keys: ["d"],
+    label: "ctrl+d",
+    action: "submit",
+    ctrl: true,
+  }),
+  Cancel: new KeyBinding({
+    keys: ["escape"],
+    label: "esc",
+    action: "cancel",
+  }),
+};
+
+const TextAreaNavKeys = {
+  Left: new KeyBinding({ keys: ["left"], label: "left", action: "left" }),
+  Right: new KeyBinding({ keys: ["right"], label: "right", action: "right" }),
+  Up: new KeyBinding({ keys: ["up"], label: "up", action: "up" }),
+  Down: new KeyBinding({ keys: ["down"], label: "down", action: "down" }),
+  Backspace: new KeyBinding({
+    keys: ["backspace"],
+    label: "backspace",
+    action: "delete",
+  }),
+  Delete: new KeyBinding({
+    keys: ["delete"],
+    label: "delete",
+    action: "delete forward",
+  }),
+  Home: new KeyBinding({ keys: ["home"], label: "home", action: "start" }),
+  End: new KeyBinding({ keys: ["end"], label: "end", action: "end" }),
+};
 
 export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
   const message = options.message;
@@ -116,16 +156,6 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
 
     const content = Box.vcat([label, inputContent], Box.left);
 
-    const hint = Box.punctuateH(
-      [
-        Box.text("enter new line"),
-        Box.text("ctrl+d submit"),
-        Box.text("esc cancel"),
-      ],
-      Box.left,
-      Box.text(" • "),
-    ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
-
     return Box.vsep(
       [
         content.pipe(
@@ -135,7 +165,7 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        hint,
+        Hint(TextAreaKeys),
       ],
       1,
       Box.left,
@@ -200,8 +230,23 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         );
       };
 
-      return yield* Match.value(input.key.name).pipe(
-        Match.when("left", () => {
+      return yield* Match.value(input).pipe(
+        // Modifier-aware bindings first (ctrl+d must match before 'd' is inserted)
+        whenBinding(TextAreaKeys.Submit, () => {
+          const finalValue = joinLines(state.lines) || defaultValue;
+          if (options.validate) {
+            return options.validate(finalValue).pipe(
+              Effect.map((v) => Action.Submit({ value: v })),
+              Effect.catch(() => next({})),
+            );
+          }
+          return Effect.succeed(Action.Submit({ value: finalValue }));
+        }),
+        whenBinding(TextAreaKeys.Cancel, () =>
+          Effect.succeed(Action.Submit({ value: defaultValue })),
+        ),
+        // Navigation
+        whenBinding(TextAreaNavKeys.Left, () => {
           if (state.col > 0) {
             const newCol = state.col - 1;
             return next({ col: newCol, stickyCol: newCol });
@@ -214,9 +259,9 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
               stickyCol: prevLine.length,
             });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
+          return next({});
         }),
-        Match.when("right", () => {
+        whenBinding(TextAreaNavKeys.Right, () => {
           if (state.col < currentLine.length) {
             const newCol = state.col + 1;
             return next({ col: newCol, stickyCol: newCol });
@@ -224,23 +269,21 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
           if (state.row < state.lines.length - 1) {
             return next({ row: state.row + 1, col: 0, stickyCol: 0 });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
+          return next({});
         }),
-        Match.when("up", () => {
-          if (state.row === 0)
-            return Effect.succeed(Action.NextFrame({ state }));
+        whenBinding(TextAreaNavKeys.Up, () => {
+          if (state.row === 0) return next({});
           const targetLine = state.lines[state.row - 1] ?? "";
           const newCol = clampCol(state.stickyCol, targetLine);
           return next({ row: state.row - 1, col: newCol });
         }),
-        Match.when("down", () => {
-          if (state.row >= state.lines.length - 1)
-            return Effect.succeed(Action.NextFrame({ state }));
+        whenBinding(TextAreaNavKeys.Down, () => {
+          if (state.row >= state.lines.length - 1) return next({});
           const targetLine = state.lines[state.row + 1] ?? "";
           const newCol = clampCol(state.stickyCol, targetLine);
           return next({ row: state.row + 1, col: newCol });
         }),
-        Match.when("backspace", () => {
+        whenBinding(TextAreaNavKeys.Backspace, () => {
           if (state.col > 0) {
             const newLine =
               currentLine.slice(0, state.col - 1) +
@@ -248,7 +291,11 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             const newLines = [...state.lines];
             newLines[state.row] = newLine;
             const newCol = state.col - 1;
-            return next({ lines: newLines, col: newCol, stickyCol: newCol });
+            return next({
+              lines: newLines,
+              col: newCol,
+              stickyCol: newCol,
+            });
           }
           if (state.row > 0) {
             const prevLine = state.lines[state.row - 1] ?? "";
@@ -262,9 +309,9 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
               stickyCol: prevLine.length,
             });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
+          return next({});
         }),
-        Match.when("delete", () => {
+        whenBinding(TextAreaNavKeys.Delete, () => {
           if (state.col < currentLine.length) {
             const newLine =
               currentLine.slice(0, state.col) +
@@ -280,49 +327,17 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             newLines.splice(state.row, 2, mergedLine);
             return next({ lines: newLines });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
+          return next({});
         }),
-        Match.when("home", () => next({ col: 0, stickyCol: 0 })),
-        Match.when("end", () =>
+        whenBinding(TextAreaNavKeys.Home, () => next({ col: 0, stickyCol: 0 })),
+        whenBinding(TextAreaNavKeys.End, () =>
           next({
             col: currentLine.length,
             stickyCol: currentLine.length,
           }),
         ),
-        Match.when("escape", () =>
-          Effect.succeed(Action.Submit({ value: defaultValue })),
-        ),
-        Match.when("d", () => {
-          if (input.key.ctrl) {
-            const finalValue = joinLines(state.lines) || defaultValue;
-            if (options.validate) {
-              return options.validate(finalValue).pipe(
-                Effect.map((v) => Action.Submit({ value: v })),
-                Effect.catch(() => Effect.succeed(Action.NextFrame({ state }))),
-              );
-            }
-            return Effect.succeed(Action.Submit({ value: finalValue }));
-          }
-          const newLine =
-            currentLine.slice(0, state.col) +
-            "d" +
-            currentLine.slice(state.col);
-          const newLines = [...state.lines];
-          newLines[state.row] = newLine;
-          const newCol = state.col + 1;
-          return next({ lines: newLines, col: newCol, stickyCol: newCol });
-        }),
-        Match.whenOr("enter", "return", "j", () => {
-          if (input.key.name === "j" && !input.key.ctrl) {
-            const newLine =
-              currentLine.slice(0, state.col) +
-              "j" +
-              currentLine.slice(state.col);
-            const newLines = [...state.lines];
-            newLines[state.row] = newLine;
-            const newCol = state.col + 1;
-            return next({ lines: newLines, col: newCol, stickyCol: newCol });
-          }
+        // Enter/return inserts new line (non-ctrl)
+        whenBinding(TextAreaKeys.NewLine, () => {
           const before = currentLine.slice(0, state.col);
           const after = currentLine.slice(state.col);
           const insertLines = [...state.lines];
@@ -334,6 +349,7 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             stickyCol: 0,
           });
         }),
+        // Insert printable characters or no-op
         Match.orElse(() => {
           if (char && char.length === 1 && !input.key.ctrl && !input.key.meta) {
             const newLine =
@@ -343,9 +359,13 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
             const newLines = [...state.lines];
             newLines[state.row] = newLine;
             const newCol = state.col + 1;
-            return next({ lines: newLines, col: newCol, stickyCol: newCol });
+            return next({
+              lines: newLines,
+              col: newCol,
+              stickyCol: newCol,
+            });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
+          return next({});
         }),
       );
     }),

--- a/apps/cli/src/components/TextArea.ts
+++ b/apps/cli/src/components/TextArea.ts
@@ -19,7 +19,7 @@ interface TextAreaState {
   readonly col: number;
   readonly stickyCol: number;
   readonly viewport: Viewport.State;
-  readonly prevRows: number;
+  readonly error: Option.Option<string>;
 }
 
 const splitLines = (value: string): Array<string> => {
@@ -78,6 +78,7 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
   const placeholder = options.placeholder ?? "";
 
   const renderLayout = (state: TextAreaState, submitted: boolean) => {
+    const hasError = Option.isSome(state.error);
     const label = Box.text(message).pipe(Box.annotate(Ansi.bold));
 
     if (submitted) {
@@ -150,22 +151,32 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         });
 
     const inputContent = Box.vcat(
-      [Box.text("? ").pipe(Box.annotate(Ansi.cyan)), ...lineBoxes],
+      [
+        Box.text("? ").pipe(Box.annotate(hasError ? Ansi.red : Ansi.cyan)),
+        ...lineBoxes,
+      ],
       Box.left,
     ).pipe(Box.minHeight(minRows + 1), Box.minWidth(40), Box.border("rounded"));
 
     const content = Box.vcat([label, inputContent], Box.left);
+
+    const footer = hasError
+      ? Box.text(`✘ ${state.error.value}`).pipe(
+          Box.moveRight(2),
+          Box.annotate(Ansi.red),
+        )
+      : Hint(TextAreaKeys);
 
     return Box.vsep(
       [
         content.pipe(
           Box.pad(0, 0, 0, 1),
           Box.border("thick", {
-            annotation: Ansi.dim,
+            annotation: hasError ? Ansi.red : Ansi.dim,
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        Hint(TextAreaKeys),
+        footer,
       ],
       1,
       Box.left,
@@ -179,12 +190,13 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
     col: 0,
     stickyCol: 0,
     viewport: Viewport.initial,
-    prevRows: 0,
+    error: Option.none(),
   };
+
+  let hasRendered = false;
 
   return Prompt.custom<TextAreaState, string>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
-      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -192,11 +204,11 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         default: () => renderLayout(state, false),
       });
 
-      // Clear previous output and render new in a single write to avoid flicker
-      const clear =
-        currentState.prevRows > 0
-          ? Cmd.clearLines(currentState.prevRows)
-          : Cmd.cursorHide;
+      // Compute previous frame height from old state; skip on initial render
+      const clear = hasRendered
+        ? Cmd.clearLines(renderLayout(state, false).rows)
+        : Cmd.cursorHide;
+      hasRendered = true;
 
       const cmds =
         action._tag === "Submit"
@@ -211,20 +223,23 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
       const char = Option.getOrElse(input.input, () => "");
       const currentLine = state.lines[state.row] ?? "";
 
+      /** Advance to next frame, clearing any active error on edits. */
       const next = (patch: Partial<TextAreaState>) => {
-        const newState = { ...state, ...patch };
+        const newState = {
+          ...state,
+          error: Option.none() as Option.Option<string>,
+          ...patch,
+        };
         const newViewport = Viewport.scrollToReveal(
           newState.viewport ?? state.viewport,
           newState.row ?? state.row,
           maxRows,
         );
-        const layout = renderLayout(state, false);
         return Effect.succeed(
           Action.NextFrame({
             state: {
               ...newState,
               viewport: newViewport,
-              prevRows: layout.rows,
             },
           }),
         );
@@ -237,7 +252,13 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
           if (options.validate) {
             return options.validate(finalValue).pipe(
               Effect.map((v) => Action.Submit({ value: v })),
-              Effect.catch(() => next({})),
+              Effect.catch((err) =>
+                next({
+                  error: Option.some(
+                    typeof err === "string" ? err : String(err),
+                  ),
+                }),
+              ),
             );
           }
           return Effect.succeed(Action.Submit({ value: finalValue }));

--- a/apps/cli/src/components/TextInput.ts
+++ b/apps/cli/src/components/TextInput.ts
@@ -1,13 +1,51 @@
 import { Data, Effect, Match, Option } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
+import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
+import { Hint } from "./Hint.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
 interface TextState {
   readonly value: string;
   readonly cursor: number;
+  readonly prevRows: number;
 }
+
+const TextInputKeys = {
+  Type: new KeyBinding({
+    keys: [],
+    label: "type",
+    action: "to edit",
+  }),
+  Submit: new KeyBinding({
+    keys: ["enter", "return"],
+    label: "enter",
+    action: "submit",
+  }),
+  Cancel: new KeyBinding({
+    keys: ["escape"],
+    label: "esc",
+    action: "cancel",
+  }),
+};
+
+const TextInputNavKeys = {
+  Left: new KeyBinding({ keys: ["left"], label: "left", action: "left" }),
+  Right: new KeyBinding({ keys: ["right"], label: "right", action: "right" }),
+  Backspace: new KeyBinding({
+    keys: ["backspace"],
+    label: "backspace",
+    action: "delete",
+  }),
+  Delete: new KeyBinding({
+    keys: ["delete"],
+    label: "delete",
+    action: "delete forward",
+  }),
+  Home: new KeyBinding({ keys: ["home"], label: "home", action: "start" }),
+  End: new KeyBinding({ keys: ["end"], label: "end", action: "end" }),
+};
 
 export const TextInput = (
   options: Prompt.TextOptions,
@@ -64,16 +102,6 @@ export const TextInput = (
 
     const content = Box.vcat([label, inputBox], Box.left);
 
-    const hint = Box.punctuateH(
-      [
-        Box.text("type to edit"),
-        Box.text("enter submit"),
-        Box.text("esc cancel"),
-      ],
-      Box.left,
-      Box.text(" • "),
-    ).pipe(Box.moveRight(2), Box.annotate(Ansi.dim));
-
     return Box.vsep(
       [
         content.pipe(
@@ -83,17 +111,18 @@ export const TextInput = (
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        hint,
+        Hint(TextInputKeys),
       ],
       1,
       Box.left,
     ).pipe(Box.moveDown(1));
   };
 
-  const initialState: TextState = { value: "", cursor: 0 };
+  const initialState: TextState = { value: "", cursor: 0, prevRows: 0 };
 
   return Prompt.custom<TextState, string>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
+      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -101,76 +130,65 @@ export const TextInput = (
         default: () => renderLayout(state, false),
       });
 
+      // Clear previous output and render new in a single write to avoid flicker
+      const clear =
+        currentState.prevRows > 0
+          ? Cmd.clearLines(currentState.prevRows)
+          : Cmd.cursorHide;
+
       const cmds =
         action._tag === "Submit"
           ? Box.combine(Cmd.cursorShow, Cmd.cursorNextLine(1))
           : Cmd.cursorHide;
 
-      return yield* Box.renderPretty(layout.pipe(Box.combine(cmds)));
+      return yield* Box.renderPretty(
+        Box.combine(clear, layout.pipe(Box.combine(cmds))),
+      );
     }),
     process: Effect.fnUntraced(function* (input, state) {
       const char = Option.getOrElse(input.input, () => "");
+      const prevRows = renderLayout(state, false).rows;
 
-      return yield* Match.value(input.key.name).pipe(
-        Match.when("left", () =>
-          Effect.succeed(
-            Action.NextFrame({
-              state: { ...state, cursor: Math.max(0, state.cursor - 1) },
-            }),
-          ),
+      const next = (patch: Partial<TextState>) =>
+        Effect.succeed(
+          Action.NextFrame({ state: { ...state, prevRows, ...patch } }),
+        );
+
+      return yield* Match.value(input).pipe(
+        whenBinding(TextInputNavKeys.Left, () =>
+          next({ cursor: Math.max(0, state.cursor - 1) }),
         ),
-        Match.when("right", () =>
-          Effect.succeed(
-            Action.NextFrame({
-              state: {
-                ...state,
-                cursor: Math.min(state.value.length, state.cursor + 1),
-              },
-            }),
-          ),
+        whenBinding(TextInputNavKeys.Right, () =>
+          next({ cursor: Math.min(state.value.length, state.cursor + 1) }),
         ),
-        Match.when("backspace", () => {
+        whenBinding(TextInputNavKeys.Backspace, () => {
           if (state.cursor === 0) return Effect.succeed(Action.Beep());
           const newValue =
             state.value.slice(0, state.cursor - 1) +
             state.value.slice(state.cursor);
-          return Effect.succeed(
-            Action.NextFrame({
-              state: { value: newValue, cursor: state.cursor - 1 },
-            }),
-          );
+          return next({ value: newValue, cursor: state.cursor - 1 });
         }),
-        Match.when("delete", () => {
+        whenBinding(TextInputNavKeys.Delete, () => {
           if (state.cursor >= state.value.length)
             return Effect.succeed(Action.Beep());
           const newValue =
             state.value.slice(0, state.cursor) +
             state.value.slice(state.cursor + 1);
-          return Effect.succeed(
-            Action.NextFrame({
-              state: { value: newValue, cursor: state.cursor },
-            }),
-          );
+          return next({ value: newValue, cursor: state.cursor });
         }),
-        Match.when("home", () =>
-          Effect.succeed(Action.NextFrame({ state: { ...state, cursor: 0 } })),
+        whenBinding(TextInputNavKeys.Home, () => next({ cursor: 0 })),
+        whenBinding(TextInputNavKeys.End, () =>
+          next({ cursor: state.value.length }),
         ),
-        Match.when("end", () =>
-          Effect.succeed(
-            Action.NextFrame({
-              state: { ...state, cursor: state.value.length },
-            }),
-          ),
-        ),
-        Match.when("escape", () =>
+        whenBinding(TextInputKeys.Cancel, () =>
           Effect.succeed(Action.Submit({ value: defaultValue })),
         ),
-        Match.whenOr("enter", "return", () => {
+        whenBinding(TextInputKeys.Submit, () => {
           const finalValue = state.value || defaultValue;
           if (options.validate) {
             return options.validate(finalValue).pipe(
               Effect.map((v) => Action.Submit({ value: v })),
-              Effect.catch(() => Effect.succeed(Action.NextFrame({ state }))),
+              Effect.catch(() => next({})),
             );
           }
           return Effect.succeed(Action.Submit({ value: finalValue }));
@@ -181,20 +199,14 @@ export const TextInput = (
               state.value.slice(0, state.cursor) +
               char +
               state.value.slice(state.cursor);
-            return Effect.succeed(
-              Action.NextFrame({
-                state: { value: newValue, cursor: state.cursor + 1 },
-              }),
-            );
+            return next({ value: newValue, cursor: state.cursor + 1 });
           }
-          return Effect.succeed(Action.NextFrame({ state }));
+          return next({});
         }),
       );
     }),
-    clear: Effect.fnUntraced(function* (state) {
-      return yield* Box.renderPretty(
-        Cmd.clearLines(renderLayout(state, false).rows),
-      );
+    clear: Effect.fnUntraced(function* (_state) {
+      return "";
     }),
   });
 };

--- a/apps/cli/src/components/TextInput.ts
+++ b/apps/cli/src/components/TextInput.ts
@@ -9,7 +9,7 @@ const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 interface TextState {
   readonly value: string;
   readonly cursor: number;
-  readonly prevRows: number;
+  readonly error: Option.Option<string>;
 }
 
 const TextInputKeys = {
@@ -54,6 +54,7 @@ export const TextInput = (
   const defaultValue = options.default ?? "";
 
   const renderLayout = (state: TextState, submitted: boolean) => {
+    const hasError = Option.isSome(state.error);
     const label = Box.text(message).pipe(Box.annotate(Ansi.bold));
 
     const displayValue = state.value || defaultValue;
@@ -69,7 +70,7 @@ export const TextInput = (
         )
       : Box.hsep(
           [
-            Box.text("? ").pipe(Box.annotate(Ansi.cyan)),
+            Box.text("? ").pipe(Box.annotate(hasError ? Ansi.red : Ansi.cyan)),
             Box.text(textBeforeCursor).pipe(
               Box.annotate(
                 isPlaceholder ? Ansi.dim : Ansi.combine(Ansi.white, Ansi.bold),
@@ -102,27 +103,39 @@ export const TextInput = (
 
     const content = Box.vcat([label, inputBox], Box.left);
 
+    const footer = hasError
+      ? Box.text(`✘ ${state.error.value}`).pipe(
+          Box.moveRight(2),
+          Box.annotate(Ansi.red),
+        )
+      : Hint(TextInputKeys);
+
     return Box.vsep(
       [
         content.pipe(
           Box.pad(0, 0, 0, 1),
           Box.border("thick", {
-            annotation: Ansi.dim,
+            annotation: hasError ? Ansi.red : Ansi.dim,
             sides: { top: false, bottom: false, right: false },
           }),
         ),
-        Hint(TextInputKeys),
+        footer,
       ],
       1,
       Box.left,
     ).pipe(Box.moveDown(1));
   };
 
-  const initialState: TextState = { value: "", cursor: 0, prevRows: 0 };
+  const initialState: TextState = {
+    value: "",
+    cursor: 0,
+    error: Option.none(),
+  };
+
+  let hasRendered = false;
 
   return Prompt.custom<TextState, string>(initialState, {
     render: Effect.fnUntraced(function* (state, action) {
-      const currentState = action._tag === "NextFrame" ? action.state : state;
       const layout = Action.$match(action, {
         Beep: () => renderLayout(state, false),
         Submit: () => renderLayout(state, true),
@@ -130,11 +143,11 @@ export const TextInput = (
         default: () => renderLayout(state, false),
       });
 
-      // Clear previous output and render new in a single write to avoid flicker
-      const clear =
-        currentState.prevRows > 0
-          ? Cmd.clearLines(currentState.prevRows)
-          : Cmd.cursorHide;
+      // Compute previous frame height from old state; skip on initial render
+      const clear = hasRendered
+        ? Cmd.clearLines(renderLayout(state, false).rows)
+        : Cmd.cursorHide;
+      hasRendered = true;
 
       const cmds =
         action._tag === "Submit"
@@ -147,11 +160,13 @@ export const TextInput = (
     }),
     process: Effect.fnUntraced(function* (input, state) {
       const char = Option.getOrElse(input.input, () => "");
-      const prevRows = renderLayout(state, false).rows;
 
+      /** Advance to next frame, clearing any active error on edits. */
       const next = (patch: Partial<TextState>) =>
         Effect.succeed(
-          Action.NextFrame({ state: { ...state, prevRows, ...patch } }),
+          Action.NextFrame({
+            state: { ...state, error: Option.none(), ...patch },
+          }),
         );
 
       return yield* Match.value(input).pipe(
@@ -188,7 +203,13 @@ export const TextInput = (
           if (options.validate) {
             return options.validate(finalValue).pipe(
               Effect.map((v) => Action.Submit({ value: v })),
-              Effect.catch(() => next({})),
+              Effect.catch((err) =>
+                next({
+                  error: Option.some(
+                    typeof err === "string" ? err : String(err),
+                  ),
+                }),
+              ),
             );
           }
           return Effect.succeed(Action.Submit({ value: finalValue }));

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -8,8 +8,9 @@ import {
   PlanService,
   ScaffoldFormatter,
 } from "@repo/scaffold";
-import { Config, Effect, Layer } from "effect";
+import { Cause, Config, Console, Effect, Layer } from "effect";
 import { Command } from "effect/unstable/cli";
+import { Ansi, Box } from "effect-boxes";
 import { add } from "./commands/add";
 import { graph } from "./commands/graph";
 import { init } from "./commands/init";
@@ -44,6 +45,26 @@ const program = root.pipe(
   Command.withSubcommands([init, add, graph]),
   Command.run({ version: "1.0.0" }),
   Effect.provide(MainLayer),
+  Effect.catchCause((cause) => {
+    if (Cause.hasInterruptsOnly(cause)) {
+      const message = Box.vsep(
+        [
+          Box.text("Interrupted.").pipe(
+            Box.annotate(Ansi.combine(Ansi.bold, Ansi.yellow)),
+          ),
+          Box.text("Goodbye! Come back when you're ready to stack."),
+        ],
+        1,
+        Box.center1,
+      ).pipe(
+        Box.pad(0, 1),
+        Box.border("rounded", { annotation: Ansi.yellow }),
+        Box.moveDown(1),
+      );
+      return Console.log(`\n${Box.renderPrettySync(message)}`);
+    }
+    return Effect.failCause(cause);
+  }),
 );
 
 NodeRuntime.runMain(program);

--- a/apps/cli/src/lib/KeyBinding.ts
+++ b/apps/cli/src/lib/KeyBinding.ts
@@ -1,0 +1,114 @@
+/**
+ * KeyBinding — single-source-of-truth for key definitions.
+ *
+ * Each KeyBinding carries the terminal key names used for matching in process
+ * handlers **and** the display label + action text rendered in hint bars.
+ * This ensures hints and handlers can never drift out of sync.
+ *
+ * @module
+ */
+
+import type { Terminal } from "effect";
+import { Effect, Match, Schema } from "effect";
+
+// ─── Schema Class ────────────────────────────────────────────────────────────
+
+export class KeyBinding extends Schema.Class<KeyBinding>("KeyBinding")({
+  /** Terminal key names that trigger this binding (e.g. ["enter", "return"]). */
+  keys: Schema.Array(Schema.String),
+  /** Display label for the key shown in hints (e.g. "enter", "↑/↓", "ctrl+d"). */
+  label: Schema.String,
+  /** Short action description shown in hints (e.g. "submit", "navigate"). */
+  action: Schema.String,
+  /** Whether the binding is active. Disabled bindings are hidden in hints and ignored by `matches`. */
+  enabled: Schema.Boolean.pipe(
+    Schema.optional,
+    Schema.withConstructorDefault(Effect.succeed(true)),
+  ),
+  /** Required modifier keys. Omitted or false means the modifier must NOT be held. */
+  ctrl: Schema.Boolean.pipe(
+    Schema.optional,
+    Schema.withConstructorDefault(Effect.succeed(false)),
+  ),
+  meta: Schema.Boolean.pipe(
+    Schema.optional,
+    Schema.withConstructorDefault(Effect.succeed(false)),
+  ),
+  shift: Schema.Boolean.pipe(
+    Schema.optional,
+    Schema.withConstructorDefault(Effect.succeed(false)),
+  ),
+}) {
+  /**
+   * Returns true when the user input satisfies this binding's key names and
+   * modifier requirements. The `enabled` flag only affects hint visibility,
+   * not matching.
+   */
+  matches(input: Terminal.UserInput): boolean {
+    return (
+      this["keys"].includes(input.key.name) &&
+      (this["ctrl"] ?? false) === input.key.ctrl &&
+      (this["meta"] ?? false) === input.key.meta &&
+      (this["shift"] ?? false) === input.key.shift
+    );
+  }
+}
+
+// ─── KeyMap helpers ──────────────────────────────────────────────────────────
+
+/** A record of named KeyBindings for a component. */
+export type KeyMap = Record<string, KeyBinding>;
+
+/**
+ * Return the first binding from a keymap that matches the given input.
+ * Useful for process handlers that need to identify which binding fired.
+ */
+export const findBinding = (
+  keymap: KeyMap,
+  input: Terminal.UserInput,
+): KeyBinding | undefined =>
+  Object.values(keymap).find((binding) => binding.matches(input));
+
+/**
+ * Derive a new keymap with selected bindings enabled or disabled.
+ *
+ * ```ts
+ * const keys = withEnabled(SelectKeys, { Prev: false, Submit: true });
+ * ```
+ */
+export const withEnabled = <K extends KeyMap>(
+  keymap: K,
+  overrides: Partial<Record<keyof K, boolean>>,
+): K => {
+  const result = { ...keymap };
+  for (const [name, enabled] of Object.entries(overrides)) {
+    const binding = result[name as keyof K];
+    if (binding) {
+      result[name as keyof K] = new KeyBinding({
+        ...binding,
+        enabled: enabled as boolean,
+      }) as K[keyof K];
+    }
+  }
+  return result;
+};
+
+// ─── Match combinator ────────────────────────────────────────────────────────
+
+/**
+ * Match combinator that tests a `Terminal.UserInput` against a `KeyBinding`.
+ *
+ * Use inside `Match.value(input).pipe(...)` where `input` is `Terminal.UserInput`:
+ *
+ * ```ts
+ * Match.value(input).pipe(
+ *   whenBinding(SelectKeys.Down, () => Action.NextFrame({ state: next })),
+ *   whenBinding(SelectKeys.Submit, () => Action.Submit({ value })),
+ *   Match.orElse(() => Action.NextFrame({ state })),
+ * );
+ * ```
+ */
+export const whenBinding = <Ret>(
+  binding: KeyBinding,
+  f: (input: Terminal.UserInput) => Ret,
+) => Match.when((input: Terminal.UserInput) => binding.matches(input), f);


### PR DESCRIPTION
## Goals/Scope

As i start to formalize the components before moving to their own package, it want to start exploring some of the patterns around the key bindings and how they can be checked against the process and hint.  At the same time I want to make sure all the components follow the same patterns and implementations.

## Description

- Implement key binding + navigation handling across CLI components
- Introduce single-source key handling logic for consistent input behavior
- Add validation-driven error state for text input
- Improve interrupt handling with styled CLI output