### PR TITLE
fix: address e2e tests failing

### DIFF
--- a/.changeset/proud-otters-notice.md
+++ b/.changeset/proud-otters-notice.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+append args to call or array literal

--- a/.changeset/young-buttons-juggle.md
+++ b/.changeset/young-buttons-juggle.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+preserve existing file contents on modify

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -1,0 +1,35 @@
+name: E2E - cli
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/cli/**"
+      - "packages/domain/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "apps/cli/**"
+      - "packages/domain/**"
+
+jobs:
+  e2e:
+    name: "E2E Test (init + add)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Dependencies
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: bun build src/index.ts --outdir=dist --target=bun --minify --banner '#!/usr/bin/env bun'
+        working-directory: apps/cli
+
+      - name: Run E2E Tests
+        run: bunx vitest run --config vitest.e2e.config.ts e2e/init.test.ts e2e/add.test.ts
+        working-directory: apps/cli

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,0 +1,37 @@
+name: E2E - matrix
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/scaffold/**"
+      - "packages/catalog/**"
+      - "packages/domain/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/scaffold/**"
+      - "packages/catalog/**"
+      - "packages/domain/**"
+
+jobs:
+  e2e:
+    name: "E2E Test (matrix)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Dependencies
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: bun build src/index.ts --outdir=dist --target=bun --minify --banner '#!/usr/bin/env bun'
+        working-directory: apps/cli
+
+      - name: Run Matrix E2E Tests
+        run: bunx vitest run --config vitest.e2e.config.ts e2e/matrix.test.ts
+        working-directory: apps/cli

--- a/packages/catalog/src/registry/content/api.ts
+++ b/packages/catalog/src/registry/content/api.ts
@@ -28,7 +28,7 @@ export const HealthGroupLive = HttpApiBuilder.group(Api, "health", (handlers) =>
   handlers.handle("get", () => Effect.succeed("Hello Effect!")),
 );
 `;
-export const serverHelloContents = `import { Api, ApiResponse } from "@repo/domain/Api";
+export const serverHelloContents = `import { Api, type ApiResponse } from "@repo/domain/Api";
 import { Effect } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -43,7 +43,8 @@ export const cliTsconfigContents = `{
  *
  * Additional subcommands are added by modules.
  */
-export const cliIndexContents = `import { BunRuntime } from "@effect/platform-bun";
+export const cliIndexContents = `import { BunRuntime, BunServices } from "@effect/platform-bun";
+import { Effect } from "effect";
 import { Command } from "effect/unstable/cli";
 
 // ============================================================================
@@ -59,12 +60,12 @@ const root = Command.make("{{packageName}}");
 // Subcommands - modules inject additional subcommands via Command.withSubcommands
 const AllCommands = Command.withSubcommands([]);
 
-const program = root.pipe(
+root.pipe(
   AllCommands,
   Command.run({ version: "0.0.0" }),
+  Effect.provide(BunServices.layer),
+  BunRuntime.runMain,
 );
-
-BunRuntime.runMain(program);
 `;
 
 /**
@@ -72,10 +73,10 @@ BunRuntime.runMain(program);
  *
  * A simple subcommand that prints a greeting message.
  */
-export const cliHelloCommandContents = `import { Console, Effect } from "effect";
+export const cliHelloCommandContents = `import { Console, Effect, Option } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 
-const name = Argument.text({ name: "name" }).pipe(
+const name = Argument.string("name").pipe(
   Argument.optional,
 );
 
@@ -86,8 +87,8 @@ const shout = Flag.boolean("shout").pipe(
 
 export const hello = Command.make("hello", { name, shout }, ({ name, shout }) =>
   Effect.gen(function* () {
-    const greeting = \`Hello, \${name ?? "World"}!\`;
-    yield* Console.log(shout ? greeting.toUpperCase() : greeting);
+    const greeting = \`Hello, \${Option.getOrElse(name, () => "World")}!\`;
+    yield* Console.log(Option.getOrElse(shout, () => false) ? greeting.toUpperCase() : greeting);
   }),
 ).pipe(Command.withDescription("Print a greeting message"));
 `;

--- a/packages/catalog/src/registry/content/client-chat.ts
+++ b/packages/catalog/src/registry/content/client-chat.ts
@@ -31,7 +31,7 @@ export class ChatRpcClient extends Context.Service<ChatRpcClient>()("ChatRpcClie
 
 // Client chat atom (uses ChatRpcClient instead of RpcClient)
 export const clientChatAtomContents = `import type { ChatMessage, ChatResponse, ToolCall } from "@repo/domain/Chat";
-import { Effect, Layer, Stream } from "effect";
+import { Effect, Stream } from "effect";
 import { Atom, type Atom as AtomType } from "effect/unstable/reactivity";
 import { ChatRpcClient } from "../chat-rpc-client";
 
@@ -298,7 +298,7 @@ export const chatAtom: AtomType.AtomResultFn<
 export const clientChatBoxContents = `import { useAtom } from "@effect/atom-react";
 import type { ChatResponse, MessageSegment } from "@repo/domain/Chat";
 import { AsyncResult } from "effect/unstable/reactivity";
-import { type FC, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { chatAtom } from "@/lib/atoms/chat-atom";
 import { cn } from "@/lib/utils";
 

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -93,7 +93,7 @@ const HttpLive = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const allowedOrigins = config.allowedOrigins.split(",").map((o) => o.trim());
 
-  yield* Effect.logInfo("CORS allowed origins: " + allowedOrigins.join(", "));
+  yield* Effect.logInfo(\`CORS allowed origins: \${allowedOrigins.join(", ")}\`);
   yield* Effect.logInfo("Starting server with:");
   yield* Effect.logInfo("  - HTTP API at /");
 

--- a/packages/scaffold/src/service/apply/ApplyService.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.ts
@@ -194,15 +194,25 @@ export class ApplyService extends Context.Service<ApplyService>()(
               },
             });
           case "write-composed": {
-            // Get base contents: use seedContents if provided, otherwise load from file
+            // Get base contents:
+            // For "modify" mode, always prefer the existing file so we don't
+            // overwrite fields added by prior apply runs. Fall back to
+            // seedContents (used for "create") or a sensible default.
             let baseContents: string;
-            if (action.seedContents !== undefined) {
+            const existingContents =
+              action.writeMode === "modify"
+                ? yield* loadFileContents(path.join(repoRoot, action.path))
+                : Option.none<string>();
+
+            if (Option.isSome(existingContents)) {
+              baseContents = existingContents.value;
+            } else if (action.seedContents !== undefined) {
               baseContents = action.seedContents;
             } else {
-              const existingContents = yield* loadFileContents(
+              const fallbackContents = yield* loadFileContents(
                 path.join(repoRoot, action.path),
               );
-              if (Option.isNone(existingContents)) {
+              if (Option.isNone(fallbackContents)) {
                 // No existing file and no seed - start with empty for JSON, fail for TS
                 if (action.path.endsWith(".json")) {
                   baseContents = "{}";
@@ -210,7 +220,7 @@ export class ApplyService extends Context.Service<ApplyService>()(
                   baseContents = "";
                 }
               } else {
-                baseContents = existingContents.value;
+                baseContents = fallbackContents.value;
               }
             }
 

--- a/packages/scaffold/src/service/apply/TypeScriptComposer.ts
+++ b/packages/scaffold/src/service/apply/TypeScriptComposer.ts
@@ -148,6 +148,38 @@ const applyTsAddReexport = (
   }
 };
 
+/**
+ * Append an argument to a call expression. If the call's sole argument is an
+ * array literal, the new value is added as an element of that array instead
+ * of as a second function argument. This handles patterns like
+ * `Command.withSubcommands([])` where new entries belong inside the array.
+ */
+const appendToCallOrArray = (call: CallExpression, argument: string): void => {
+  const args = call.getArguments();
+
+  // If the only argument is an array literal, add inside it
+  if (
+    args.length === 1 &&
+    args[0] !== undefined &&
+    args[0].isKind(SyntaxKind.ArrayLiteralExpression)
+  ) {
+    const array = args[0].asKindOrThrow(SyntaxKind.ArrayLiteralExpression);
+    const alreadyExists = array
+      .getElements()
+      .some((el) => el.getText() === argument);
+    if (!alreadyExists) {
+      array.addElement(argument);
+    }
+    return;
+  }
+
+  // Otherwise add as a regular function argument
+  const alreadyExists = args.some((arg) => arg.getText() === argument);
+  if (!alreadyExists) {
+    call.addArgument(argument);
+  }
+};
+
 const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
   sourceFile: SourceFile,
   op: typeof TsAppendCallArgOp.Type,
@@ -199,12 +231,7 @@ const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
   // First check if initializer itself is the call expression
   if (initializer.isKind(SyntaxKind.CallExpression)) {
     if (isMatchingCall(initializer)) {
-      // Check if argument already exists
-      const args = initializer.getArguments();
-      const alreadyExists = args.some((arg) => arg.getText() === op.argument);
-      if (!alreadyExists) {
-        initializer.addArgument(op.argument);
-      }
+      appendToCallOrArray(initializer, op.argument);
       return;
     }
   }
@@ -216,12 +243,7 @@ const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
 
   for (const call of callExpressions) {
     if (isMatchingCall(call)) {
-      // Check if argument already exists
-      const args = call.getArguments();
-      const alreadyExists = args.some((arg) => arg.getText() === op.argument);
-      if (!alreadyExists) {
-        call.addArgument(op.argument);
-      }
+      appendToCallOrArray(call, op.argument);
       return;
     }
   }


### PR DESCRIPTION
## Goals/Scope

Ensure end-to-end tests pass reliably by fixing CLI/hello program wiring and import alignment and validate scaffolding behavior to avoid regressions affecting e2e flows.

## Description

- Align imports and fix CLI/hello program wiring.
- Fix scaffold argument handling (append args when calling or building array literals).
- Preserve existing file contents during scaffold “modify” operations.
- Add end-to-end GitHub workflow to run/guard against e2e failures.