### PR TITLE
feat: add progressive disclosure of scripts

### DIFF
--- a/.changeset/modern-canyons-hide.md
+++ b/.changeset/modern-canyons-hide.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add progressive disclosure of scripts to be run for opt out, closes #103

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -57,7 +57,7 @@ describe("init", () => {
             cli.workdir,
           );
 
-          yield* cli.expectExitCode(1);
+          yield* cli.expectExitCode(0);
           yield* cli.expectFileNotExists("ghost-app/package.json");
         }),
       { timeout: 15_000 },

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -15,7 +15,7 @@ import { HorizontalSelect } from "../components/HorizontalSelect";
 import { MultiSelect } from "../components/MultiSelect";
 import { Select } from "../components/Select";
 import { TextInput } from "../components/TextInput";
-import { dryRunFlag, rootFlag, yesFlag } from "../flags";
+import { dryRunFlag, rootFlag, trustFlag, yesFlag } from "../flags";
 import { ConfigureService } from "../service/ConfigureService";
 import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
 
@@ -557,6 +557,7 @@ export const add = Command.make(
     modules: modulesFlag,
     yes: yesFlag,
     dryRun: dryRunFlag,
+    trust: trustFlag,
   },
   (flags) =>
     Effect.gen(function* () {
@@ -600,6 +601,7 @@ export const add = Command.make(
         repoRoot,
         yes: flags.yes,
         dryRun: flags.dryRun,
+        trust: flags.trust || flags.yes,
         config,
       });
     }).pipe(

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -329,7 +329,7 @@ export const init = Command.make(
         Box.left,
       );
 
-      if (!flags.yes) {
+      if (!flags.yes && !flags.dryRun) {
         const proceed = yield* Confirm({
           message: "Create project?",
           children: configBox,
@@ -344,11 +344,6 @@ export const init = Command.make(
       if (!flags.dryRun) {
         yield* configure.writeConfig(repoRoot, config);
         yield* Console.log(`\nWritten ${CONFIG_FILENAME}`);
-      } else {
-        yield* Console.log("[dry-run] skipping config write:");
-        yield* Console.log(
-          Schema.encodeSync(Schema.fromJsonString(StackConfig))(config),
-        );
       }
 
       // Scaffold root monorepo files

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -12,7 +12,7 @@ import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
 import { Select } from "../components/Select";
 import { TextInput } from "../components/TextInput";
-import { dryRunFlag, noGitFlag, rootFlag, yesFlag } from "../flags";
+import { dryRunFlag, noGitFlag, rootFlag, trustFlag, yesFlag } from "../flags";
 import {
   CONFIG_FILENAME,
   ConfigureService,
@@ -108,6 +108,7 @@ export const init = Command.make(
     dryRun: dryRunFlag,
     packageManager: runtimeFlag,
     noGit: noGitFlag,
+    trust: trustFlag,
   },
   (flags) =>
     Effect.gen(function* () {
@@ -359,6 +360,7 @@ export const init = Command.make(
         repoRoot,
         yes: flags.yes,
         dryRun: flags.dryRun,
+        trust: flags.trust || flags.yes,
         config,
       });
 

--- a/apps/cli/src/components/DryRunPreview.ts
+++ b/apps/cli/src/components/DryRunPreview.ts
@@ -1,0 +1,185 @@
+import type { ApplyResult } from "@repo/domain/Apply";
+import { Ansi, Box } from "effect-boxes";
+
+const sectionTitle = (title: string) =>
+  Box.text(title).pipe(Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)));
+
+export const DryRunPreview = ({
+  blueprint,
+  plan,
+  apply,
+  scripts,
+}: {
+  blueprint: Box.Box<Ansi.AnsiStyle>;
+  plan: {
+    summary: string;
+    tree: Box.Box<Ansi.AnsiStyle>;
+    legend: Box.Box<Ansi.AnsiStyle>;
+  };
+  apply: typeof ApplyResult.Type;
+  scripts: ReadonlyArray<{
+    label: string;
+    command: string;
+    phase: string;
+    origin: string;
+  }>;
+}): Box.Box<Ansi.AnsiStyle> => {
+  const terminalWidth = process.stdout.columns ?? 80;
+
+  // Blueprint panel
+  const blueprintContent = Box.vsep(
+    [sectionTitle("Blueprint"), blueprint],
+    1,
+    Box.left,
+  );
+
+  // Apply panel
+  const changesStats = Box.hsep(
+    [
+      Box.text(`${apply.created.length}`).pipe(Box.annotate(Ansi.green)),
+      Box.text("create").pipe(Box.annotate(Ansi.dim)),
+      Box.text(`${apply.modified.length}`).pipe(Box.annotate(Ansi.yellow)),
+      Box.text("modify").pipe(Box.annotate(Ansi.dim)),
+      Box.text(`${apply.skipped.length}`).pipe(Box.annotate(Ansi.dim)),
+      Box.text("skip").pipe(Box.annotate(Ansi.dim)),
+    ],
+    1,
+    Box.left,
+  );
+
+  const applyContent = Box.vsep(
+    [sectionTitle("Apply"), plan.tree, changesStats],
+    1,
+    Box.left,
+  );
+
+  // Finalize panel
+  const phaseLabels: Record<string, string> = {
+    finalize: "Finalize",
+    config: "Install & Format",
+    "post-finalize": "Post-Finalize",
+  };
+
+  const groupedScripts = scripts.reduce<
+    Map<string, Array<(typeof scripts)[number]>>
+  >((groups, script) => {
+    const list = groups.get(script.phase) ?? [];
+    list.push(script);
+    groups.set(script.phase, list);
+    return groups;
+  }, new Map());
+
+  const scriptGroups =
+    groupedScripts.size > 0
+      ? Box.vcat(
+          [...groupedScripts.entries()].map(([phase, items]) =>
+            Box.vcat(
+              [
+                Box.text(phaseLabels[phase] ?? phase).pipe(
+                  Box.annotate(Ansi.dim),
+                ),
+                ...items.map((s) =>
+                  Box.hsep(
+                    [
+                      Box.text(">").pipe(Box.annotate(Ansi.dim)),
+                      Box.text(s.command),
+                    ],
+                    1,
+                    Box.left,
+                  ),
+                ),
+              ],
+              Box.left,
+            ),
+          ),
+          Box.left,
+        )
+      : Box.text("(none)").pipe(Box.annotate(Ansi.dim));
+
+  const finalizeContent = Box.vsep(
+    [sectionTitle("Finalize"), scriptGroups],
+    1,
+    Box.left,
+  );
+
+  // Footer
+  const footer = Box.text("No changes written.").pipe(Box.annotate(Ansi.dim));
+
+  // Determine layout based on natural content width vs terminal
+  const naturalHorizontalWidth =
+    Box.cols(blueprintContent) +
+    Box.cols(applyContent) +
+    Box.cols(finalizeContent) +
+    18; // padding + borders overhead
+
+  if (naturalHorizontalWidth <= terminalWidth) {
+    // Wide layout: horizontal panels
+    const maxHeight = Math.max(
+      Box.rows(blueprintContent),
+      Box.rows(applyContent),
+      Box.rows(finalizeContent),
+    );
+
+    const leftPanel = blueprintContent.pipe(
+      Box.minHeight(maxHeight),
+      Box.pad(0, 2),
+      Box.border("rounded", { annotation: Ansi.dim }),
+    );
+
+    const middlePanel = applyContent.pipe(
+      Box.minHeight(maxHeight),
+      Box.pad(0, 2),
+      Box.border("rounded", {
+        annotation: Ansi.dim,
+        sides: { left: false },
+      }),
+    );
+
+    const rightPanel = finalizeContent.pipe(
+      Box.minHeight(maxHeight),
+      Box.pad(0, 2),
+      Box.border("rounded", {
+        annotation: Ansi.dim,
+        sides: { left: false },
+      }),
+    );
+
+    const panels = Box.hcat([leftPanel, middlePanel, rightPanel], Box.top);
+
+    return Box.vsep([panels, footer], 1, Box.left).pipe(Box.moveDown(1));
+  }
+
+  // Narrow layout: stacked panels
+  const stackedWidth = terminalWidth - 4; // border + padding
+
+  const topPanel = blueprintContent.pipe(
+    Box.minWidth(stackedWidth),
+    Box.pad(0, 1),
+    Box.border("rounded", {
+      annotation: Ansi.dim,
+      sides: { bottom: false },
+    }),
+  );
+
+  const midPanel = applyContent.pipe(
+    Box.minWidth(stackedWidth),
+    Box.pad(0, 1),
+    Box.border("rounded", {
+      annotation: Ansi.dim,
+      sides: { top: false, bottom: false },
+    }),
+  );
+
+  const botPanel = finalizeContent.pipe(
+    Box.minWidth(stackedWidth),
+    Box.pad(0, 1),
+    Box.border("rounded", {
+      annotation: Ansi.dim,
+      sides: { top: false },
+    }),
+  );
+
+  const stacked = Box.vcat([topPanel, midPanel, botPanel], Box.left);
+
+  return Box.vsep([stacked, footer], 1, Box.left).pipe(Box.moveDown(1));
+};

--- a/apps/cli/src/components/MultiSelect.ts
+++ b/apps/cli/src/components/MultiSelect.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Match } from "effect";
+import { Array as Arr, Data, Effect, Match, pipe } from "effect";
 import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
@@ -47,10 +47,23 @@ const MultiSelectHintKeys = {
   Submit: MultiSelectKeys.Submit,
 };
 
+export interface GroupedSelectChoice<A> extends Prompt.SelectChoice<A> {
+  readonly group?: string;
+}
+
+export interface GroupedSelectOptions<A> extends Prompt.MultiSelectOptions {
+  readonly message: string;
+  readonly choices: ReadonlyArray<GroupedSelectChoice<A>>;
+  readonly groups?: ReadonlyArray<{
+    readonly key: string;
+    readonly label: string;
+  }>;
+}
+
 export const MultiSelect = <A>(
-  options: Prompt.SelectOptions<A> & Prompt.MultiSelectOptions,
+  options: GroupedSelectOptions<A>,
 ): Prompt.Prompt<Array<A>> => {
-  const { message, choices } = options;
+  const { message, choices, groups } = options;
   const min = options.min ?? 0;
   const max = options.max ?? choices.length;
 
@@ -74,25 +87,54 @@ export const MultiSelect = <A>(
       );
     }
 
-    const items = choices.map((c, i) => {
-      const isCursor = i === state.cursor;
-      const isChecked = state.selected.has(i);
-      const checkbox = Box.char(isChecked ? "◼" : "◻").pipe(
-        Box.annotate(isChecked ? Ansi.green : Ansi.dim),
-      );
-      const indicator = Box.char(isCursor ? "⏵" : " ").pipe(
-        Box.annotate(Ansi.cyan),
-      );
-      const title = Box.text(c.title).pipe(
-        Box.annotate(isChecked ? Ansi.green : Ansi.white),
-      );
-      const description =
-        isCursor && c.description
-          ? Box.text(c.description).pipe(Box.annotate(Ansi.dim))
-          : Box.nullBox;
+    // Build group label lookup
+    const groupLabelMap = new Map((groups ?? []).map((g) => [g.key, g.label]));
 
-      return Box.hsep([indicator, checkbox, title, description], 1, Box.left);
-    });
+    // Group choices by their group key, preserving order
+    const grouped = Arr.groupBy(
+      Arr.map(choices, (choice, index) => ({ choice, index })),
+      ({ choice }) => choice.group ?? "",
+    );
+
+    const items = pipe(
+      Object.entries(grouped),
+      Arr.flatMap(([groupKey, groupChoices]) => {
+        const header =
+          groupKey !== ""
+            ? Box.text(`── ${groupLabelMap.get(groupKey) ?? groupKey} ──`).pipe(
+                Box.annotate(Ansi.dim),
+              )
+            : Box.nullBox;
+
+        const rows = Arr.map(groupChoices, ({ choice: c, index: i }) => {
+          const isCursor = i === state.cursor;
+          const isChecked = state.selected.has(i);
+          const indicator = Box.char(isCursor ? "⏵" : " ").pipe(
+            Box.annotate(Ansi.cyan),
+          );
+          const checkbox = Box.char(isChecked ? "◼" : "◻").pipe(
+            Box.annotate(isChecked ? Ansi.green : Ansi.dim),
+          );
+          const title = Box.text(c.title).pipe(
+            Box.annotate(isChecked ? Ansi.green : Ansi.white),
+          );
+          const description =
+            isCursor && c.description
+              ? Box.text(c.description).pipe(Box.annotate(Ansi.dim))
+              : Box.nullBox;
+
+          return Box.hsep(
+            [indicator, checkbox, title, description],
+            1,
+            Box.left,
+          );
+        });
+
+        return [header, ...rows];
+      }),
+      // Remove leading empty line if first element is a spacer
+      Arr.dropWhile((item) => Box.renderPrettySync(item).trim() === ""),
+    );
 
     const count = Box.text(`(${state.selected.size}/${choices.length})`).pipe(
       Box.annotate(Ansi.dim),

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -20,3 +20,9 @@ export const yesFlag = Flag.boolean("yes").pipe(
 export const noGitFlag = Flag.boolean("no-git").pipe(
   Flag.withDescription("Skip git repository initialization"),
 );
+
+export const trustFlag = Flag.boolean("trust").pipe(
+  Flag.withDescription(
+    "Skip finalize script approval prompt and run all scripts",
+  ),
+);

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -14,6 +14,7 @@ import {
 import { Console, Context, Data, Effect, Layer, Result, Stream } from "effect";
 import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
+import { MultiSelect } from "../components/MultiSelect";
 
 class ScaffoldAborted extends Data.TaggedError("ScaffoldAborted")<{
   message: string;
@@ -47,12 +48,14 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
         repoRoot,
         yes,
         dryRun,
+        trust,
         config,
       }: {
         selection: typeof Selection.Type;
         repoRoot: string;
         yes: boolean;
         dryRun: boolean;
+        trust: boolean;
         config: typeof StackConfig.Type;
       }) =>
         Effect.gen(function* () {
@@ -167,48 +170,91 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             finalizeConfig,
           );
           if (previewScripts.length > 0) {
-            yield* Console.log("\nRunning finalize scripts...");
-            const executables = yield* finalizeService.run(
-              blueprint,
-              finalizeConfig,
-            );
+            const skipPrompt = yes || trust;
 
-            const results = yield* Effect.forEach(
-              executables,
-              ({ script, execute }) =>
-                Effect.scoped(
-                  Effect.gen(function* () {
-                    yield* Console.log(
-                      `  [>] ${script.label}: ${script.command}`,
-                    );
-                    const execution = yield* execute();
+            // Determine which scripts to run
+            const selectedScripts = skipPrompt
+              ? previewScripts
+              : yield* MultiSelect({
+                  message: "Finalize scripts to run:",
+                  groups: [
+                    { key: "finalize", label: "Finalize" },
+                    { key: "config", label: "Install & Format" },
+                    { key: "post-finalize", label: "Post-Finalize" },
+                  ],
+                  choices: previewScripts.map((s) => ({
+                    title: `${s.command}`,
+                    description: s.origin,
+                    value: s,
+                    selected: true,
+                    group: s.phase,
+                  })),
+                });
 
-                    yield* execution.output.pipe(
-                      Stream.tap((line) => Console.log(`      ${line}`)),
-                      Stream.runDrain,
-                    );
+            // Print script list for non-interactive (audit trail)
+            if (skipPrompt) {
+              yield* Console.log("\nFinalize scripts:");
+              for (const script of previewScripts) {
+                yield* Console.log(
+                  `  ${script.label}: ${script.command} (${script.origin})`,
+                );
+              }
+            }
 
-                    const result = yield* execution.result;
-                    const icon = Result.isSuccess(result) ? "+" : "x";
-                    yield* Console.log(
-                      `  [${icon}] ${Result.isSuccess(result) ? "success" : "failure"}`,
-                    );
-                    if (Result.isFailure(result)) {
-                      yield* Console.log(
-                        `      Error: ${result.failure.error}`,
-                      );
-                    }
-                    return result;
-                  }),
-                ),
-              { concurrency: 1 },
-            );
-
-            const report = new FinalizeReport({ results });
-            if (report.failed > 0) {
-              yield* Console.log(
-                `\n${report.failed} finalize script(s) failed. See errors above.`,
+            if (selectedScripts.length === 0) {
+              yield* Console.log("\nNo finalize scripts selected. Skipping.");
+            } else {
+              yield* Console.log("\nRunning finalize scripts...");
+              const executables = yield* finalizeService.run(
+                blueprint,
+                finalizeConfig,
               );
+
+              // Filter executables to only selected scripts
+              const selectedCommands = new Set(
+                selectedScripts.map((s) => s.command),
+              );
+              const filteredExecutables = executables.filter((e) =>
+                selectedCommands.has(e.script.command),
+              );
+
+              const results = yield* Effect.forEach(
+                filteredExecutables,
+                ({ script, execute }) =>
+                  Effect.scoped(
+                    Effect.gen(function* () {
+                      yield* Console.log(
+                        `  [>] ${script.label}: ${script.command}`,
+                      );
+                      const execution = yield* execute();
+
+                      yield* execution.output.pipe(
+                        Stream.tap((line) => Console.log(`      ${line}`)),
+                        Stream.runDrain,
+                      );
+
+                      const result = yield* execution.result;
+                      const icon = Result.isSuccess(result) ? "+" : "x";
+                      yield* Console.log(
+                        `  [${icon}] ${Result.isSuccess(result) ? "success" : "failure"}`,
+                      );
+                      if (Result.isFailure(result)) {
+                        yield* Console.log(
+                          `      Error: ${result.failure.error}`,
+                        );
+                      }
+                      return result;
+                    }),
+                  ),
+                { concurrency: 1 },
+              );
+
+              const report = new FinalizeReport({ results });
+              if (report.failed > 0) {
+                yield* Console.log(
+                  `\n${report.failed} finalize script(s) failed. See errors above.`,
+                );
+              }
             }
           }
         });

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -14,6 +14,7 @@ import {
 import { Console, Context, Data, Effect, Layer, Result, Stream } from "effect";
 import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
+import { DryRunPreview } from "../components/DryRunPreview";
 import { MultiSelect } from "../components/MultiSelect";
 
 class ScaffoldAborted extends Data.TaggedError("ScaffoldAborted")<{
@@ -63,13 +64,25 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
           const blueprintService = yield* BlueprintService;
           const planService = yield* PlanService;
           const finalizeService = yield* FinalizeService;
+          const applyService = yield* ApplyService;
 
           // Blueprint
           const blueprint = yield* blueprintService.resolve(selection);
 
-          const blueprintBox = yield* formatter.formatBlueprint(blueprint);
+          const formattedBlueprint =
+            yield* formatter.formatBlueprint(blueprint);
+          const blueprintBox = Box.vsep(
+            [
+              Box.text(formattedBlueprint.title).pipe(
+                Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
+              ),
+              formattedBlueprint.content,
+            ],
+            1,
+            Box.left,
+          );
 
-          if (!yes) {
+          if (!yes && !dryRun) {
             const confirm = yield* Confirm({
               message: "Continue with these changes?",
               children: blueprintBox,
@@ -83,6 +96,10 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
                 retry: true,
               });
             }
+          }
+
+          if (dryRun) {
+            // no-op: blueprint shown inside DryRunPreview
           }
 
           // Plan
@@ -106,8 +123,15 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             Box.left,
           );
 
-          // Dry run exits here
+          // Dry run: show full preview without writing or executing
           if (dryRun) {
+            // Preview apply outcomes
+            const result = yield* applyService.preview({
+              apply: new Apply({ plan, decisions: [] }),
+              repoRoot,
+            });
+
+            // Preview finalize scripts
             const finalizeConfig: FinalizeConfig = {
               config,
               repoRoot,
@@ -116,16 +140,18 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
               blueprint,
               finalizeConfig,
             );
-            if (previewScripts.length > 0) {
-              yield* Console.log("\nFinalize scripts:");
-              for (const script of previewScripts) {
-                yield* Console.log(`  ${script.label}: ${script.command}`);
-              }
-            }
-            yield* Console.log("\n[dry-run] No changes written.");
-            return yield* new ScaffoldAborted({
-              message: "Dry run completed. No changes written.",
-            });
+
+            yield* Console.log(
+              Box.renderPrettySync(
+                DryRunPreview({
+                  blueprint: formattedBlueprint.content,
+                  plan: pl,
+                  apply: result,
+                  scripts: previewScripts,
+                }),
+              ),
+            );
+            return;
           }
 
           // Resolve conflicts
@@ -147,7 +173,6 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
           }
 
           // Apply
-          const applyService = yield* ApplyService;
           const result = yield* applyService.apply({
             apply: new Apply({ plan, decisions }),
             repoRoot,

--- a/packages/scaffold/scratchpad.ts
+++ b/packages/scaffold/scratchpad.ts
@@ -6,6 +6,7 @@ import type { RepoSnapshot } from "@repo/domain/Plan";
 import { StackConfig } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
 import { Console, Effect, FileSystem, Layer, Random } from "effect";
+import { Box } from "effect-boxes";
 import {
   ApplyService,
   BlueprintService,
@@ -119,7 +120,9 @@ const main = Effect.gen(function* () {
     // Step 1: Selection → Blueprint
     const blueprint = yield* blueprintService.resolve(example.selection);
     const formattedBlueprint = yield* formatter.formatBlueprint(blueprint);
-    yield* Console.log(`\n${formattedBlueprint}`);
+    yield* Console.log(
+      Box.renderPrettySync(formattedBlueprint.content.pipe(Box.moveDown(1))),
+    );
 
     // Step 2: Blueprint → Plan
     const plan = yield* planService.build({

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -119,11 +119,11 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
     make: Effect.gen(function* () {
       const formatBlueprint = Effect.fn("ScaffoldFormatter.formatBlueprint")(
         function* (blueprint: typeof Blueprint.Type) {
-          const header = Box.text("Blueprint").pipe(
-            Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)),
-          );
           if (blueprint.nodes.length === 0) {
-            return header;
+            return {
+              title: "Blueprint",
+              content: Box.text("(empty)").pipe(Box.annotate(Ansi.dim)),
+            };
           }
 
           const attachedModulesByTarget = pipe(
@@ -186,7 +186,12 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
                         Arr.fromIterable(
                           outgoingEdgesByNode.get(attachedModule.id) ?? [],
                         ),
-                        (edge) => edge.reason !== "owns-module",
+                        (edge) =>
+                          edge.reason !== "owns-module" &&
+                          !(
+                            edge.reason === "required-target" &&
+                            edge.to === attachedModule.targetId
+                          ),
                       ),
                       idOrd,
                     ),
@@ -213,7 +218,10 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
             },
           );
 
-          return Box.vsep([header, ...targetBoxes], 1, Box.left);
+          return {
+            title: "Blueprint",
+            content: Box.vsep(targetBoxes, 1, Box.left),
+          };
         },
       );
 
@@ -246,7 +254,12 @@ export class ScaffoldFormatter extends Context.Service<ScaffoldFormatter>()(
 
         const treeNodes = buildNodes(
           Arr.map(Arr.sort(plan.outcomes, pathOrd), (outcome) => ({
-            segments: String.split(outcome.path, "/"),
+            segments: String.split(
+              outcome.path.startsWith("./")
+                ? outcome.path.slice(2)
+                : outcome.path,
+              "/",
+            ),
             outcome,
           })),
           0,

--- a/packages/scaffold/src/service/ScaffoldFormatter.test.ts
+++ b/packages/scaffold/src/service/ScaffoldFormatter.test.ts
@@ -101,7 +101,7 @@ describe("ScaffoldFormatter", () => {
         });
 
         const result = yield* formatter.formatBlueprint(blueprint);
-        expect(Box.renderPlainSync(result)).toContain("Blueprint");
+        expect(result.title).toBe("Blueprint");
       }),
     );
 
@@ -111,8 +111,8 @@ describe("ScaffoldFormatter", () => {
         const blueprint = makeUnsortedBlueprint().toSorted();
 
         const result = yield* formatter.formatBlueprint(blueprint);
-        const rendered = Box.renderPlainSync(result);
-        expect(rendered).toContain("Blueprint");
+        const rendered = Box.renderPlainSync(result.content);
+        expect(result.title).toBe("Blueprint");
         expect(rendered).toContain("apps/server-api");
         expect(rendered).toContain("http-api-server");
         expect(rendered).toContain("packages/domain");

--- a/packages/scaffold/src/service/apply/ApplyService.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.ts
@@ -358,7 +358,31 @@ export class ApplyService extends Context.Service<ApplyService>()(
         }).toSorted();
       });
 
-      return { apply } as const;
+      const preview = Effect.fn("ApplyService.preview")(function* ({
+        apply: applyIntent,
+        repoRoot,
+      }: {
+        apply: typeof Apply.Type;
+        repoRoot: string;
+      }) {
+        const actions = yield* materializeFrom(applyIntent);
+        const actionProjection = yield* projection({ actions, repoRoot });
+
+        return new ApplyResult({
+          created: actionProjection.writeRequests
+            .filter((r) => r.writeMode === "create")
+            .map((r) => r.path),
+          modified: actionProjection.writeRequests
+            .filter(
+              (r) => r.writeMode === "modify" || r.writeMode === "override",
+            )
+            .map((r) => r.path),
+          skipped: [...actionProjection.skippedPaths],
+          failed: [],
+        }).toSorted();
+      });
+
+      return { apply, preview } as const;
     }),
   },
 ) {

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -27,7 +27,8 @@ type ResolvedScript = {
   readonly label: string;
   readonly command: string;
   readonly workdir: string;
-  readonly phase: "finalize" | "post-finalize";
+  readonly phase: "finalize" | "config" | "post-finalize";
+  readonly origin: string;
 };
 
 export class FinalizeService extends Context.Service<FinalizeService>()(
@@ -62,6 +63,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
               command: context.resolve(s.command),
               workdir: context.resolve(s.workdir ?? "{{targetPath}}"),
               phase: (s.phase ?? "finalize") as "finalize" | "post-finalize",
+              origin: `target: ${node.identity.kind}`,
             }));
           }),
         ).pipe(Effect.map(Arr.flatten));
@@ -86,6 +88,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
               command: context.resolve(s.command),
               workdir: context.resolve(s.workdir ?? "{{targetPath}}"),
               phase: (s.phase ?? "finalize") as "finalize" | "post-finalize",
+              origin: `module: ${moduleNode.moduleId}`,
             }));
           }),
         ).pipe(Effect.map(Arr.flatten));
@@ -114,9 +117,11 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
         const scripts = yield* collectResolvedScripts(blueprint, config);
         const configScripts = buildConfigDerivedScripts(config);
         return orderScripts(scripts, configScripts).map(
-          ({ label, command }) => ({
+          ({ label, command, phase, origin }) => ({
             label,
             command,
+            phase,
+            origin,
           }),
         );
       });
@@ -166,7 +171,8 @@ const buildConfigDerivedScripts = (
             label: entry.label,
             command: entry.command,
             workdir: ".",
-            phase: "finalize" as const,
+            phase: "config" as const,
+            origin: "config",
           })
         : Result.failVoid,
   );


### PR DESCRIPTION
## Goals/Scope

Introduce progressive disclosure for scripts to reduce initial CLI complexity and script-related controls with safer defaults

## Description

- Add grouped multiselect options for clearer selection flows
- Add a `trust` flag plus an opt-out mechanism for scripts
- Improve scaffolded dry run and preview output for better validation before execution
