### PR TITLE
feat: add oxlint and dprint modules

### DIFF
--- a/.changeset/thirty-states-read.md
+++ b/.changeset/thirty-states-read.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add oxlint (linter) and dprint (formatter) modules

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,6 +1,12 @@
-import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
+import { CatalogService } from "@repo/catalog";
+import {
+  ModuleCategory,
+  ModuleId,
+  TargetIdentity,
+  TargetKind,
+} from "@repo/domain/Catalog";
 import type { Selection } from "@repo/domain/Selection";
-import { Console, Effect, Option, Schema } from "effect";
+import { Array as Arr, Console, Effect, Option, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
@@ -17,12 +23,16 @@ import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
 const buildInitSelection = (
   config: typeof StackConfig.Type,
 ): typeof Selection.Type => {
-  const modules: Array<{ id: typeof ModuleId.Type }> = [];
-
-  if (config.monorepo === "turbo") modules.push({ id: ModuleId.make("turbo") });
-  if (config.lint === "biome" || config.format === "biome")
-    modules.push({ id: ModuleId.make("biome") });
-  if (config.test === "vitest") modules.push({ id: ModuleId.make("vitest") });
+  // Collect unique module IDs from all category fields
+  const moduleIds = new Set<string>();
+  for (const field of [
+    config.monorepo,
+    config.lint,
+    config.format,
+    config.test,
+  ]) {
+    if (field !== undefined) moduleIds.add(field);
+  }
 
   return {
     targets: [
@@ -31,7 +41,9 @@ const buildInitSelection = (
           kind: TargetKind.make("init"),
           name: config.name,
         }),
-        modules,
+        modules: Arr.fromIterable(moduleIds).map((id) => ({
+          id: ModuleId.make(id),
+        })),
       },
     ],
   };
@@ -54,7 +66,7 @@ const optionalSelect = <A extends string>(
   Effect.gen(function* () {
     const v = yield* Select({
       message,
-      choices: [...choices, { title: "none", value: "none" as A }],
+      choices: [...choices, { title: "< skip >", value: "none" as A }],
     });
     return v === "none" ? Option.none<A>() : Option.some(v);
   });
@@ -71,7 +83,38 @@ export const init = Command.make(
   (flags) =>
     Effect.gen(function* () {
       const configure = yield* ConfigureService;
+      const catalog = yield* CatalogService;
       const repoRoot = Option.getOrElse(flags.root, () => process.cwd());
+
+      // Build choices from catalog for each init category
+      const monorepoChoices = catalog
+        .getModules({ category: ModuleCategory.make("monorepo") })
+        .map((m) => ({
+          title: m.title,
+          description: m.description,
+          value: m.id,
+        }));
+      const lintChoices = catalog
+        .getModules({ category: ModuleCategory.make("lint") })
+        .map((m) => ({
+          title: m.title,
+          description: m.description,
+          value: m.id,
+        }));
+      const formatChoices = catalog
+        .getModules({ category: ModuleCategory.make("format") })
+        .map((m) => ({
+          title: m.title,
+          description: m.description,
+          value: m.id,
+        }));
+      const testChoices = catalog
+        .getModules({ category: ModuleCategory.make("test") })
+        .map((m) => ({
+          title: m.title,
+          description: m.description,
+          value: m.id,
+        }));
 
       // Check if already initialized
       const existing = yield* configure
@@ -146,31 +189,32 @@ export const init = Command.make(
 
       // Monorepo
       const monorepo = flags.yes
-        ? Option.some("turbo" as const)
-        : yield* optionalSelect("What monorepo tool will you use?", [
-            { title: "turbo", value: "turbo" as const },
-          ]);
+        ? Option.some(monorepoChoices[0]?.value ?? "turbo")
+        : yield* optionalSelect(
+            "What monorepo tool will you use?",
+            monorepoChoices,
+          );
 
       // Lint
       const lint = flags.yes
-        ? Option.some("biome" as const)
-        : yield* optionalSelect("What will you use for linting?", [
-            { title: "biome", value: "biome" as const },
-          ]);
+        ? Option.some(lintChoices[0]?.value ?? "biome")
+        : yield* optionalSelect("What will you use for linting?", lintChoices);
 
       // Format
       const format_ = flags.yes
-        ? Option.some("biome" as const)
-        : yield* optionalSelect("What will you use for formatting?", [
-            { title: "biome", value: "biome" as const },
-          ]);
+        ? Option.some(formatChoices[0]?.value ?? "biome")
+        : yield* optionalSelect(
+            "What will you use for formatting?",
+            formatChoices,
+          );
 
       // Test
       const test = flags.yes
-        ? Option.some("vitest" as const)
-        : yield* optionalSelect("What test framework will you use?", [
-            { title: "vitest", value: "vitest" as const },
-          ]);
+        ? Option.some(testChoices[0]?.value ?? "vitest")
+        : yield* optionalSelect(
+            "What test framework will you use?",
+            testChoices,
+          );
 
       const config = new StackConfig({
         name: projectName as typeof Schema.NonEmptyString.Type,
@@ -219,10 +263,10 @@ export const init = Command.make(
                   Box.text(config.name),
                   Box.text(config.runtimeName),
                   Box.text(config.packageManagerName),
-                  Box.text(Option.getOrElse(monorepo, () => "none")),
-                  Box.text(Option.getOrElse(lint, () => "none")),
-                  Box.text(Option.getOrElse(format_, () => "none")),
-                  Box.text(Option.getOrElse(test, () => "none")),
+                  Box.text(config.monorepo ?? "none"),
+                  Box.text(config.lint ?? "none"),
+                  Box.text(config.format ?? "none"),
+                  Box.text(config.test ?? "none"),
                   Box.text(configure.configPath(repoRoot)),
                 ],
                 Box.left,

--- a/apps/cli/src/components/MultiSelect.ts
+++ b/apps/cli/src/components/MultiSelect.ts
@@ -80,7 +80,7 @@ export const MultiSelect = <A>(
       const checkbox = Box.char(isChecked ? "◼" : "◻").pipe(
         Box.annotate(isChecked ? Ansi.green : Ansi.dim),
       );
-      const indicator = Box.char(isCursor ? ">" : " ").pipe(
+      const indicator = Box.char(isCursor ? "⏵" : " ").pipe(
         Box.annotate(Ansi.cyan),
       );
       const title = Box.text(c.title).pipe(

--- a/apps/cli/src/components/Select.ts
+++ b/apps/cli/src/components/Select.ts
@@ -30,12 +30,18 @@ export const Select = <A>(
 
     const items = choices.map((c, i) => {
       const isSelected = i === cursor;
-      const indicator = isSelected ? "> " : "  ";
-      return Box.text(`${indicator}${c.title}`).pipe(
-        Box.annotate(
-          isSelected ? Ansi.combine(Ansi.cyan, Ansi.bold) : Ansi.dim,
-        ),
+      const indicator = Box.char(isSelected ? "⏵" : " ").pipe(
+        Box.annotate(Ansi.cyan),
       );
+      const title = Box.text(c.title).pipe(
+        Box.annotate(isSelected ? Ansi.bold : Ansi.dim),
+      );
+      const description =
+        isSelected && c.description
+          ? Box.text(c.description).pipe(Box.annotate(Ansi.dim))
+          : Box.nullBox;
+
+      return Box.hsep([indicator, title, description], 1, Box.left);
     });
 
     if (submitted) {

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogGraph,
+  ModuleCategory,
   ModuleId,
   ModuleImplication,
   TargetIdentity,
@@ -177,8 +178,31 @@ export class CatalogService extends Context.Service<CatalogService>()(
         }
       });
 
+      const getModules = (options?: {
+        category?: typeof ModuleCategory.Type;
+        visibility?: typeof Visibility.Type;
+      }): ReadonlyArray<
+        typeof import("@repo/domain/Catalog").ModuleDefinition.Type
+      > =>
+        Arr.filter(Arr.fromIterable(moduleIndex.values()), (mod) => {
+          if (
+            options?.category &&
+            !Arr.contains(mod.categories ?? [], options.category)
+          ) {
+            return false;
+          }
+          if (
+            options?.visibility &&
+            (mod.visibility ?? "public") !== options.visibility
+          ) {
+            return false;
+          }
+          return true;
+        });
+
       return {
         getImplications,
+        getModules,
         getModule,
         getSupportedModules,
         getTarget,

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -191,6 +191,37 @@ export const biomeJsoncContents = `{
 }
 `;
 
+// -- dprint -----------------------------------------------------------------
+
+export const dprintJsonContents = `{
+  "$schema": "https://dprint.dev/schemas/v0.json",
+  "includes": ["**/*.{ts,tsx,js,jsx,json,md}"],
+  "indentWidth": 2,
+  "lineWidth": 120,
+  "newLineKind": "lf",
+  "typescript": {
+    "semiColons": "asi",
+    "quoteStyle": "alwaysDouble",
+    "trailingCommas": "never",
+    "operatorPosition": "maintain",
+    "arrowFunction.useParentheses": "force"
+  },
+  "excludes": [
+    "**/dist",
+    "**/build",
+    "**/node_modules",
+    "**/coverage",
+    "**/.turbo",
+    "**/.cache"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.93.4.wasm",
+    "https://plugins.dprint.dev/markdown-0.20.0.wasm",
+    "https://plugins.dprint.dev/json-0.21.1.wasm"
+  ]
+}
+`;
+
 // -- vitest -----------------------------------------------------------------
 
 export const vitestConfigContents = `import { defineConfig } from "vitest/config";

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -6,6 +6,7 @@ import {
 } from "@repo/domain/Catalog";
 import {
   biomeJsoncContents,
+  dprintJsonContents,
   turboJsonContents,
   vitestConfigContents,
 } from "../content/init";
@@ -19,6 +20,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "Turborepo",
     description: "Monorepo build orchestration with caching",
     visibility: "internal",
+    initCategory: ["monorepo"],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {
@@ -78,6 +80,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "Biome",
     description: "Fast linter and formatter",
     visibility: "internal",
+    initCategory: ["lint", "format"],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {
@@ -125,10 +128,96 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
   },
   {
+    id: ModuleId.make("dprint"),
+    title: "dprint",
+    description: "Fast pluggable formatter used by the Effect team",
+    visibility: "internal",
+    initCategory: ["format"],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("init"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/dprint.json",
+        contents: dprintJsonContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "dprint",
+        value: "^0.54.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "format",
+        value: "dprint fmt",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "format:check",
+        value: "dprint check",
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("oxlint"),
+    title: "oxlint",
+    description: "Fast Rust-based linter used by the Effect team",
+    visibility: "internal",
+    initCategory: ["lint"],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("init"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "oxlint",
+        value: "^1.42.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "lint",
+        value: "oxlint",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "lint:fix",
+        value: "oxlint --fix",
+      },
+    ],
+  },
+  {
     id: ModuleId.make("vitest"),
     title: "Vitest",
     description: "Unit and integration testing framework",
     visibility: "internal",
+    initCategory: ["test"],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -1,4 +1,5 @@
 import {
+  ModuleCategory,
   type ModuleDefinition,
   ModuleId,
   TargetIdentity,
@@ -20,7 +21,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "Turborepo",
     description: "Monorepo build orchestration with caching",
     visibility: "internal",
-    initCategory: ["monorepo"],
+    categories: [ModuleCategory.make("monorepo")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {
@@ -80,7 +81,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "Biome",
     description: "Fast linter and formatter",
     visibility: "internal",
-    initCategory: ["lint", "format"],
+    categories: [ModuleCategory.make("lint"), ModuleCategory.make("format")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {
@@ -132,7 +133,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "dprint",
     description: "Fast pluggable formatter used by the Effect team",
     visibility: "internal",
-    initCategory: ["format"],
+    categories: [ModuleCategory.make("format")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {
@@ -177,7 +178,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "oxlint",
     description: "Fast Rust-based linter used by the Effect team",
     visibility: "internal",
-    initCategory: ["lint"],
+    categories: [ModuleCategory.make("lint")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {
@@ -217,7 +218,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "Vitest",
     description: "Unit and integration testing framework",
     visibility: "internal",
-    initCategory: ["test"],
+    categories: [ModuleCategory.make("test")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
     dependencies: [
       {

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -198,6 +198,14 @@ export const ModuleDependency = Schema.TaggedUnion({
 
 export const Visibility = Schema.Literals(["public", "internal"]);
 
+/**
+ * Freeform tag for grouping modules into selectable categories.
+ * Modules sharing a category are presented as alternatives in prompts.
+ */
+export const ModuleCategory = Schema.String.pipe(
+  Schema.brand("ModuleCategory"),
+);
+
 export const ModuleDefinition = Schema.Struct({
   id: ModuleId,
   title: Schema.String,
@@ -205,6 +213,10 @@ export const ModuleDefinition = Schema.Struct({
   visibility: Visibility.pipe(
     Schema.optionalKey,
     Schema.withConstructorDefault(Effect.succeed("public" as const)),
+  ),
+  categories: Schema.Array(ModuleCategory).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
   ),
   supportedOn: Schema.Array(SupportedOn),
   dependencies: Schema.Array(ModuleDependency),

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -27,10 +27,10 @@ const Runtime = Schema.TaggedUnion({
 export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   name: Schema.NonEmptyString,
   runtime: Runtime,
-  lint: Schema.optional(Schema.Literals(["biome"])),
-  format: Schema.optional(Schema.Literals(["biome"])),
-  test: Schema.optional(Schema.Literals(["vitest"])),
-  monorepo: Schema.optional(Schema.Literals(["turbo"])),
+  lint: Schema.optional(Schema.String),
+  format: Schema.optional(Schema.String),
+  test: Schema.optional(Schema.String),
+  monorepo: Schema.optional(Schema.String),
 }) {
   get runtimeName(): "bun" | "node" {
     return this.runtime._tag;


### PR DESCRIPTION
## Goals/Scope

Add new `dprint` and `oxlint` initialization modules from the effect-smol repo

## Description

- Create/initialize `dprint` + `oxlint` modules for formatting/linting setup.
- Refactor catalog to support module categorization and filtering.
- Update UI styling for select controls (indicators/layout) for better clarity.