### PR TITLE
feat: add git init module

### DIFF
--- a/.changeset/lovely-worlds-join.md
+++ b/.changeset/lovely-worlds-join.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add git init module and flags, closes #106

--- a/.changeset/small-bottles-give.md
+++ b/.changeset/small-bottles-give.md
@@ -1,0 +1,18 @@
+---
+"stack-effect": minor
+---
+
+init now creates a subdirectory from the project name
+
+The 'init' command uses the positional name to create and write into a subdirectory, and '.' initializes in the current directory using the folder name as the project name:
+
+```bash
+    # Create a new project in ./my-app
+  stack-effect init my-app --yes
+
+  # Initialize in the current directory, deriving name from folder
+  cd my-app && stack-effect init . --yes
+
+  # Create in a specific parent directory
+  stack-effect init my-app --yes --root /tmp
+```

--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -17,7 +17,7 @@ describe("add", () => {
           const cli = yield* CLI;
           const root = `${cli.workdir}/add-test`;
 
-          yield* cli.run("init", "add-test", "--yes", "--root", root);
+          yield* cli.run("init", "add-test", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           yield* cli.run(
@@ -47,7 +47,7 @@ describe("add", () => {
           const cli = yield* CLI;
           const root = `${cli.workdir}/impl-test`;
 
-          yield* cli.run("init", "impl-test", "--yes", "--root", root);
+          yield* cli.run("init", "impl-test", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           // http-api-client implies http-api-server on server — rejected non-interactively
@@ -74,7 +74,7 @@ describe("add", () => {
           const cli = yield* CLI;
           const root = `${cli.workdir}/dry-add`;
 
-          yield* cli.run("init", "dry-add", "--yes", "--root", root);
+          yield* cli.run("init", "dry-add", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           yield* cli.run(
@@ -104,7 +104,7 @@ describe("add", () => {
           const cli = yield* CLI;
           const root = `${cli.workdir}/impl-exists`;
 
-          yield* cli.run("init", "impl-exists", "--yes", "--root", root);
+          yield* cli.run("init", "impl-exists", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           // First add domain-api (required by server)
@@ -157,7 +157,7 @@ describe("add", () => {
           const cli = yield* CLI;
           const root = `${cli.workdir}/dep-test`;
 
-          yield* cli.run("init", "dep-test", "--yes", "--root", root);
+          yield* cli.run("init", "dep-test", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           // Add chat-server which depends on domain-chat on package/domain
@@ -188,7 +188,7 @@ describe("add", () => {
           const cli = yield* CLI;
           const root = `${cli.workdir}/ai-test`;
 
-          yield* cli.run("init", "ai-test", "--yes", "--root", root);
+          yield* cli.run("init", "ai-test", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           yield* cli.run(

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -162,5 +162,51 @@ describe("init", () => {
         }),
       { timeout: 30_000 },
     );
+
+    it.effect(
+      "init --yes initializes a git repository by default",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "git-app",
+            "--yes",
+            "--root",
+            `${cli.workdir}/git-app`,
+          );
+
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileExists("git-app/.git/HEAD");
+          yield* cli.expectFileContaining(
+            "git-app/.git/HEAD",
+            "refs/heads/main",
+          );
+        }),
+      { timeout: 60_000 },
+    );
+
+    it.effect(
+      "init --yes --no-git skips git initialization",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "nogit-app",
+            "--yes",
+            "--no-git",
+            "--root",
+            `${cli.workdir}/nogit-app`,
+          );
+
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileExists("nogit-app/package.json");
+          yield* cli.expectFileNotExists("nogit-app/.git");
+        }),
+      { timeout: 30_000 },
+    );
   });
 });

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -16,13 +16,7 @@ describe("init", () => {
         Effect.gen(function* () {
           const cli = yield* CLI;
 
-          yield* cli.run(
-            "init",
-            "my-app",
-            "--yes",
-            "--root",
-            `${cli.workdir}/my-app`,
-          );
+          yield* cli.run("init", "my-app", "--yes", "--root", cli.workdir);
 
           yield* cli.expectExitCode(0);
           yield* cli.expectFileExists("my-app/package.json");
@@ -38,13 +32,7 @@ describe("init", () => {
         Effect.gen(function* () {
           const cli = yield* CLI;
 
-          yield* cli.run(
-            "init",
-            "mono-app",
-            "--yes",
-            "--root",
-            `${cli.workdir}/mono-app`,
-          );
+          yield* cli.run("init", "mono-app", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           yield* cli.expectFileExists("mono-app/turbo.json");
@@ -66,7 +54,7 @@ describe("init", () => {
             "--yes",
             "--dry-run",
             "--root",
-            `${cli.workdir}/ghost-app`,
+            cli.workdir,
           );
 
           yield* cli.expectExitCode(1);
@@ -81,13 +69,7 @@ describe("init", () => {
         Effect.gen(function* () {
           const cli = yield* CLI;
 
-          yield* cli.run(
-            "init",
-            "lint-app",
-            "--yes",
-            "--root",
-            `${cli.workdir}/lint-app`,
-          );
+          yield* cli.run("init", "lint-app", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           yield* cli.withinProject("lint-app", function* (project) {
@@ -103,13 +85,7 @@ describe("init", () => {
         Effect.gen(function* () {
           const cli = yield* CLI;
 
-          yield* cli.run(
-            "init",
-            "format-app",
-            "--yes",
-            "--root",
-            `${cli.workdir}/format-app`,
-          );
+          yield* cli.run("init", "format-app", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           yield* cli.withinProject("format-app", function* (project) {
@@ -130,7 +106,7 @@ describe("init", () => {
             "typecheck-app",
             "--yes",
             "--root",
-            `${cli.workdir}/typecheck-app`,
+            cli.workdir,
           );
           yield* cli.expectExitCode(0);
 
@@ -154,7 +130,7 @@ describe("init", () => {
             "--runtime",
             "node",
             "--root",
-            `${cli.workdir}/node-app`,
+            cli.workdir,
           );
 
           yield* cli.expectExitCode(0);
@@ -169,13 +145,7 @@ describe("init", () => {
         Effect.gen(function* () {
           const cli = yield* CLI;
 
-          yield* cli.run(
-            "init",
-            "git-app",
-            "--yes",
-            "--root",
-            `${cli.workdir}/git-app`,
-          );
+          yield* cli.run("init", "git-app", "--yes", "--root", cli.workdir);
 
           yield* cli.expectExitCode(0);
           yield* cli.expectFileExists("git-app/.git/HEAD");
@@ -199,7 +169,7 @@ describe("init", () => {
             "--yes",
             "--no-git",
             "--root",
-            `${cli.workdir}/nogit-app`,
+            cli.workdir,
           );
 
           yield* cli.expectExitCode(0);

--- a/apps/cli/e2e/matrix.test.ts
+++ b/apps/cli/e2e/matrix.test.ts
@@ -164,7 +164,7 @@ describe("matrix", () => {
             const root = `${cli.workdir}/${name}`;
 
             // Init project
-            yield* cli.run("init", name, "--yes", "--root", root);
+            yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
             // Add modules to target
@@ -201,7 +201,7 @@ describe("matrix", () => {
             const root = `${cli.workdir}/${name}`;
 
             // Init project
-            yield* cli.run("init", name, "--yes", "--root", root);
+            yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
             // Add server modules first (satisfies implications)
@@ -250,7 +250,7 @@ describe("matrix", () => {
           const root = `${cli.workdir}/${name}`;
 
           // Init
-          yield* cli.run("init", name, "--yes", "--root", root);
+          yield* cli.run("init", name, "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
           // Add all server modules

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -12,7 +12,7 @@ import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
 import { Select } from "../components/Select";
 import { TextInput } from "../components/TextInput";
-import { dryRunFlag, rootFlag, yesFlag } from "../flags";
+import { dryRunFlag, noGitFlag, rootFlag, yesFlag } from "../flags";
 import {
   CONFIG_FILENAME,
   ConfigureService,
@@ -32,6 +32,10 @@ const buildInitSelection = (
     config.test,
   ]) {
     if (field !== undefined) moduleIds.add(field);
+  }
+
+  if (config.git !== false) {
+    moduleIds.add("git-init");
   }
 
   return {
@@ -79,6 +83,7 @@ export const init = Command.make(
     yes: yesFlag,
     dryRun: dryRunFlag,
     packageManager: runtimeFlag,
+    noGit: noGitFlag,
   },
   (flags) =>
     Effect.gen(function* () {
@@ -216,6 +221,16 @@ export const init = Command.make(
             testChoices,
           );
 
+      // Git
+      const git = flags.noGit
+        ? false
+        : flags.yes
+          ? true
+          : yield* Confirm({
+              message: "Initialize a git repository?",
+              initial: true,
+            });
+
       const config = new StackConfig({
         name: projectName as typeof Schema.NonEmptyString.Type,
         runtime,
@@ -235,6 +250,7 @@ export const init = Command.make(
           onNone: () => ({}),
           onSome: (v) => ({ monorepo: v }),
         }),
+        git,
       });
 
       // Preview
@@ -254,6 +270,7 @@ export const init = Command.make(
                   Box.text("Lint:"),
                   Box.text("Format:"),
                   Box.text("Test:"),
+                  Box.text("Git:"),
                   Box.text("Config:"),
                 ],
                 Box.left,
@@ -267,6 +284,7 @@ export const init = Command.make(
                   Box.text(config.lint ?? "none"),
                   Box.text(config.format ?? "none"),
                   Box.text(config.test ?? "none"),
+                  Box.text(config.git === false ? "no" : "yes"),
                   Box.text(configure.configPath(repoRoot)),
                 ],
                 Box.left,

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -6,7 +6,7 @@ import {
   TargetKind,
 } from "@repo/domain/Catalog";
 import type { Selection } from "@repo/domain/Selection";
-import { Array as Arr, Console, Effect, Option, Schema } from "effect";
+import { Array as Arr, Console, Effect, Option, Path, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
@@ -61,6 +61,30 @@ const runtimeFlag = Flag.choice("runtime", ["bun", "node"]).pipe(
 );
 
 /**
+ * Resolve project name and output directory from the positional name argument
+ * and the `--root` flag, matching the convention used by create-t3-app and
+ * create-better-t-stack:
+ *
+ * - `stack-effect init my-app`       → dir=cwd/my-app, name="my-app"
+ * - `stack-effect init .`            → dir=cwd,        name=basename(cwd)
+ * - `stack-effect init my-app -r /d` → dir=/d/my-app,  name="my-app"
+ * - `stack-effect init . -r /d`      → dir=/d,         name=basename(/d)
+ */
+const resolveNameAndRoot = Effect.fn("resolveNameAndRoot")(function* (
+  nameInput: string,
+  rootFlag: Option.Option<string>,
+) {
+  const path = yield* Path.Path;
+  const base = Option.getOrElse(rootFlag, () => process.cwd());
+  if (nameInput === ".") {
+    const resolved = path.resolve(base);
+    return { projectName: path.basename(resolved), repoRoot: resolved };
+  }
+  const repoRoot = path.resolve(base, nameInput);
+  return { projectName: nameInput, repoRoot };
+});
+
+/**
  * Prompt for an optional tool choice, returning Option.none for "none".
  */
 const optionalSelect = <A extends string>(
@@ -89,7 +113,6 @@ export const init = Command.make(
     Effect.gen(function* () {
       const configure = yield* ConfigureService;
       const catalog = yield* CatalogService;
-      const repoRoot = Option.getOrElse(flags.root, () => process.cwd());
 
       // Build choices from catalog for each init category
       const monorepoChoices = catalog
@@ -121,6 +144,28 @@ export const init = Command.make(
           value: m.id,
         }));
 
+      // Project name and output directory
+      if (flags.yes && Option.isNone(flags.name)) {
+        return yield* Effect.fail(
+          "When using --yes with init, provide a project name as the positional argument.",
+        );
+      }
+
+      const nameInput = Option.isSome(flags.name)
+        ? flags.name.value
+        : yield* TextInput({
+            message: "What is your project name?",
+            validate: (v) =>
+              v.trim().length > 0
+                ? Effect.succeed(v.trim())
+                : Effect.fail("Name cannot be empty"),
+          });
+
+      const { projectName, repoRoot } = yield* resolveNameAndRoot(
+        nameInput,
+        flags.root,
+      );
+
       // Check if already initialized
       const existing = yield* configure
         .readConfig(repoRoot)
@@ -145,23 +190,6 @@ export const init = Command.make(
           return;
         }
       }
-
-      // Project name
-      if (flags.yes && Option.isNone(flags.name)) {
-        return yield* Effect.fail(
-          "When using --yes with init, provide a project name as the positional argument.",
-        );
-      }
-
-      const projectName = Option.isSome(flags.name)
-        ? flags.name.value
-        : yield* TextInput({
-            message: "What is your project name?",
-            validate: (v) =>
-              v.trim().length > 0
-                ? Effect.succeed(v.trim())
-                : Effect.fail("Name cannot be empty"),
-          });
 
       // Runtime
       const runtimeChoice = Option.isSome(flags.packageManager)
@@ -264,6 +292,7 @@ export const init = Command.make(
               Box.vcat(
                 [
                   Box.text("Name:"),
+                  Box.text("Directory:"),
                   Box.text("Runtime:"),
                   Box.text("Package manager:"),
                   Box.text("Monorepo:"),
@@ -278,6 +307,7 @@ export const init = Command.make(
               Box.vcat(
                 [
                   Box.text(config.name),
+                  Box.text(repoRoot),
                   Box.text(config.runtimeName),
                   Box.text(config.packageManagerName),
                   Box.text(config.monorepo ?? "none"),

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -16,3 +16,7 @@ export const yesFlag = Flag.boolean("yes").pipe(
     "Skip confirmation prompts (uses defaults where available)",
   ),
 );
+
+export const noGitFlag = Flag.boolean("no-git").pipe(
+  Flag.withDescription("Skip git repository initialization"),
+);

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -15,6 +15,42 @@ import {
 /**
  * Init modules - project-wide tooling (turbo, biome, vitest)
  */
+const gitInitModule: typeof ModuleDefinition.Type = {
+  id: ModuleId.make("git-init"),
+  title: "Git",
+  description: "Initialize a git repository with an initial commit",
+  visibility: "internal",
+  categories: [ModuleCategory.make("git")],
+  supportedOn: [{ _tag: "kind", kind: TargetKind.make("init") }],
+  dependencies: [
+    {
+      _tag: "required-target",
+      identity: new TargetIdentity({
+        kind: TargetKind.make("init"),
+        name: "root",
+      }),
+    },
+  ],
+  contributions: [],
+  scripts: [
+    {
+      label: "Initialize git repository",
+      command: "git init --initial-branch=main",
+      phase: "post-finalize",
+    },
+    {
+      label: "Stage all files",
+      command: "git add -A",
+      phase: "post-finalize",
+    },
+    {
+      label: "Create initial commit",
+      command: 'git commit -m "initial commit"',
+      phase: "post-finalize",
+    },
+  ],
+};
+
 export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("turbo"),
@@ -251,4 +287,5 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       },
     ],
   },
+  gitInitModule,
 ];

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -85,12 +85,18 @@ export const SupportedOn = Schema.TaggedUnion({
   },
 });
 
+export const ScriptPhase = Schema.Literals(["finalize", "post-finalize"]);
+
 export const ScriptDefinition = Schema.Struct({
   label: Schema.String,
   command: Schema.String,
   workdir: Schema.String.pipe(
     Schema.optionalKey,
     Schema.withConstructorDefault(Effect.succeed("{{targetPath}}")),
+  ),
+  phase: ScriptPhase.pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed("finalize" as const)),
   ),
 });
 

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -31,6 +31,7 @@ export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   format: Schema.optional(Schema.String),
   test: Schema.optional(Schema.String),
   monorepo: Schema.optional(Schema.String),
+  git: Schema.optional(Schema.Boolean),
 }) {
   get runtimeName(): "bun" | "node" {
     return this.runtime._tag;

--- a/packages/scaffold/src/service/finalize/FinalizeService.test.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.test.ts
@@ -462,5 +462,75 @@ describe("FinalizeService", () => {
           ),
         ),
     );
+
+    it.effect("runs post-finalize scripts after config-derived scripts", () =>
+      Effect.gen(function* () {
+        const svc = yield* FinalizeService;
+        const moduleId = ModuleId.make("git-init");
+        const blueprint = targetWithModule(serverIdentity, moduleId);
+
+        const report = yield* runToReport(svc, blueprint, makeConfig());
+
+        const labels = report.results.map((r) =>
+          Result.isSuccess(r) ? r.success.label : r.failure.label,
+        );
+        expect(labels).toEqual(["Install dependencies", "Git init"]);
+      }).pipe(
+        Effect.provide(
+          makeFinalizeLayer([], {
+            modules: {
+              "git-init": {
+                scripts: [
+                  {
+                    label: "Git init",
+                    command: "git init",
+                    phase: "post-finalize",
+                  },
+                ],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    it.effect(
+      "orders finalize scripts, then config-derived, then post-finalize",
+      () =>
+        Effect.gen(function* () {
+          const svc = yield* FinalizeService;
+          const moduleId = ModuleId.make("git-init");
+          const blueprint = targetWithModule(serverIdentity, moduleId);
+          const config = new StackConfig({
+            name: "test" as typeof import("effect").Schema.NonEmptyString.Type,
+            runtime: { _tag: "bun" },
+            lint: "biome",
+          });
+
+          const scripts = yield* svc.preview(blueprint, makeConfig(config));
+
+          expect(scripts.map((s) => s.label)).toEqual([
+            "Install dependencies",
+            "Run biome lint",
+            "Git init",
+          ]);
+        }).pipe(
+          Effect.provide(
+            makeFinalizeLayer([], {
+              modules: {
+                "git-init": {
+                  scripts: [
+                    {
+                      label: "Git init",
+                      command: "git init",
+                      phase: "post-finalize",
+                    },
+                  ],
+                },
+              },
+            }),
+          ),
+        ),
+    );
   });
 });

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -27,6 +27,7 @@ type ResolvedScript = {
   readonly label: string;
   readonly command: string;
   readonly workdir: string;
+  readonly phase: "finalize" | "post-finalize";
 };
 
 export class FinalizeService extends Context.Service<FinalizeService>()(
@@ -60,6 +61,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
               label: s.label,
               command: context.resolve(s.command),
               workdir: context.resolve(s.workdir ?? "{{targetPath}}"),
+              phase: (s.phase ?? "finalize") as "finalize" | "post-finalize",
             }));
           }),
         ).pipe(Effect.map(Arr.flatten));
@@ -83,6 +85,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
               label: s.label,
               command: context.resolve(s.command),
               workdir: context.resolve(s.workdir ?? "{{targetPath}}"),
+              phase: (s.phase ?? "finalize") as "finalize" | "post-finalize",
             }));
           }),
         ).pipe(Effect.map(Arr.flatten));
@@ -96,7 +99,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
       ) {
         const scripts = yield* collectResolvedScripts(blueprint, config);
         const configScripts = buildConfigDerivedScripts(config);
-        const allScripts = [...scripts, ...configScripts];
+        const allScripts = orderScripts(scripts, configScripts);
 
         return allScripts.map((script) => ({
           script,
@@ -110,10 +113,12 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
       ) {
         const scripts = yield* collectResolvedScripts(blueprint, config);
         const configScripts = buildConfigDerivedScripts(config);
-        return [...scripts, ...configScripts].map(({ label, command }) => ({
-          label,
-          command,
-        }));
+        return orderScripts(scripts, configScripts).map(
+          ({ label, command }) => ({
+            label,
+            command,
+          }),
+        );
       });
 
       return { run, preview };
@@ -124,6 +129,22 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
     FinalizeService.make,
   ).pipe(Layer.provide(CatalogService.layer));
 }
+
+/**
+ * Orders scripts so that finalize-phase module/target scripts run first,
+ * then config-derived scripts (install, lint, format), then post-finalize
+ * scripts (e.g. git init).
+ */
+const orderScripts = (
+  resolvedScripts: ResolvedScript[],
+  configScripts: ResolvedScript[],
+): ResolvedScript[] => {
+  const finalize = resolvedScripts.filter((s) => s.phase === "finalize");
+  const postFinalize = resolvedScripts.filter(
+    (s) => s.phase === "post-finalize",
+  );
+  return [...finalize, ...configScripts, ...postFinalize];
+};
 
 const buildConfigDerivedScripts = (
   config: FinalizeConfig,
@@ -145,6 +166,7 @@ const buildConfigDerivedScripts = (
             label: entry.label,
             command: entry.command,
             workdir: ".",
+            phase: "finalize" as const,
           })
         : Result.failVoid,
   );


### PR DESCRIPTION
## Goals/Scope

Add initial project setup steps, including script phases and deterministic ordering

## Description

- Scaffold scripts now include defined phases with explicit ordering
- Scaffolding supports optionally running `git init` to create a repository
- The init command uses the positional name to create and write into a subdirectory