### PR TITLE
feat: add layout and composition helpers

### DIFF
--- a/.changeset/thirty-wombats-sleep.md
+++ b/.changeset/thirty-wombats-sleep.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add Layout and Panel helpers for responsive composition

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,12 @@ The CLI (`apps/cli`) orchestrates this flow using shared packages in `packages/*
   composition for DI
 - **Error handling**: Use Effect error channel; avoid try/catch
 - **Type safety**: Never use `as unknown as` casts; if a type cannot be expressed safely, fix the model or use framework-provided typed test stubs/helpers
+- **Declarative over imperative**: Prefer declarative, expression-based code
+  over imperative mutation and branching. Use Effect modules (`Array`, `Match`,
+  `Record`, `Option`, `pipe`, `flow`) to express transformations as data
+  pipelines rather than step-by-step procedures with `let`, `if/else`, or
+  `for` loops. When composing operations, build a declarative pipeline
+  (filter, map, reduce) instead of accumulating results imperatively.
 
 ## Effect Essentials
 

--- a/apps/cli/scratchpad-layout.ts
+++ b/apps/cli/scratchpad-layout.ts
@@ -1,0 +1,326 @@
+/**
+ * Layout Scratchpad — annotated demos of each layout helper.
+ *
+ * Run with: bun apps/cli/scratchpad-layout.ts
+ */
+import { BunServices } from "@effect/platform-bun";
+import { Console, Effect, Terminal } from "effect";
+import * as Ansi from "effect-boxes/Ansi";
+import * as Box from "effect-boxes/Box";
+import { Panel } from "./src/components/Panel";
+import { Breakpoint, Container, Flex, Grid } from "./src/lib/Layout";
+
+// ─── Styling Helpers ─────────────────────────────────────────────────────────
+
+const title = (text: string) =>
+  Box.text(text).pipe(Box.annotate(Ansi.combine(Ansi.bold, Ansi.white)));
+
+const label = (text: string) => Box.text(text).pipe(Box.annotate(Ansi.cyan));
+
+const desc = (text: string) => Box.text(text).pipe(Box.annotate(Ansi.dim));
+
+const sectionTitle = (name: string) =>
+  Box.text(` ${name} `).pipe(
+    Box.annotate(
+      Ansi.combine(Ansi.bold, Ansi.bgColorRGB(60, 60, 120), Ansi.white),
+    ),
+  );
+
+const propNote = (prop: string, explanation: string) =>
+  Box.hsep(
+    [Box.text(prop).pipe(Box.annotate(Ansi.yellow)), desc(explanation)],
+    1,
+    Box.left,
+  );
+
+// ─── 1. Flex ─────────────────────────────────────────────────────────────────
+
+const flexDemo = (termWidth: number) =>
+  Container.make({ width: termWidth - 4, padding: 0 }, (ctx) => {
+    return Box.vcat(
+      [
+        sectionTitle("Flex.row / Flex.col"),
+        desc(
+          "Distribute space among fixed and grow children within a container.",
+        ),
+        Box.emptyBox(1, 1),
+        propNote("Flex.fixed(box)", "child keeps its intrinsic width"),
+        propNote(
+          "Flex.grow(box, factor?)",
+          "child expands (space allocated, content unchanged)",
+        ),
+        propNote(
+          "Flex.fill((w) => box, factor?)",
+          "builder receives allocated width — content fills exactly",
+        ),
+        propNote("gap", "spacing between children"),
+        Box.emptyBox(1, 1),
+        label(`Flex.row(${ctx.width}, [fixed, fill(1), fixed])`),
+        Flex.row(
+          ctx.width,
+          [
+            Flex.fixed(
+              Panel.make(Box.text("FIXED").pipe(Box.minHeight(2)), {
+                border: Box.border("single"),
+                padding: Box.pad(0, 1),
+              }),
+            ),
+            Flex.fill((w) =>
+              Panel.make(
+                Box.text("FILL (factor=1)").pipe(
+                  Box.minHeight(2),
+                  Box.minWidth(w - 4),
+                ),
+                { border: Box.border("double"), padding: Box.pad(0, 1) },
+              ),
+            ),
+            Flex.fixed(
+              Panel.make(Box.text("FIXED").pipe(Box.minHeight(2)), {
+                border: Box.border("single"),
+                padding: Box.pad(0, 1),
+              }),
+            ),
+          ],
+          { gap: 1 },
+        ),
+        Box.emptyBox(1, 1),
+        label(`Flex.row(${ctx.width}, [fill(1), fill(2)]) — proportional`),
+        Flex.row(
+          ctx.width,
+          [
+            Flex.fill(
+              (w) =>
+                Panel.make(Box.text("1/3 width").pipe(Box.minWidth(w - 4)), {
+                  border: Box.border("rounded"),
+                  padding: Box.pad(0, 1),
+                }),
+              1,
+            ),
+            Flex.fill(
+              (w) =>
+                Panel.make(Box.text("2/3 width").pipe(Box.minWidth(w - 4)), {
+                  border: Box.border("rounded"),
+                  padding: Box.pad(0, 1),
+                }),
+              2,
+            ),
+          ],
+          { gap: 1 },
+        ),
+      ],
+      Box.top,
+    );
+  });
+
+// ─── 2. Grid ─────────────────────────────────────────────────────────────────
+
+const gridLabels = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"];
+
+const gridDemo = (termWidth: number) =>
+  Container.make({ width: termWidth - 4, padding: 0 }, (ctx) => {
+    // Build items with target width so borders span the full cell
+    const makeGridItems = (colWidth: number) =>
+      gridLabels.map((name) =>
+        Panel.make(Box.text(name).pipe(Box.minWidth(colWidth - 4)), {
+          border: Box.border("single"),
+          padding: Box.pad(0, 1),
+        }),
+      );
+
+    return Box.vcat(
+      [
+        sectionTitle("Grid.make / Grid.auto"),
+        desc("Arrange items in rows of N columns with fixed cell width."),
+        Box.emptyBox(1, 1),
+        propNote("cols", "number of columns per row"),
+        propNote("colWidth", "fixed character width per cell"),
+        propNote("gap: [h, v]", "horizontal and vertical gap between cells"),
+        propNote(
+          "Grid.auto(width, items, { minColWidth })",
+          "auto-calculate cols from container",
+        ),
+        propNote("stretch", "expand items to fill cell width (default false)"),
+        Box.emptyBox(1, 1),
+        label("Grid.make(items, { cols: 3, colWidth: 20, gap: [1, 1] })"),
+        Grid.make(makeGridItems(20), {
+          cols: 3,
+          colWidth: 20,
+          gap: [1, 1],
+        }).pipe(Box.border("rounded")),
+        Box.emptyBox(1, 1),
+        label(`Grid.auto(${ctx.width}, items, { minColWidth: 14, gap: 1 })`),
+        desc(
+          "  Columns auto-calculated from available width. Capped at item count.",
+        ),
+        (() => {
+          const gap = 1;
+          const cols = Math.min(
+            gridLabels.length,
+            Math.max(1, Math.floor((ctx.width + gap) / (14 + gap))),
+          );
+          const colWidth = Math.floor((ctx.width - (cols - 1) * gap) / cols);
+          return Grid.make(makeGridItems(colWidth), {
+            cols,
+            colWidth,
+            gap: [gap, 0],
+          });
+        })().pipe(Box.border("rounded")),
+      ],
+      Box.top,
+    );
+  });
+
+// ─── 3. Panel ────────────────────────────────────────────────────────────────
+
+const panelDemo = Box.vcat(
+  [
+    sectionTitle("Panel.make"),
+    desc("Bordered + padded section. Extracts the most common Box pattern."),
+    Box.emptyBox(1, 1),
+    propNote("border", "BoxOperator — e.g. Box.border('rounded')"),
+    propNote("padding", "BoxOperator — e.g. Box.pad(0, 1)"),
+    propNote("margin", "BoxOperator — e.g. Box.pad(1)"),
+    Box.emptyBox(1, 1),
+    Box.hsep(
+      [
+        Panel.make(Box.text("rounded\npad: [0,1]"), {
+          border: Box.border("rounded"),
+          padding: Box.pad(0, 1),
+        }),
+        Panel.make(Box.text("single\npad: 1"), {
+          border: Box.border("single"),
+          padding: Box.pad(1),
+        }),
+        Panel.make(Box.text("double\npad: [0,2]"), {
+          border: Box.border("double"),
+          padding: Box.pad(0, 2),
+        }),
+        Panel.make(Box.text("thick\nno pad"), { border: Box.border("thick") }),
+      ],
+      1,
+      Box.center1,
+    ),
+    Box.emptyBox(1, 1),
+    label("Partial borders: sides: { left: true, others: false }"),
+    Panel.make(Box.text("left border only"), {
+      border: Box.border("rounded", {
+        sides: { top: false, right: false, bottom: false, left: true },
+      }),
+      padding: Box.pad(0, 1),
+    }),
+  ],
+  Box.top,
+);
+
+// ─── 4. Breakpoint ───────────────────────────────────────────────────────────
+
+const breakpointDemo = (termWidth: number) =>
+  Container.make({ width: termWidth - 4, padding: 0 }, (ctx) => {
+    const current = Breakpoint.select(ctx.width, [
+      { minWidth: 100, render: () => Box.text("WIDE layout (>=100 cols)") },
+      { minWidth: 60, render: () => Box.text("MEDIUM layout (>=60 cols)") },
+      { minWidth: 0, render: () => Box.text("NARROW layout (<60 cols)") },
+    ]);
+
+    return Box.vcat(
+      [
+        sectionTitle("Breakpoint.select"),
+        desc(
+          "Switch layout based on container width. Largest matching minWidth wins.",
+        ),
+        Box.emptyBox(1, 1),
+        propNote("minWidth", "minimum container width to activate this layout"),
+        propNote("render", "() => Box — lazy builder for this breakpoint"),
+        Box.emptyBox(1, 1),
+        label(`Container width: ${ctx.width} cols`),
+        label("Breakpoints: [100, 60, 0]"),
+        desc("Active:"),
+        current.pipe(
+          Box.pad(0, 1),
+          Box.annotate(Ansi.combine(Ansi.bgColorRGB(40, 80, 40), Ansi.white)),
+        ),
+      ],
+      Box.top,
+    );
+  });
+
+// ─── 5. Container ────────────────────────────────────────────────────────────
+
+const containerDemo = (termWidth: number) =>
+  Container.make({ width: termWidth - 4, padding: 0 }, (ctx) =>
+    Box.vcat(
+      [
+        sectionTitle("Container.make"),
+        desc(
+          "Provides container context (width, height, innerWidth) to a builder fn.",
+        ),
+        Box.emptyBox(1, 1),
+        propNote("width", "total container width"),
+        propNote("padding", "number or [y, x] — subtracted to get innerWidth"),
+        propNote("ctx.innerWidth", "usable width after padding"),
+        Box.emptyBox(1, 1),
+        label(
+          `Container.make({ width: ${termWidth - 4}, padding: 2 }, (ctx) => ...)`,
+        ),
+        Container.make({ width: ctx.width, padding: 2 }, (inner) =>
+          Box.vcat(
+            [
+              desc(`  ctx.width = ${inner.width}`),
+              desc(`  ctx.innerWidth = ${inner.innerWidth}`),
+              Panel.make(
+                Box.text(`content area: ${inner.innerWidth} cols`).pipe(
+                  Box.minWidth(inner.innerWidth - 4),
+                ),
+                { border: Box.border("rounded"), padding: Box.pad(0, 1) },
+              ),
+            ],
+            Box.top,
+          ),
+        ).pipe(Box.border("single")),
+      ],
+      Box.top,
+    ),
+  );
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+const main = Effect.gen(function* () {
+  const terminal = yield* Terminal.Terminal;
+  const termWidth = yield* terminal.columns;
+
+  const divider = Box.text("─".repeat(termWidth - 4)).pipe(
+    Box.annotate(Ansi.dim),
+  );
+
+  const layout = Box.vsep(
+    [
+      Box.emptyBox(1, 1),
+      title("Layout Helpers — Interactive Reference"),
+      desc(`Terminal: ${termWidth} cols`),
+      divider,
+      flexDemo(termWidth),
+      divider,
+      gridDemo(termWidth),
+      divider,
+      panelDemo,
+      divider,
+      breakpointDemo(termWidth),
+      divider,
+      containerDemo(termWidth),
+      divider,
+      Box.emptyBox(1, 1),
+    ],
+    1,
+    Box.top,
+  ).pipe(Box.pad(0, 1));
+
+  yield* Console.log(Box.renderPrettySync(layout));
+});
+
+// ─── Run ─────────────────────────────────────────────────────────────────────
+
+void Effect.runPromise(main.pipe(Effect.provide(BunServices.layer))).catch(
+  (error) => {
+    console.error("Error in Layout Scratchpad:", error);
+  },
+);

--- a/apps/cli/src/components/Confirm.ts
+++ b/apps/cli/src/components/Confirm.ts
@@ -5,6 +5,7 @@ import type { AnsiStyle } from "effect-boxes/Ansi";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import * as Viewport from "../lib/Viewport.js";
 import { Hint } from "./Hint.js";
+import { Panel, PromptChrome } from "./Panel.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -108,7 +109,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     return Box.vcat(items, Box.left).pipe(
       Box.minWidth(childrenBox?.cols ?? 0),
       Box.maxWidth((process.stdout.columns ?? 80) - 10),
-      Box.border("rounded", { annotation: Ansi.dim }),
+      Panel.make({ border: Box.border("rounded", { annotation: Ansi.dim }) }),
     );
   });
 
@@ -123,20 +124,10 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
       Box.left,
     );
 
-    return Box.vsep(
-      [
-        content.pipe(
-          Box.pad(0, 0, 0, 1),
-          Box.border("thick", {
-            annotation: Ansi.dim,
-            sides: { top: false, bottom: false, right: false },
-          }),
-        ),
-        Hint(ConfirmKeys(hasChildren)),
-      ],
-      1,
+    return Box.vcat(
+      [content.pipe(PromptChrome()), Hint(ConfirmKeys(hasChildren))],
       Box.left,
-    ).pipe(Box.moveDown(1));
+    );
   });
 
   const renderLayout = Effect.fnUntraced(function* (

--- a/apps/cli/src/components/DryRunPreview.ts
+++ b/apps/cli/src/components/DryRunPreview.ts
@@ -1,5 +1,7 @@
 import type { ApplyResult } from "@repo/domain/Apply";
 import { Ansi, Box } from "effect-boxes";
+import { Breakpoint, Container } from "../lib/Layout.js";
+import { Panel } from "./Panel.js";
 
 const sectionTitle = (title: string) =>
   Box.text(title).pipe(Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)));
@@ -105,81 +107,93 @@ export const DryRunPreview = ({
   // Footer
   const footer = Box.text("No changes written.").pipe(Box.annotate(Ansi.dim));
 
-  // Determine layout based on natural content width vs terminal
+  // Natural width needed for horizontal layout
   const naturalHorizontalWidth =
     Box.cols(blueprintContent) +
     Box.cols(applyContent) +
     Box.cols(finalizeContent) +
     18; // padding + borders overhead
 
-  if (naturalHorizontalWidth <= terminalWidth) {
-    // Wide layout: horizontal panels
-    const maxHeight = Math.max(
-      Box.rows(blueprintContent),
-      Box.rows(applyContent),
-      Box.rows(finalizeContent),
-    );
+  const panels = Breakpoint.select(terminalWidth, [
+    {
+      minWidth: naturalHorizontalWidth,
+      render: () => {
+        const maxHeight = Math.max(
+          Box.rows(blueprintContent),
+          Box.rows(applyContent),
+          Box.rows(finalizeContent),
+        );
 
-    const leftPanel = blueprintContent.pipe(
-      Box.minHeight(maxHeight),
-      Box.pad(0, 2),
-      Box.border("rounded", { annotation: Ansi.dim }),
-    );
+        const leftPanel = blueprintContent.pipe(
+          Box.minHeight(maxHeight),
+          Panel.make({
+            padding: Box.pad(0, 2),
+            border: Box.border("rounded", { annotation: Ansi.dim }),
+          }),
+        );
+        const middlePanel = applyContent.pipe(
+          Box.minHeight(maxHeight),
+          Panel.make({
+            padding: Box.pad(0, 2),
+            border: Box.border("rounded", {
+              annotation: Ansi.dim,
+              sides: { left: false },
+            }),
+          }),
+        );
+        const rightPanel = finalizeContent.pipe(
+          Box.minHeight(maxHeight),
+          Panel.make({
+            padding: Box.pad(0, 2),
+            border: Box.border("rounded", {
+              annotation: Ansi.dim,
+              sides: { left: false },
+            }),
+          }),
+        );
 
-    const middlePanel = applyContent.pipe(
-      Box.minHeight(maxHeight),
-      Box.pad(0, 2),
-      Box.border("rounded", {
-        annotation: Ansi.dim,
-        sides: { left: false },
-      }),
-    );
+        return Box.hcat([leftPanel, middlePanel, rightPanel], Box.top);
+      },
+    },
+    {
+      minWidth: 0,
+      render: () =>
+        Container.make({ width: terminalWidth, paddingX: 2 }, (ctx) => {
+          const topPanel = blueprintContent.pipe(
+            Box.minWidth(ctx.innerWidth),
+            Panel.make({
+              padding: Box.pad(0, 1),
+              border: Box.border("rounded", {
+                annotation: Ansi.dim,
+                sides: { bottom: false },
+              }),
+            }),
+          );
+          const midPanel = applyContent.pipe(
+            Box.minWidth(ctx.innerWidth),
+            Panel.make({
+              padding: Box.pad(0, 1),
+              border: Box.border("rounded", {
+                annotation: Ansi.dim,
+                sides: { top: false, bottom: false },
+              }),
+            }),
+          );
+          const botPanel = finalizeContent.pipe(
+            Box.minWidth(ctx.innerWidth),
+            Panel.make({
+              padding: Box.pad(0, 1),
+              border: Box.border("rounded", {
+                annotation: Ansi.dim,
+                sides: { top: false },
+              }),
+            }),
+          );
 
-    const rightPanel = finalizeContent.pipe(
-      Box.minHeight(maxHeight),
-      Box.pad(0, 2),
-      Box.border("rounded", {
-        annotation: Ansi.dim,
-        sides: { left: false },
-      }),
-    );
+          return Box.vcat([topPanel, midPanel, botPanel], Box.left);
+        }),
+    },
+  ]);
 
-    const panels = Box.hcat([leftPanel, middlePanel, rightPanel], Box.top);
-
-    return Box.vsep([panels, footer], 1, Box.left).pipe(Box.moveDown(1));
-  }
-
-  // Narrow layout: stacked panels
-  const stackedWidth = terminalWidth - 4; // border + padding
-
-  const topPanel = blueprintContent.pipe(
-    Box.minWidth(stackedWidth),
-    Box.pad(0, 1),
-    Box.border("rounded", {
-      annotation: Ansi.dim,
-      sides: { bottom: false },
-    }),
-  );
-
-  const midPanel = applyContent.pipe(
-    Box.minWidth(stackedWidth),
-    Box.pad(0, 1),
-    Box.border("rounded", {
-      annotation: Ansi.dim,
-      sides: { top: false, bottom: false },
-    }),
-  );
-
-  const botPanel = finalizeContent.pipe(
-    Box.minWidth(stackedWidth),
-    Box.pad(0, 1),
-    Box.border("rounded", {
-      annotation: Ansi.dim,
-      sides: { top: false },
-    }),
-  );
-
-  const stacked = Box.vcat([topPanel, midPanel, botPanel], Box.left);
-
-  return Box.vsep([stacked, footer], 1, Box.left).pipe(Box.moveDown(1));
+  return Box.vsep([panels, footer], 1, Box.left).pipe(Box.moveDown(1));
 };

--- a/apps/cli/src/components/HorizontalSelect.ts
+++ b/apps/cli/src/components/HorizontalSelect.ts
@@ -3,6 +3,7 @@ import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import { Hint } from "./Hint.js";
+import { Panel, PromptChrome } from "./Panel.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -46,8 +47,7 @@ export const HorizontalSelect = <A extends string>(
       const isSelected = i === cursor;
 
       return Box.text(c.title).pipe(
-        Box.pad(0, 2),
-        Box.border("rounded"),
+        Panel.make({ padding: Box.pad(0, 2) }),
         Box.annotate(
           isSelected ? Ansi.combine(Ansi.cyan, Ansi.bold) : Ansi.dim,
         ),
@@ -75,20 +75,10 @@ export const HorizontalSelect = <A extends string>(
       Box.left,
     );
 
-    return Box.vsep(
-      [
-        content.pipe(
-          Box.pad(0, 0, 0, 1),
-          Box.border("thick", {
-            annotation: Ansi.dim,
-            sides: { top: false, bottom: false, right: false },
-          }),
-        ),
-        Hint(HorizontalSelectKeys),
-      ],
-      1,
+    return Box.vcat(
+      [content.pipe(PromptChrome()), Hint(HorizontalSelectKeys)],
       Box.left,
-    ).pipe(Box.moveDown(1));
+    );
   };
 
   let hasRendered = false;

--- a/apps/cli/src/components/MultiSelect.ts
+++ b/apps/cli/src/components/MultiSelect.ts
@@ -3,6 +3,7 @@ import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import { Hint } from "./Hint.js";
+import { PromptChrome } from "./Panel.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -145,20 +146,10 @@ export const MultiSelect = <A>(
       Box.left,
     );
 
-    return Box.vsep(
-      [
-        content.pipe(
-          Box.pad(0, 0, 0, 1),
-          Box.border("thick", {
-            annotation: Ansi.dim,
-            sides: { top: false, bottom: false, right: false },
-          }),
-        ),
-        Hint(MultiSelectHintKeys),
-      ],
-      1,
+    return Box.vcat(
+      [content.pipe(PromptChrome()), Hint(MultiSelectHintKeys)],
       Box.left,
-    ).pipe(Box.moveDown(1));
+    );
   };
 
   const initialSelected = new Set<number>(

--- a/apps/cli/src/components/NextStepsPreview.ts
+++ b/apps/cli/src/components/NextStepsPreview.ts
@@ -1,4 +1,6 @@
 import { Ansi, Box } from "effect-boxes";
+import { Container } from "../lib/Layout.js";
+import { Panel } from "./Panel.js";
 
 const sectionTitle = (title: string) =>
   Box.text(title).pipe(Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan)));
@@ -69,26 +71,29 @@ export const NextStepsPreview = ({
 
   // Stack sections vertically with borders
   const terminalWidth = process.stdout.columns ?? 80;
-  const contentWidth = terminalWidth - 4;
 
-  const panels = sections.map((section, i) => {
-    const isFirst = i === 0;
-    const isLast = i === sections.length - 1;
-    return section.pipe(
-      Box.minWidth(contentWidth),
-      Box.pad(0, 1),
-      Box.border("rounded", {
-        annotation: Ansi.dim,
-        sides: { top: isFirst, bottom: isLast },
-      }),
+  return Container.make({ width: terminalWidth, paddingX: 2 }, (ctx) => {
+    const panels = sections.map((section, i) => {
+      const isFirst = i === 0;
+      const isLast = i === sections.length - 1;
+      return section.pipe(
+        Box.minWidth(ctx.innerWidth),
+        Panel.make({
+          padding: Box.pad(0, 1),
+          border: Box.border("rounded", {
+            annotation: Ansi.dim,
+            sides: { top: isFirst, bottom: isLast },
+          }),
+        }),
+      );
+    });
+
+    const footer = Box.text(
+      "Add modules with 'stack-effect add' or explore available options with 'stack-effect graph'",
+    ).pipe(Box.annotate(Ansi.dim));
+
+    return Box.vsep([Box.vcat(panels, Box.left), footer], 1, Box.left).pipe(
+      Box.moveDown(1),
     );
   });
-
-  const footer = Box.text(
-    "Add modules with 'stack-effect add' or explore available options with 'stack-effect graph'",
-  ).pipe(Box.annotate(Ansi.dim));
-
-  return Box.vsep([Box.vcat(panels, Box.left), footer], 1, Box.left).pipe(
-    Box.moveDown(1),
-  );
 };

--- a/apps/cli/src/components/Panel.ts
+++ b/apps/cli/src/components/Panel.ts
@@ -1,9 +1,9 @@
 import { dual } from "effect/Function";
-import { Box, type Box as BoxType } from "effect-boxes";
+import { Ansi, Box, type Box as BoxType } from "effect-boxes";
 
 // ─── Panel ───────────────────────────────────────────────────────────────────
 
-type BoxOperator = (box: BoxType.Box<unknown>) => BoxType.Box<unknown>;
+type BoxOperator = (box: BoxType.Box<any>) => BoxType.Box<any>;
 type PanelOptions = {
   readonly padding?: BoxOperator;
   readonly border?: BoxOperator;
@@ -63,6 +63,36 @@ export const Panel = {
       options?.margin,
     ].filter((op): op is BoxOperator => op != null);
 
-    return ops.reduce((box, op) => op(box), self as BoxType.Box<unknown>) as BoxType.Box<A>;
+    return ops.reduce((box, op) => op(box), self);
   }),
 };
+
+// ─── PromptChrome ────────────────────────────────────────────────────────────
+
+/**
+ * Shared prompt wrapper used by all interactive prompt components.
+ * Applies a left-side thick border with inner left-padding, plus
+ * consistent top/bottom margin (1 row each), matching the standard
+ * prompt chrome pattern.
+ *
+ * @param annotation - Border colour, defaults to `Ansi.dim`
+ *
+ * @example
+ * ```typescript
+ * import { pipe } from "effect"
+ * import { Ansi, Box } from "effect-boxes"
+ * import { PromptChrome } from "./Panel"
+ *
+ * const wrapped = pipe(content, PromptChrome())
+ * const errorWrapped = pipe(content, PromptChrome(Ansi.red))
+ * ```
+ */
+export const PromptChrome = (annotation: Ansi.AnsiAnnotation = Ansi.dim) =>
+  Panel.make({
+    padding: Box.pad(0, 0, 0, 1),
+    border: Box.border("thick", {
+      annotation,
+      sides: { top: false, bottom: false, right: false },
+    }),
+    margin: Box.pad(1, 0),
+  });

--- a/apps/cli/src/components/Panel.ts
+++ b/apps/cli/src/components/Panel.ts
@@ -1,0 +1,68 @@
+import { dual } from "effect/Function";
+import { Box, type Box as BoxType } from "effect-boxes";
+
+// ─── Panel ───────────────────────────────────────────────────────────────────
+
+type BoxOperator = (box: BoxType.Box<unknown>) => BoxType.Box<unknown>;
+type PanelOptions = {
+  readonly padding?: BoxOperator;
+  readonly border?: BoxOperator;
+  readonly margin?: BoxOperator;
+};
+
+/**
+ * Creates a bordered, padded section by composing Box operators in
+ * CSS box-model order: content → padding → border → margin.
+ *
+ * Accepts any `BoxOperator` for each layer, giving full control over
+ * border style, padding shape, and outer spacing without Panel needing
+ * to know about annotation, sides, or other border options.
+ *
+ * If no `border` operator is provided, defaults to `Box.border("rounded")`.
+ *
+ * @example
+ * ```typescript
+ * import { pipe } from "effect"
+ * import { Box } from "effect-boxes"
+ * import { Panel } from "./Panel"
+ *
+ * // Data-first: pass box and options directly
+ * const card = Panel.make(Box.text("Hello"), {
+ *   padding: Box.pad(0, 1),
+ *   border: Box.border("rounded"),
+ * })
+ *
+ * // Data-last: use with pipe
+ * const info = pipe(
+ *   Box.text("Status: OK"),
+ *   Panel.make({
+ *     padding: Box.pad(1),
+ *     border: Box.border("single", { annotation: Ansi.green }),
+ *     margin: Box.pad(0, 1),
+ *   })
+ * )
+ *
+ * // Partial borders via Box.border options
+ * const sidebar = pipe(
+ *   Box.text("Menu"),
+ *   Panel.make({
+ *     padding: Box.pad(0, 1),
+ *     border: Box.border("rounded", { sides: { right: false } }),
+ *   })
+ * )
+ * ```
+ */
+export const Panel = {
+  make: dual<
+    <A>(options?: PanelOptions) => (self: Box.Box<A>) => Box.Box<A>,
+    <A>(self: Box.Box<A>, options?: PanelOptions) => Box.Box<A>
+  >(2, <A>(self: Box.Box<A>, options?: PanelOptions): Box.Box<A> => {
+    const ops: Array<BoxOperator> = [
+      options?.padding,
+      options?.border ?? Box.border("rounded"),
+      options?.margin,
+    ].filter((op): op is BoxOperator => op != null);
+
+    return ops.reduce((box, op) => op(box), self as BoxType.Box<unknown>) as BoxType.Box<A>;
+  }),
+};

--- a/apps/cli/src/components/Select.ts
+++ b/apps/cli/src/components/Select.ts
@@ -3,6 +3,7 @@ import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import { Hint } from "./Hint.js";
+import { PromptChrome } from "./Panel.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -59,20 +60,7 @@ export const Select = <A>(
 
     const content = Box.vcat([label, Box.vcat(items, Box.left)], Box.left);
 
-    return Box.vsep(
-      [
-        content.pipe(
-          Box.pad(0, 0, 0, 1),
-          Box.border("thick", {
-            annotation: Ansi.dim,
-            sides: { top: false, bottom: false, right: false },
-          }),
-        ),
-        Hint(SelectKeys),
-      ],
-      1,
-      Box.left,
-    ).pipe(Box.moveDown(1));
+    return Box.vcat([content.pipe(PromptChrome()), Hint(SelectKeys)], Box.left);
   };
 
   let hasRendered = false;

--- a/apps/cli/src/components/TextArea.ts
+++ b/apps/cli/src/components/TextArea.ts
@@ -4,6 +4,7 @@ import { Ansi, Box, Cmd } from "effect-boxes";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import * as Viewport from "../lib/Viewport.js";
 import { Hint } from "./Hint.js";
+import { Panel, PromptChrome } from "./Panel.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -156,7 +157,7 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         ...lineBoxes,
       ],
       Box.left,
-    ).pipe(Box.minHeight(minRows + 1), Box.minWidth(40), Box.border("rounded"));
+    ).pipe(Box.minHeight(minRows + 1), Box.minWidth(40), Panel.make());
 
     const content = Box.vcat([label, inputContent], Box.left);
 
@@ -167,20 +168,10 @@ export const TextArea = (options: TextAreaOptions): Prompt.Prompt<string> => {
         )
       : Hint(TextAreaKeys);
 
-    return Box.vsep(
-      [
-        content.pipe(
-          Box.pad(0, 0, 0, 1),
-          Box.border("thick", {
-            annotation: hasError ? Ansi.red : Ansi.dim,
-            sides: { top: false, bottom: false, right: false },
-          }),
-        ),
-        footer,
-      ],
-      1,
+    return Box.vcat(
+      [content.pipe(PromptChrome(hasError ? Ansi.red : Ansi.dim)), footer],
       Box.left,
-    ).pipe(Box.moveDown(1));
+    );
   };
 
   const initialLines = defaultValue ? splitLines(defaultValue) : [""];

--- a/apps/cli/src/components/TextInput.ts
+++ b/apps/cli/src/components/TextInput.ts
@@ -3,6 +3,7 @@ import { Prompt } from "effect/unstable/cli";
 import { Ansi, Box, Cmd } from "effect-boxes";
 import { KeyBinding, whenBinding } from "../lib/KeyBinding.js";
 import { Hint } from "./Hint.js";
+import { PromptChrome } from "./Panel.js";
 
 const Action = Data.taggedEnum<Prompt.ActionDefinition>();
 
@@ -110,20 +111,10 @@ export const TextInput = (
         )
       : Hint(TextInputKeys);
 
-    return Box.vsep(
-      [
-        content.pipe(
-          Box.pad(0, 0, 0, 1),
-          Box.border("thick", {
-            annotation: hasError ? Ansi.red : Ansi.dim,
-            sides: { top: false, bottom: false, right: false },
-          }),
-        ),
-        footer,
-      ],
-      1,
+    return Box.vcat(
+      [content.pipe(PromptChrome(hasError ? Ansi.red : Ansi.dim)), footer],
       Box.left,
-    ).pipe(Box.moveDown(1));
+    );
   };
 
   const initialState: TextState = {

--- a/apps/cli/src/lib/Layout.ts
+++ b/apps/cli/src/lib/Layout.ts
@@ -1,0 +1,385 @@
+/**
+ * Layout — responsive layout helpers built on top of Box.
+ *
+ * Provides container-aware composition primitives inspired by CSS Flexbox:
+ * - `Flex.row` / `Flex.col` — distribute space among children
+ * - `Breakpoint` — switch layout based on container width
+ * - `Container` — pass available dimensions to child builders
+ * - `Grid` — fixed-column grid layout
+ * - `Row` / `Col` — ergonomic wrappers for hsep/vsep
+ *
+ * All helpers are pure functions that return standard Box values,
+ * composable with existing Box primitives (border, annotate, pad, etc).
+ *
+ * @module
+ */
+import { Array as Arr, Order, pipe } from "effect";
+import { Box } from "effect-boxes";
+
+// ─── Flex Internals ──────────────────────────────────────────────────────────
+
+const flexFactor = <A>(child: FlexChild<A>): number =>
+  child._tag === "Fixed" ? 0 : child.factor;
+
+const flexFixedSize = <A>(
+  child: FlexChild<A>,
+  measure: (box: Box.Box<A>) => number,
+): number => (child._tag === "Fixed" ? measure(child.box) : 0);
+
+const resolveFlexChildren = <A>(
+  children: ReadonlyArray<FlexChild<A>>,
+  available: number,
+  totalFactor: number,
+  alignFn: (box: Box.Box<A>, size: number) => Box.Box<A>,
+): Box.Box<A>[] =>
+  Arr.map(children, (child) => {
+    if (child._tag === "Fixed") return child.box;
+    const size =
+      totalFactor > 0
+        ? Math.max(1, Math.floor((child.factor / totalFactor) * available))
+        : 1;
+    if (child._tag === "Fill") return child.builder(size);
+    return alignFn(child.box, size);
+  });
+
+// ─── Flex ────────────────────────────────────────────────────────────────────
+
+/**
+ * A flex child that occupies its intrinsic width/height.
+ */
+export interface FlexFixed<A = never> {
+  readonly _tag: "Fixed";
+  readonly box: Box.Box<A>;
+}
+
+/**
+ * A flex child that grows to fill remaining space.
+ * `factor` controls proportional distribution (default 1).
+ */
+export interface FlexGrow<A = never> {
+  readonly _tag: "Grow";
+  readonly box: Box.Box<A>;
+  readonly factor: number;
+}
+
+/**
+ * A flex child that fills remaining space via a builder function.
+ * The builder receives the allocated width/height so content can
+ * be constructed to fit exactly.
+ */
+export interface FlexFill<A = never> {
+  readonly _tag: "Fill";
+  readonly builder: (size: number) => Box.Box<A>;
+  readonly factor: number;
+}
+
+export type FlexChild<A = never> = FlexFixed<A> | FlexGrow<A> | FlexFill<A>;
+
+export const Flex = {
+  /**
+   * Mark a child as fixed-size (uses intrinsic width/height).
+   */
+  fixed: <A>(box: Box.Box<A>): FlexChild<A> => ({ _tag: "Fixed", box }),
+
+  /**
+   * Mark a child as growable — it will expand to fill remaining space.
+   * @param factor - Proportional growth factor (default 1)
+   */
+  grow: <A>(box: Box.Box<A>, factor = 1): FlexChild<A> => ({
+    _tag: "Grow",
+    box,
+    factor,
+  }),
+
+  /**
+   * Fill remaining space using a builder that receives the allocated size.
+   * Unlike `grow`, the builder can construct content that fills exactly.
+   * @param builder - Receives allocated width (for row) or height (for col)
+   * @param factor - Proportional growth factor (default 1)
+   */
+  fill: <A>(
+    builder: (size: number) => Box.Box<A>,
+    factor = 1,
+  ): FlexChild<A> => ({
+    _tag: "Fill",
+    builder,
+    factor,
+  }),
+
+  /**
+   * Lay out children horizontally within a fixed container width.
+   * Fixed children keep their intrinsic width; grow children share
+   * the remaining space proportionally.
+   *
+   * @example
+   * ```typescript
+   * Flex.row(80, [
+   *   Flex.fixed(Box.text("Name")),
+   *   Flex.grow(Box.text("...")),
+   *   Flex.fixed(Box.text("100%")),
+   * ])
+   * ```
+   */
+  row: <A>(
+    containerWidth: number,
+    children: ReadonlyArray<FlexChild<A>>,
+    options?: { readonly align?: Box.Alignment; readonly gap?: number },
+  ): Box.Box<A> => {
+    const align = options?.align ?? Box.top;
+    const gap = options?.gap ?? 0;
+
+    const totalGap = gap * Math.max(0, children.length - 1);
+    const fixedWidth = Arr.reduce(
+      children,
+      0,
+      (sum, c) => sum + flexFixedSize(c, Box.cols),
+    );
+    const available = Math.max(0, containerWidth - fixedWidth - totalGap);
+    const totalFactor = Arr.reduce(
+      children,
+      0,
+      (sum, c) => sum + flexFactor(c),
+    );
+
+    const sized = resolveFlexChildren(
+      children,
+      available,
+      totalFactor,
+      (box, w) => box.pipe(Box.alignHoriz(Box.left, w)),
+    );
+
+    return gap > 0 ? Box.hsep(sized, gap, align) : Box.hcat(sized, align);
+  },
+
+  /**
+   * Lay out children vertically within a fixed container height.
+   * Fixed children keep their intrinsic height; grow children share
+   * the remaining space proportionally.
+   */
+  col: <A>(
+    containerHeight: number,
+    children: ReadonlyArray<FlexChild<A>>,
+    options?: { readonly align?: Box.Alignment; readonly gap?: number },
+  ): Box.Box<A> => {
+    const align = options?.align ?? Box.left;
+    const gap = options?.gap ?? 0;
+
+    const totalGap = gap * Math.max(0, children.length - 1);
+    const fixedHeight = Arr.reduce(
+      children,
+      0,
+      (sum, c) => sum + flexFixedSize(c, Box.rows),
+    );
+    const available = Math.max(0, containerHeight - fixedHeight - totalGap);
+    const totalFactor = Arr.reduce(
+      children,
+      0,
+      (sum, c) => sum + flexFactor(c),
+    );
+
+    const sized = resolveFlexChildren(
+      children,
+      available,
+      totalFactor,
+      (box, h) => box.pipe(Box.alignVert(Box.top, h)),
+    );
+
+    return gap > 0 ? Box.vsep(sized, gap, align) : Box.vcat(sized, align);
+  },
+} as const;
+
+// ─── Breakpoint ──────────────────────────────────────────────────────────────
+
+export interface BreakpointEntry<A = never> {
+  /** Minimum container width for this layout to apply */
+  readonly minWidth: number;
+  /** Builder that produces the layout for this breakpoint */
+  readonly render: () => Box.Box<A>;
+}
+
+/**
+ * Select a layout based on container width (largest matching breakpoint wins).
+ * Entries are evaluated from largest minWidth to smallest.
+ *
+ * @example
+ * ```typescript
+ * Breakpoint.select(terminalWidth, [
+ *   { minWidth: 100, render: () => wideLayout },
+ *   { minWidth: 60,  render: () => mediumLayout },
+ *   { minWidth: 0,   render: () => narrowLayout },
+ * ])
+ * ```
+ */
+export const Breakpoint = {
+  select: <A>(
+    containerWidth: number,
+    entries: ReadonlyArray<BreakpointEntry<A>>,
+  ): Box.Box<A> =>
+    pipe(
+      entries,
+      Arr.sort(
+        Order.mapInput(
+          Order.flip(Order.Number),
+          (e: BreakpointEntry<A>) => e.minWidth,
+        ),
+      ),
+      Arr.findFirst((e) => containerWidth >= e.minWidth),
+      (match) => (match._tag === "Some" ? match.value.render() : Box.nullBox),
+    ),
+};
+
+// ─── Container ───────────────────────────────────────────────────────────────
+
+export interface ContainerContext {
+  /** Total container width */
+  readonly width: number;
+  /** Total container height (when known) */
+  readonly height: number;
+  /** Usable width after padding */
+  readonly innerWidth: number;
+  /** Usable height after padding */
+  readonly innerHeight: number;
+}
+
+/**
+ * Provide container dimensions to a child builder function.
+ * Automatically computes inner dimensions after padding.
+ *
+ * @example
+ * ```typescript
+ * Container.make(
+ *   { width: terminalWidth, height: terminalHeight, padding: 2 },
+ *   (ctx) => Flex.row(ctx.innerWidth, [
+ *     Flex.fixed(sidebar),
+ *     Flex.grow(mainContent),
+ *   ])
+ * )
+ * ```
+ */
+export const Container = {
+  make: <A>(
+    options: {
+      readonly width: number;
+      readonly height?: number;
+      readonly padding?: number | readonly [number, number];
+      readonly paddingX?: number;
+      readonly paddingY?: number;
+    },
+    builder: (ctx: ContainerContext) => Box.Box<A>,
+  ): Box.Box<A> => {
+    const height = options.height ?? 0;
+    const [py, px] =
+      options.padding != null
+        ? typeof options.padding === "number"
+          ? [options.padding, options.padding]
+          : options.padding
+        : [options.paddingY ?? 0, options.paddingX ?? 0];
+
+    const ctx: ContainerContext = {
+      width: options.width,
+      height,
+      innerWidth: Math.max(0, options.width - px * 2),
+      innerHeight: Math.max(0, height - py * 2),
+    };
+
+    const content = builder(ctx);
+    return py > 0 || px > 0 ? content.pipe(Box.pad(py, px)) : content;
+  },
+};
+
+// ─── Grid ────────────────────────────────────────────────────────────────────
+
+/**
+ * Arrange items in a fixed-column grid.
+ *
+ * @example
+ * ```typescript
+ * Grid.make(items.map(Box.text), {
+ *   cols: 3,
+ *   colWidth: 25,
+ *   gap: [1, 1],
+ * })
+ * ```
+ */
+export const Grid = {
+  make: <A>(
+    items: ReadonlyArray<Box.Box<A>>,
+    options: {
+      readonly cols: number;
+      readonly colWidth: number;
+      readonly gap?: readonly [number, number];
+      readonly align?: Box.Alignment;
+      readonly stretch?: boolean;
+    },
+  ): Box.Box<A> => {
+    const { cols, colWidth } = options;
+    const [hGap, vGap] = options.gap ?? [1, 0];
+    const align = options.align ?? Box.left;
+    const stretch = options.stretch ?? false;
+
+    const sizeCell = (item: Box.Box<A>) =>
+      stretch
+        ? item.pipe(Box.minWidth(colWidth), Box.alignHoriz(align, colWidth))
+        : item.pipe(Box.alignHoriz(align, colWidth));
+
+    const padRow = (row: Box.Box<A>[]): Box.Box<A>[] =>
+      row.length < cols
+        ? [
+            ...row,
+            ...Arr.makeBy(cols - row.length, () => Box.emptyBox(1, colWidth)),
+          ]
+        : row;
+
+    const rowBoxes = pipe(
+      Arr.chunksOf(items, cols),
+      Arr.map((chunk) =>
+        pipe(Arr.map(chunk, sizeCell), padRow, (cells) =>
+          Box.hsep(cells, hGap, Box.top),
+        ),
+      ),
+    );
+
+    return Box.vsep(rowBoxes, vGap, Box.left);
+  },
+
+  /**
+   * Auto-calculate column count from container width.
+   */
+  auto: <A>(
+    containerWidth: number,
+    items: ReadonlyArray<Box.Box<A>>,
+    options: {
+      /** Minimum width per column */
+      readonly minColWidth: number;
+      /** Maximum width per column (prevents over-stretching on wide terminals) */
+      readonly maxColWidth?: number;
+      /** Gap between columns */
+      readonly gap?: number;
+      /** Alignment within cells */
+      readonly align?: Box.Alignment;
+      /** Stretch items to fill cell width (default false) */
+      readonly stretch?: boolean;
+    },
+  ): Box.Box<A> => {
+    const gap = options.gap ?? 1;
+    const cols = Math.min(
+      items.length,
+      Math.max(
+        1,
+        Math.floor((containerWidth + gap) / (options.minColWidth + gap)),
+      ),
+    );
+    let colWidth = Math.floor((containerWidth - (cols - 1) * gap) / cols);
+    if (options.maxColWidth != null) {
+      colWidth = Math.min(colWidth, options.maxColWidth);
+    }
+
+    return Grid.make(items, {
+      cols,
+      colWidth,
+      gap: [gap, 0],
+      ...(options.align != null ? { align: options.align } : {}),
+      ...(options.stretch != null ? { stretch: options.stretch } : {}),
+    });
+  },
+} as const;


### PR DESCRIPTION
## Goals/Scope

Add reusable Panel and responsive Layout helpers for consistent TUI component structure.

## Description

- Introduce `Panel` and responsive `Layout` helper utilities.
- Refactor CLI/TUI components to use the new layout helpers for consistent rendering.

## Comment

Have used this to create feature requests in `effect-boxes` so that the Layout module could be added there as a core part of the library
