### PR TITLE
feat(cli): add contextual next-steps output

### DIFF
--- a/.changeset/green-ears-sin.md
+++ b/.changeset/green-ears-sin.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add contextual next-steps output, closes #107

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -358,7 +358,5 @@ export const init = Command.make(
         trust: flags.trust || flags.yes,
         config,
       });
-
-      yield* Console.log("Run 'stack-effect add' to add targets and modules.");
     }),
 );

--- a/apps/cli/src/components/NextStepsPreview.ts
+++ b/apps/cli/src/components/NextStepsPreview.ts
@@ -1,0 +1,94 @@
+import { Ansi, Box } from "effect-boxes";
+
+const sectionTitle = (title: string) =>
+  Box.text(title).pipe(Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)));
+
+export const NextStepsPreview = ({
+  conflicts,
+  skippedScripts,
+  steps,
+}: {
+  conflicts: ReadonlyArray<string>;
+  skippedScripts: ReadonlyArray<{ label: string; command: string }>;
+  steps: ReadonlyArray<string>;
+}): Box.Box<Ansi.AnsiStyle> => {
+  const sections: Box.Box<Ansi.AnsiStyle>[] = [];
+
+  // Conflicts section
+  if (conflicts.length > 0) {
+    const items = conflicts.map((path) =>
+      Box.hsep(
+        [Box.text("\u2022").pipe(Box.annotate(Ansi.yellow)), Box.text(path)],
+        1,
+        Box.left,
+      ),
+    );
+    sections.push(
+      Box.vsep(
+        [sectionTitle("Manual Resolution Needed"), ...items],
+        0,
+        Box.left,
+      ),
+    );
+  }
+
+  // Skipped scripts section
+  if (skippedScripts.length > 0) {
+    const items = skippedScripts.map((s) =>
+      Box.hsep(
+        [
+          Box.text("\u2022").pipe(Box.annotate(Ansi.yellow)),
+          Box.text(s.command).pipe(Box.annotate(Ansi.dim)),
+        ],
+        1,
+        Box.left,
+      ),
+    );
+    sections.push(
+      Box.vsep([sectionTitle("Skipped Scripts"), ...items], 0, Box.left),
+    );
+  }
+
+  // Next steps section
+  if (steps.length > 0) {
+    const items = steps.map((step, i) =>
+      Box.hsep(
+        [Box.text(`${i + 1}.`).pipe(Box.annotate(Ansi.cyan)), Box.text(step)],
+        1,
+        Box.left,
+      ),
+    );
+    sections.push(
+      Box.vsep([sectionTitle("Next Steps"), ...items], 0, Box.left),
+    );
+  }
+
+  if (sections.length === 0) {
+    return Box.text("");
+  }
+
+  // Stack sections vertically with borders
+  const terminalWidth = process.stdout.columns ?? 80;
+  const contentWidth = terminalWidth - 4;
+
+  const panels = sections.map((section, i) => {
+    const isFirst = i === 0;
+    const isLast = i === sections.length - 1;
+    return section.pipe(
+      Box.minWidth(contentWidth),
+      Box.pad(0, 1),
+      Box.border("rounded", {
+        annotation: Ansi.dim,
+        sides: { top: isFirst, bottom: isLast },
+      }),
+    );
+  });
+
+  const footer = Box.text(
+    "Add modules with 'stack-effect add' or explore available options with 'stack-effect graph'",
+  ).pipe(Box.annotate(Ansi.dim));
+
+  return Box.vsep([Box.vcat(panels, Box.left), footer], 1, Box.left).pipe(
+    Box.moveDown(1),
+  );
+};

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -16,6 +16,7 @@ import { Ansi, Box } from "effect-boxes";
 import { Confirm } from "../components/Confirm";
 import { DryRunPreview } from "../components/DryRunPreview";
 import { MultiSelect } from "../components/MultiSelect";
+import { NextStepsPreview } from "../components/NextStepsPreview";
 
 class ScaffoldAborted extends Data.TaggedError("ScaffoldAborted")<{
   message: string;
@@ -281,6 +282,45 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
                 );
               }
             }
+
+            // Determine skipped scripts (deselected by user)
+            const selectedCommands = new Set(
+              selectedScripts.map((s) => s.command),
+            );
+            const skippedScripts = previewScripts
+              .filter((s) => !selectedCommands.has(s.command))
+              .map((s) => ({ label: s.label, command: s.command }));
+
+            // Collect and render post-scaffold summary
+            const nextSteps = yield* finalizeService.collectNextSteps(
+              blueprint,
+              finalizeConfig,
+            );
+
+            const isInit = selection.targets.some(
+              (t) => t.identity.kind === "init",
+            );
+
+            const allSteps: string[] = [];
+            if (isInit) {
+              allSteps.push(`cd ${config.name}`);
+              allSteps.push(`${config.packageManagerName} install`);
+            }
+            if (result.skipped.length > 0) {
+              allSteps.push("Resolve conflicts listed above");
+            }
+            allSteps.push(...nextSteps);
+            if (!isInit) {
+              allSteps.push(`${config.packageManagerName} run dev`);
+            }
+
+            const preview = NextStepsPreview({
+              conflicts: result.skipped,
+              skippedScripts,
+              steps: allSteps,
+            });
+
+            yield* Console.log(Box.renderPrettySync(preview));
           }
         });
 

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -235,6 +235,10 @@ export const ModuleDefinition = Schema.Struct({
     Schema.optionalKey,
     Schema.withConstructorDefault(Effect.succeed([])),
   ),
+  nextSteps: Schema.Array(Schema.String).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
 });
 
 export const TargetDefinition = Schema.Struct({
@@ -251,6 +255,10 @@ export const TargetDefinition = Schema.Struct({
   ),
   contributions: Schema.Array(Contribution),
   scripts: Schema.Array(ScriptDefinition).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
+  nextSteps: Schema.Array(Schema.String).pipe(
     Schema.optionalKey,
     Schema.withConstructorDefault(Effect.succeed([])),
   ),

--- a/packages/domain/src/Finalize.ts
+++ b/packages/domain/src/Finalize.ts
@@ -1,4 +1,4 @@
-import { Result, Schema } from "effect";
+import { Effect, Result, Schema } from "effect";
 
 export const ScriptSuccess = Schema.Struct({
   label: Schema.String,
@@ -16,12 +16,24 @@ export type ScriptResult = Result.Result<
   typeof ScriptFailure.Type
 >;
 
+export const SkippedScript = Schema.Struct({
+  label: Schema.String,
+  command: Schema.String,
+  workdir: Schema.String,
+});
+
+export const ConflictedFile = Schema.Struct({
+  path: Schema.String,
+  patchPath: Schema.String,
+});
+
 /**
  * Aggregated results of post-apply finalization scripts (install, format, etc.).
  *
  * The FinalizeReport is the terminal output of the scaffold pipeline. It
- * records which scripts succeeded and which failed, enabling the CLI to
- * present a summary to the user.
+ * records which scripts succeeded and which failed, enables the CLI to
+ * present a summary to the user, and surfaces skipped scripts and unresolved
+ * conflicts for manual resolution.
  *
  * @category Finalize
  * @since 1.0.0
@@ -30,6 +42,18 @@ export class FinalizeReport extends Schema.Class<FinalizeReport>(
   "FinalizeReport",
 )({
   results: Schema.Array(Schema.Result(ScriptSuccess, ScriptFailure)),
+  skippedScripts: Schema.Array(SkippedScript).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
+  conflicts: Schema.Array(ConflictedFile).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
+  nextSteps: Schema.Array(Schema.String).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
 }) {
   get succeeded(): number {
     return this.results.filter(Result.isSuccess).length;

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -126,7 +126,57 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
         );
       });
 
-      return { run, preview };
+      const collectNextSteps = Effect.fn("FinalizeService.collectNextSteps")(
+        function* (blueprint: typeof Blueprint.Type, config: FinalizeConfig) {
+          const moduleNodes = Arr.filter(
+            blueprint.nodes,
+            BlueprintNode.guards["attached-module"],
+          );
+          const targetNodes = Arr.filter(
+            blueprint.nodes,
+            BlueprintNode.guards.target,
+          );
+
+          const steps: string[] = [];
+
+          // Collect target-level next steps
+          for (const node of targetNodes) {
+            const definition = yield* catalog.getTarget(node.identity.kind);
+            const context = new ContributionTokenContext({
+              targetKey: node.id,
+              identity: node.identity,
+              config: config.config,
+            });
+            for (const step of definition.nextSteps ?? []) {
+              steps.push(context.resolve(step));
+            }
+          }
+
+          // Collect module-level next steps (dependency order from blueprint)
+          for (const moduleNode of moduleNodes) {
+            const targetNode = Arr.findFirst(
+              targetNodes,
+              (t) => t.id === moduleNode.targetId,
+            );
+            if (Option.isNone(targetNode)) continue;
+
+            const definition = yield* catalog.getModule(moduleNode.moduleId);
+            const context = new ContributionTokenContext({
+              targetKey: moduleNode.targetId,
+              identity: targetNode.value.identity,
+              config: config.config,
+            });
+            for (const step of definition.nextSteps ?? []) {
+              steps.push(context.resolve(step));
+            }
+          }
+
+          // Deduplicate by exact string match, preserving order
+          return [...new Set(steps)];
+        },
+      );
+
+      return { run, preview, collectNextSteps };
     }),
   },
 ) {


### PR DESCRIPTION
## Goals/Scope

Add contextual next-steps output to the CLI to guide users on what to do after key actions.

## Description

- Display context-aware “next steps” after relevant CLI operations to improve usability and reduce confusion.
- Ensure the output is consistent with the CLI’s current command flows.