### PR TITLE
feat: add llm pipeline

### DIFF
--- a/.changeset/cute-banks-end.md
+++ b/.changeset/cute-banks-end.md
@@ -1,0 +1,16 @@
+---
+"stack-effect": minor
+---
+
+add `schema` command to serialize the catalog and plan input schema, closes #109
+
+Outputs a JSON object with the full catalog (targets, modules, dependencies, implications) and a JSON Schema for the `plan` command's stdin input. Designed for LLMs, CI pipelines, and external tooling to discover available scaffolding options programmatically:
+
+```bash
+  # Dump catalog and plan input schema
+  stack-effect schema
+
+  # Pipe into jq for inspection
+  stack-effect schema | jq '.catalog.targets'
+  stack-effect schema | jq '.planInput'
+```

--- a/.changeset/long-papayas-lay.md
+++ b/.changeset/long-papayas-lay.md
@@ -1,0 +1,18 @@
+---
+"stack-effect": minor
+---
+
+add `plan` command for non-interactive blueprint and plan generation, closes #102
+
+Reads a Selection + optional config from stdin, runs the Blueprint → Plan pipeline, and outputs structured JSON. Supports three output formats for different consumers:
+
+```bash
+  # Pipe a selection to get raw plan output
+  echo '{"selection":{"targets":[{"kind":"server","name":"api"}]}}' | stack-effect plan --root ./my-app
+
+  # Get an LLM-friendly format with resolved file contents
+  echo '{"selection":{"targets":[...]}}' | stack-effect plan -f llm
+
+  # Get a visual tree summary
+  echo '{"selection":{"targets":[...]}}' | stack-effect plan -f tree
+```

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -614,4 +614,24 @@ export const add = Command.make(
         }
       }),
     ),
+).pipe(
+  Command.withDescription(
+    "Incrementally add targets and modules to a scaffolded project. Resolves dependencies and implications automatically.",
+  ),
+  Command.withShortDescription("Add targets or modules to an existing project"),
+  Command.withExamples([
+    {
+      command: "stack-effect add",
+      description: "Interactively select targets and modules",
+    },
+    {
+      command: "stack-effect add --target server/api --modules http-api",
+      description: "Add a specific module to a target",
+    },
+    {
+      command:
+        "stack-effect add --yes --target package/domain --modules domain-api --dry-run",
+      description: "Non-interactive dry run for CI/LLM usage",
+    },
+  ]),
 );

--- a/apps/cli/src/commands/graph.ts
+++ b/apps/cli/src/commands/graph.ts
@@ -345,4 +345,19 @@ export const graph = Command.make("graph", { format: formatFlag }, (flags) =>
       }
     }
   }),
+).pipe(
+  Command.withDescription(
+    "Output the catalog dependency graph in table, Mermaid, or DOT format for visualization or tooling.",
+  ),
+  Command.withShortDescription("Visualize the module dependency graph"),
+  Command.withExamples([
+    {
+      command: "stack-effect graph --format mermaid",
+      description: "Output as Mermaid diagram syntax",
+    },
+    {
+      command: "stack-effect graph --format dot | dot -Tsvg -o graph.svg",
+      description: "Render as SVG via Graphviz",
+    },
+  ]),
 );

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -357,4 +357,23 @@ export const init = Command.make(
         config,
       });
     }),
+).pipe(
+  Command.withDescription(
+    "Scaffold a new Effect project in a subdirectory (or '.' for the current directory). Runs interactively unless --yes is passed.",
+  ),
+  Command.withShortDescription("Create a new project"),
+  Command.withExamples([
+    {
+      command: "stack-effect init my-app",
+      description: "Create a new project in ./my-app interactively",
+    },
+    {
+      command: "stack-effect init . --yes",
+      description: "Initialize in the current directory using the folder name",
+    },
+    {
+      command: "stack-effect init my-app --yes --package-manager bun --no-git",
+      description: "Non-interactive with explicit options",
+    },
+  ]),
 );

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -181,7 +181,9 @@ export const plan = Command.make(
   Command.withDescription(
     "Read a Selection (and optional config) from stdin, resolve dependencies, and output a structured plan. Designed for LLM and CI consumption.",
   ),
-  Command.withShortDescription("(for LLMs) Generate a scaffold plan from stdin"),
+  Command.withShortDescription(
+    "(for LLMs) Generate a scaffold plan from stdin",
+  ),
   Command.withExamples([
     {
       command:

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -177,4 +177,26 @@ export const plan = Command.make(
         onNone: () => Effect.succeed(Console.log(outputText)),
       });
     }),
+).pipe(
+  Command.withDescription(
+    "Read a Selection (and optional config) from stdin, resolve dependencies, and output a structured plan. Designed for LLM and CI consumption.",
+  ),
+  Command.withShortDescription("(for LLMs) Generate a scaffold plan from stdin"),
+  Command.withExamples([
+    {
+      command:
+        'echo \'{"selection":{"targets":[{"kind":"server","name":"api"}]}}\' | stack-effect plan',
+      description: "Output raw plan JSON",
+    },
+    {
+      command:
+        'echo \'{"selection":{"targets":[...]}}\' | stack-effect plan -f llm',
+      description: "LLM-friendly format with resolved file contents",
+    },
+    {
+      command:
+        'echo \'{"selection":{"targets":[...]}}\' | stack-effect plan -f tree',
+      description: "Visual tree summary",
+    },
+  ]),
 );

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -1,0 +1,180 @@
+import * as fs from "node:fs/promises";
+import { StackConfig } from "@repo/domain/Scaffold";
+import { Selection } from "@repo/domain/Selection";
+import {
+  BlueprintService,
+  FinalizeService,
+  PlanService,
+  renderPlanForLlm,
+  ScaffoldFormatter,
+} from "@repo/scaffold";
+import {
+  Array as Arr,
+  Console,
+  Effect,
+  FileSystem,
+  Match,
+  Option,
+  Schema,
+  Stream,
+} from "effect";
+import { Stdio } from "effect/Stdio";
+import { Command, Flag } from "effect/unstable/cli";
+import { Box } from "effect-boxes";
+import { rootFlag } from "../flags";
+import { ConfigureService } from "../service/ConfigureService";
+
+/**
+ * Reads a PlanInput from stdin, runs Blueprint → Plan, and outputs structured
+ * JSON suitable for LLM consumption.
+ *
+ * Stdin format:
+ * ```json
+ * {
+ *   "selection": { "targets": [...] },
+ *   "config": { "name": "my-app", "runtime": { "_tag": "bun" }, ... }
+ * }
+ * ```
+ *
+ * - `config` is optional when `stack.effect.json` exists at `--root`
+ * - For greenfield (no existing config), `config` must be provided in stdin
+ *
+ * Output formats:
+ * - `llm` (default): resolved file contents + natural-language edit instructions
+ * - `raw`: outcomes/conflicts/finalize with composed operations
+ * - `tree`: visual tree summary for human review
+ */
+
+const PlanInput = Schema.Struct({
+  selection: Selection,
+  config: Schema.optional(StackConfig),
+});
+
+const formatFlag = Flag.choice("format", ["llm", "raw", "tree"]).pipe(
+  Flag.optional,
+  Flag.withAlias("f"),
+  Flag.withDescription("Output format: llm (default), raw, or tree"),
+);
+
+const outputFlag = Flag.string("output").pipe(
+  Flag.optional,
+  Flag.withAlias("o"),
+  Flag.withDescription("Write output to a file instead of stdout"),
+);
+
+export const plan = Command.make(
+  "plan",
+  { root: rootFlag, format: formatFlag, output: outputFlag },
+  (flags) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const repoRoot = Option.getOrElse(flags.root, () => process.cwd());
+      const format = Option.getOrElse(flags.format, () => "llm" as const);
+
+      // Read PlanInput from stdin
+      const stdio = yield* Stdio;
+      const stdin = yield* stdio.stdin.pipe(
+        Stream.decodeText(),
+        Stream.mkString,
+      );
+      const input = yield* Schema.decodeUnknownEffect(
+        Schema.fromJsonString(PlanInput),
+      )(stdin);
+
+      // Resolve config: stdin > file > fail
+      const configureService = yield* ConfigureService;
+      const fileConfig = yield* configureService
+        .readConfig(repoRoot)
+        .pipe(Effect.catch(() => Effect.succeed(undefined)));
+
+      const config = input.config ?? fileConfig;
+      if (!config) {
+        return yield* Effect.die(
+          "No config found. Provide 'config' in stdin or ensure stack.effect.json exists at --root.",
+        );
+      }
+
+      // Blueprint: resolve dependency closure from Selection
+      const blueprintService = yield* BlueprintService;
+      const blueprint = yield* blueprintService.resolve(input.selection);
+
+      // Plan: assess outcomes against repo state
+      const planService = yield* PlanService;
+      const planResult = yield* planService.build({
+        blueprint,
+        repoRoot,
+        config,
+      });
+
+      // Finalize: collect post-scaffold scripts
+      const finalizeService = yield* FinalizeService;
+      const scripts = yield* finalizeService
+        .preview(blueprint, { repoRoot, config })
+        .pipe(
+          Effect.catch(() =>
+            Effect.succeed([] as Array<{ label: string; command: string }>),
+          ),
+        );
+
+      const finalize = scripts.map((s) => ({
+        label: s.label,
+        command: s.command,
+      }));
+
+      // Compute summary and tree
+      const formatter = yield* ScaffoldFormatter;
+      const formattedPlan = yield* formatter.formatPlan(planResult);
+      const tree = Box.renderPlainSync(formattedPlan.tree);
+
+      const summary = Arr.reduce(
+        planResult.outcomes,
+        { total: 0, create: 0, modify: 0, unchanged: 0, conflict: 0 },
+        (acc, outcome) => ({
+          ...acc,
+          total: acc.total + 1,
+          [outcome.classification]: acc[outcome.classification] + 1,
+        }),
+      );
+
+      // Output based on format
+      const outputText = yield* Match.value(format).pipe(
+        Match.when("tree", () =>
+          Box.renderPlain(
+            Box.hcat(
+              [Box.text(formattedPlan.summary), formattedPlan.tree],
+              Box.left,
+            ),
+          ),
+        ),
+        Match.when("llm", () =>
+          Schema.encodeEffect(Schema.UnknownFromJsonString)(
+            renderPlanForLlm({
+              outcomes: planResult.outcomes,
+              conflicts: planResult.conflicts,
+              finalize,
+              summary,
+              tree,
+            }),
+          ),
+        ),
+        Match.when("raw", () =>
+          Schema.encodeEffect(Schema.UnknownFromJsonString)({
+            outcomes: planResult.outcomes,
+            conflicts: planResult.conflicts,
+            summary,
+            finalize,
+            tree,
+          }),
+        ),
+        Match.exhaustive,
+      );
+
+      yield* Option.match(flags.output, {
+        onSome: Effect.fnUntraced(function* (outputPath) {
+          yield* fs.writeFileString(outputPath, outputText);
+          yield* Console.log(`Plan written to ${outputPath}`);
+        }),
+        onNone: () => Effect.succeed(Console.log(outputText)),
+      });
+    }),
+);

--- a/apps/cli/src/commands/schema.ts
+++ b/apps/cli/src/commands/schema.ts
@@ -1,7 +1,7 @@
 import { CatalogService } from "@repo/catalog";
 import { StackConfig } from "@repo/domain/Scaffold";
 import { Selection } from "@repo/domain/Selection";
-import { Console, Effect, Match, Schema } from "effect";
+import { Console, Effect, Schema } from "effect";
 import { Command } from "effect/unstable/cli";
 
 const PlanInput = Schema.Struct({
@@ -12,82 +12,28 @@ const PlanInput = Schema.Struct({
 /**
  * Serializes the catalog for external consumption (LLMs, CI, tooling).
  *
- * Outputs a JSON object with `targets`, `modules`, and `selection` keys.
- * - `targets`: available target kinds with metadata and dependency info
- * - `modules`: available modules with supported targets, dependencies, implications
- * - `selection`: JSON Schema for the Selection input accepted by `plan`
+ * Outputs a JSON object with:
+ * - `catalog`: tree-structured catalog (targets with nested modules)
+ * - `planInput`: JSON Schema for the Selection input accepted by `plan`
  */
 export const schema = Command.make("schema", {}, () =>
   Effect.gen(function* () {
     const catalog = yield* CatalogService;
 
-    const targets = yield* Effect.forEach(catalog.getTargetKinds(), (kind) =>
-      Effect.gen(function* () {
-        const def = yield* catalog.getTarget(kind);
-        return {
-          kind: def.kind,
-          title: def.title,
-          description: def.description,
-          visibility: def.visibility ?? "public",
-          requiredModules: def.requiredModules ?? [],
-        };
-      }),
-    );
-
-    const modules = catalog.getModules().map((def) => ({
-      id: def.id,
-      title: def.title,
-      description: def.description,
-      visibility: def.visibility ?? "public",
-      categories: def.categories ?? [],
-      supportedOn: (def.supportedOn ?? []).map(
-        Match.type<(typeof def.supportedOn)[number]>().pipe(
-          Match.tag("kind", (s) => ({ _tag: "kind" as const, kind: s.kind })),
-          Match.tag("identity", (s) => ({
-            _tag: "identity" as const,
-            kind: s.identity.kind,
-            name: s.identity.name,
-          })),
-          Match.exhaustive,
-        ),
-      ),
-      dependencies: (def.dependencies ?? []).map(
-        Match.type<(typeof def.dependencies)[number]>().pipe(
-          Match.tag("required-target", (d) => ({
-            _tag: "required-target" as const,
-            kind: d.identity.kind,
-            name: d.identity.name,
-          })),
-          Match.tag("required-module", (d) => ({
-            _tag: "required-module" as const,
-            target: { kind: d.target.kind, name: d.target.name },
-            moduleId: d.moduleId,
-          })),
-          Match.exhaustive,
-        ),
-      ),
-      implies: (def.implies ?? []).map((imp) => ({
-        targetKind: imp.targetKind,
-        moduleId: imp.moduleId,
-      })),
-    }));
     const planInput = Schema.toStandardJSONSchemaV1(PlanInput)[
       "~standard"
     ].jsonSchema.input({ target: "draft-2020-12" });
 
     yield* Console.log(
       Schema.encodeSync(Schema.UnknownFromJsonString)({
-        catalog: {
-          targets,
-          modules,
-        },
+        catalog: catalog.toCatalogTree,
         planInput,
       }),
     );
   }),
 ).pipe(
   Command.withDescription(
-    "Serialize the full catalog (targets, modules, dependencies) and the JSON Schema for plan input. Useful for LLMs, CI, and external tooling.",
+    "Serialize the full catalog (targets with nested modules) and the JSON Schema for plan input. Useful for LLMs, CI, and external tooling.",
   ),
   Command.withShortDescription(
     "(for LLMs) Export catalog and input schema as JSON",

--- a/apps/cli/src/commands/schema.ts
+++ b/apps/cli/src/commands/schema.ts
@@ -85,4 +85,21 @@ export const schema = Command.make("schema", {}, () =>
       }),
     );
   }),
+).pipe(
+  Command.withDescription(
+    "Serialize the full catalog (targets, modules, dependencies) and the JSON Schema for plan input. Useful for LLMs, CI, and external tooling.",
+  ),
+  Command.withShortDescription(
+    "(for LLMs) Export catalog and input schema as JSON",
+  ),
+  Command.withExamples([
+    {
+      command: "stack-effect schema",
+      description: "Output full catalog and plan input schema",
+    },
+    {
+      command: "stack-effect schema | jq '.catalog.targets'",
+      description: "Inspect available targets",
+    },
+  ]),
 );

--- a/apps/cli/src/commands/schema.ts
+++ b/apps/cli/src/commands/schema.ts
@@ -1,0 +1,88 @@
+import { CatalogService } from "@repo/catalog";
+import { StackConfig } from "@repo/domain/Scaffold";
+import { Selection } from "@repo/domain/Selection";
+import { Console, Effect, Match, Schema } from "effect";
+import { Command } from "effect/unstable/cli";
+
+const PlanInput = Schema.Struct({
+  selection: Selection,
+  config: Schema.optional(StackConfig),
+});
+
+/**
+ * Serializes the catalog for external consumption (LLMs, CI, tooling).
+ *
+ * Outputs a JSON object with `targets`, `modules`, and `selection` keys.
+ * - `targets`: available target kinds with metadata and dependency info
+ * - `modules`: available modules with supported targets, dependencies, implications
+ * - `selection`: JSON Schema for the Selection input accepted by `plan`
+ */
+export const schema = Command.make("schema", {}, () =>
+  Effect.gen(function* () {
+    const catalog = yield* CatalogService;
+
+    const targets = yield* Effect.forEach(catalog.getTargetKinds(), (kind) =>
+      Effect.gen(function* () {
+        const def = yield* catalog.getTarget(kind);
+        return {
+          kind: def.kind,
+          title: def.title,
+          description: def.description,
+          visibility: def.visibility ?? "public",
+          requiredModules: def.requiredModules ?? [],
+        };
+      }),
+    );
+
+    const modules = catalog.getModules().map((def) => ({
+      id: def.id,
+      title: def.title,
+      description: def.description,
+      visibility: def.visibility ?? "public",
+      categories: def.categories ?? [],
+      supportedOn: (def.supportedOn ?? []).map(
+        Match.type<(typeof def.supportedOn)[number]>().pipe(
+          Match.tag("kind", (s) => ({ _tag: "kind" as const, kind: s.kind })),
+          Match.tag("identity", (s) => ({
+            _tag: "identity" as const,
+            kind: s.identity.kind,
+            name: s.identity.name,
+          })),
+          Match.exhaustive,
+        ),
+      ),
+      dependencies: (def.dependencies ?? []).map(
+        Match.type<(typeof def.dependencies)[number]>().pipe(
+          Match.tag("required-target", (d) => ({
+            _tag: "required-target" as const,
+            kind: d.identity.kind,
+            name: d.identity.name,
+          })),
+          Match.tag("required-module", (d) => ({
+            _tag: "required-module" as const,
+            target: { kind: d.target.kind, name: d.target.name },
+            moduleId: d.moduleId,
+          })),
+          Match.exhaustive,
+        ),
+      ),
+      implies: (def.implies ?? []).map((imp) => ({
+        targetKind: imp.targetKind,
+        moduleId: imp.moduleId,
+      })),
+    }));
+    const planInput = Schema.toStandardJSONSchemaV1(PlanInput)[
+      "~standard"
+    ].jsonSchema.input({ target: "draft-2020-12" });
+
+    yield* Console.log(
+      Schema.encodeSync(Schema.UnknownFromJsonString)({
+        catalog: {
+          targets,
+          modules,
+        },
+        planInput,
+      }),
+    );
+  }),
+);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,7 @@ import { Ansi, Box } from "effect-boxes";
 import { add } from "./commands/add";
 import { graph } from "./commands/graph";
 import { init } from "./commands/init";
+import { plan } from "./commands/plan";
 import { schema } from "./commands/schema";
 import { ConfigureService } from "./service/ConfigureService";
 import { ScaffoldPipeline } from "./service/ScaffoldPipeline";
@@ -43,7 +44,7 @@ const MainLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(PlatformLayer));
 
 const program = root.pipe(
-  Command.withSubcommands([init, add, graph, schema]),
+  Command.withSubcommands([init, add, graph, plan, schema]),
   Command.run({ version: "1.0.0" }),
   Effect.provide(MainLayer),
   Effect.catchCause((cause) => {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -30,7 +30,11 @@ const PlatformLayer = Layer.unwrap(
   }),
 );
 
-const root = Command.make("stack-effect");
+const root = Command.make("stack-effect").pipe(
+  Command.withDescription(
+    "Interactive CLI for scaffolding and extending Effect-powered TypeScript projects. Compose targets (server, client, cli, package) with incrementally-addable modules.",
+  ),
+);
 
 const MainLayer = Layer.mergeAll(
   ApplyService.layer,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,7 @@ import { Ansi, Box } from "effect-boxes";
 import { add } from "./commands/add";
 import { graph } from "./commands/graph";
 import { init } from "./commands/init";
+import { schema } from "./commands/schema";
 import { ConfigureService } from "./service/ConfigureService";
 import { ScaffoldPipeline } from "./service/ScaffoldPipeline";
 
@@ -42,7 +43,7 @@ const MainLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(PlatformLayer));
 
 const program = root.pipe(
-  Command.withSubcommands([init, add, graph]),
+  Command.withSubcommands([init, add, graph, schema]),
   Command.run({ version: "1.0.0" }),
   Effect.provide(MainLayer),
   Effect.catchCause((cause) => {

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogGraph,
+  CatalogTree,
   ModuleCategory,
   ModuleId,
   ModuleImplication,
@@ -8,7 +9,15 @@ import type {
   Visibility,
 } from "@repo/domain/Catalog";
 import { CatalogNotFound } from "@repo/domain/Catalog";
-import { Array as Arr, Context, Effect, Graph, Layer, Match } from "effect";
+import {
+  Array as Arr,
+  Context,
+  Effect,
+  Graph,
+  Layer,
+  Match,
+  Result,
+} from "effect";
 import { moduleRegistry } from "./registry/moduleRegistry";
 import { targetRegistry } from "./registry/targetRegistry";
 
@@ -200,6 +209,44 @@ export class CatalogService extends Context.Service<CatalogService>()(
           return true;
         });
 
+      const toCatalogTree: typeof CatalogTree.Type = {
+        targets: Arr.map(Arr.fromIterable(targetIndex.values()), (target) => ({
+          kind: target.kind,
+          title: target.title,
+          description: target.description,
+          requiredModules: target.requiredModules ?? [],
+          modules: Arr.filterMap(
+            Arr.fromIterable(moduleIndex.values()),
+            (mod) => {
+              const supported = Arr.some(
+                mod.supportedOn,
+                (s) => supportedOnTargetKind(s) === target.kind,
+              );
+              if (!supported) return Result.fail("skip" as const);
+              return Result.succeed({
+                id: mod.id,
+                title: mod.title,
+                description: mod.description,
+                categories: mod.categories ?? [],
+                requires: Arr.filterMap(mod.dependencies, (dep) => {
+                  if (dep._tag !== "required-module")
+                    return Result.fail("skip" as const);
+                  return Result.succeed({
+                    targetKind: dep.target.kind,
+                    targetName: dep.target.name,
+                    moduleId: dep.moduleId,
+                  });
+                }),
+                implies: (mod.implies ?? []).map((imp) => ({
+                  targetKind: imp.targetKind,
+                  moduleId: imp.moduleId,
+                })),
+              });
+            },
+          ),
+        })),
+      };
+
       return {
         getImplications,
         getModules,
@@ -209,6 +256,7 @@ export class CatalogService extends Context.Service<CatalogService>()(
         getTargetKinds,
         isSupportedOn,
         isImpliedByAny,
+        toCatalogTree,
         toGraph,
       };
     }),

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -283,3 +283,47 @@ export type CatalogGraph = Graph.DirectedGraph<
   typeof CatalogNode.Type,
   typeof CatalogEdge.Type
 >;
+
+// =============================================================================
+// Catalog Tree (selection-oriented view)
+// =============================================================================
+
+/**
+ * A module entry within the catalog tree, showing what it requires and implies
+ * so an LLM can understand the consequences of selecting it.
+ */
+export const CatalogTreeModule = Schema.Struct({
+  id: ModuleId,
+  title: Schema.String,
+  description: Schema.String,
+  categories: Schema.Array(ModuleCategory),
+  requires: Schema.Array(
+    Schema.Struct({
+      targetKind: TargetKind,
+      targetName: Schema.String,
+      moduleId: ModuleId,
+    }),
+  ),
+  implies: Schema.Array(ModuleImplication),
+});
+
+/**
+ * A target node in the catalog tree with its available modules nested inside.
+ * This makes it trivial to see "for target X, I can pick modules [A, B, C]"
+ * along with their dependency/implication edges.
+ */
+export const CatalogTreeTarget = Schema.Struct({
+  kind: TargetKind,
+  title: Schema.String,
+  description: Schema.String,
+  requiredModules: Schema.Array(ModuleId),
+  modules: Schema.Array(CatalogTreeModule),
+});
+
+/**
+ * The full catalog as a tree: targets at the top level, modules nested within.
+ * Designed for LLM consumption where the question is "what can I select?"
+ */
+export const CatalogTree = Schema.Struct({
+  targets: Schema.Array(CatalogTreeTarget),
+});

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -69,15 +69,27 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
         ? this.identity.name
         : this.identity.kind;
 
-    return template
-      .replaceAll("{{targetPath}}", this.identity.toPath())
-      .replaceAll("{{targetDir}}", this.identity.toPath())
-      .replaceAll("{{targetKind}}", this.identity.kind)
-      .replaceAll("{{targetName}}", resolvedTargetName)
-      .replaceAll("{{packageName}}", this.identity.toPackageName())
-      .replaceAll("{{runtime}}", this.config.runtimeName)
-      .replaceAll("{{packageManager}}", this.config.packageManagerName)
-      .replaceAll("{{packageManagerSpec}}", this.config.packageManagerSpec)
-      .replaceAll("{{projectName}}", this.config.name);
+    const targetPath = this.identity.toPath();
+    // When targetPath is "." (init target), avoid producing "./foo" paths —
+    // strip the leading "./" so paths stay consistent with module contributions.
+    const resolveTargetToken = (t: string, token: string) =>
+      targetPath === "."
+        ? t.replaceAll(`${token}/`, "").replaceAll(token, "")
+        : t.replaceAll(token, targetPath);
+
+    return resolveTargetToken(
+      resolveTargetToken(
+        template
+          .replaceAll("{{targetKind}}", this.identity.kind)
+          .replaceAll("{{targetName}}", resolvedTargetName)
+          .replaceAll("{{packageName}}", this.identity.toPackageName())
+          .replaceAll("{{runtime}}", this.config.runtimeName)
+          .replaceAll("{{packageManager}}", this.config.packageManagerName)
+          .replaceAll("{{packageManagerSpec}}", this.config.packageManagerSpec)
+          .replaceAll("{{projectName}}", this.config.name),
+        "{{targetDir}}",
+      ),
+      "{{targetPath}}",
+    );
   }
 }

--- a/packages/scaffold/src/index.ts
+++ b/packages/scaffold/src/index.ts
@@ -6,5 +6,11 @@ export {
 } from "./service/finalize/FinalizeService";
 export { ContributionResolver } from "./service/plan/ContributionResolver";
 export { PlanAssessor } from "./service/plan/PlanAssessor";
+export {
+  type LlmFileOutcome,
+  type LlmPlanOutput,
+  type LlmPlanSummary,
+  renderPlanForLlm,
+} from "./service/plan/PlanRenderer";
 export { PlanService } from "./service/plan/PlanService";
 export { ScaffoldFormatter } from "./service/ScaffolFormatter";

--- a/packages/scaffold/src/service/plan/PlanRenderer.ts
+++ b/packages/scaffold/src/service/plan/PlanRenderer.ts
@@ -1,0 +1,195 @@
+import {
+  CompositionOperation,
+  type PlanConflict,
+  type PlanOutcome,
+} from "@repo/domain/Plan";
+import { Array, Effect, Match, pipe } from "effect";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A file outcome fully resolved for LLM consumption.
+ *
+ * - `create`: the file does not exist; write `contents` verbatim.
+ * - `modify`: the file exists; apply `instructions` to the current contents.
+ *
+ * For brownfield repos, `instructions` describe atomic edits the LLM should
+ * make to an existing file rather than overwriting it entirely.
+ */
+export interface LlmFileOutcome {
+  readonly path: string;
+  readonly classification: string;
+  readonly contents: string | undefined;
+  readonly instructions: ReadonlyArray<string>;
+}
+
+export interface LlmPlanSummary {
+  readonly total: number;
+  readonly create: number;
+  readonly modify: number;
+  readonly unchanged: number;
+  readonly conflict: number;
+}
+
+export interface LlmPlanOutput {
+  readonly summary: LlmPlanSummary;
+  readonly tree: string;
+  readonly files: ReadonlyArray<LlmFileOutcome>;
+  readonly conflicts: ReadonlyArray<{
+    readonly path: string;
+    readonly kind: string;
+    readonly description: string;
+  }>;
+  readonly finalize: ReadonlyArray<{
+    readonly label: string;
+    readonly command: string;
+  }>;
+}
+
+// =============================================================================
+// Operation → Instruction Rendering
+// =============================================================================
+
+const renderOperation = (
+  path: string,
+  op: typeof CompositionOperation.Type,
+): string =>
+  Match.value(op).pipe(
+    Match.tag("json-pkg-exports", (o) => {
+      const entries = o.entries
+        .map((e) => `  "${e.name}": "${e.value}"`)
+        .join("\n");
+      return `In \`${path}\`, add these entries to the "exports" field:\n${entries}`;
+    }),
+    Match.tag("json-pkg-deps", (o) => {
+      const entries = o.entries
+        .map((e) => `  "${e.name}": "${e.value}"`)
+        .join("\n");
+      return `In \`${path}\`, add these packages to "${o.section}":\n${entries}`;
+    }),
+    Match.tag("json-pkg-scripts", (o) => {
+      const entries = o.entries
+        .map((e) => `  "${e.name}": "${e.value}"`)
+        .join("\n");
+      return `In \`${path}\`, add these scripts:\n${entries}`;
+    }),
+    Match.tag("ts-add-import", (o) => {
+      const specifiers = o.namedImports
+        ? `{ ${o.namedImports.join(", ")} }`
+        : (o.defaultImport ?? "*");
+      const typePrefix = o.typeOnly ? "type " : "";
+      return `In \`${path}\`, add import: \`import ${typePrefix}${specifiers} from "${o.moduleSpecifier}"\``;
+    }),
+    Match.tag("ts-add-reexport", (o) => {
+      const specifiers = o.namedExports
+        ? `{ ${o.namedExports.join(", ")} }`
+        : "*";
+      const typePrefix = o.typeOnly ? "type " : "";
+      return `In \`${path}\`, add re-export: \`export ${typePrefix}${specifiers} from "${o.moduleSpecifier}"\``;
+    }),
+    Match.tag("ts-append-call-arg", (o) => {
+      return `In \`${path}\`, find \`const ${o.targetVariable} = ${o.functionName}(...)\` and append \`${o.argument}\` as an additional argument`;
+    }),
+    Match.exhaustive,
+  );
+
+// =============================================================================
+// Conflict Rendering
+// =============================================================================
+
+const renderConflict = (
+  conflict: typeof PlanConflict.Type,
+): { path: string; kind: string; description: string } =>
+  Match.value(conflict).pipe(
+    Match.tag("exports", (c) => ({
+      path: c.path,
+      kind: "exports",
+      description: `Export entry "${c.name}" already exists in ${c.path}`,
+    })),
+    Match.tag("dependencies", (c) => ({
+      path: c.path,
+      kind: "dependencies",
+      description: `Package "${c.name}" already exists in ${c.section} of ${c.path}`,
+    })),
+    Match.tag("scripts", (c) => ({
+      path: c.path,
+      kind: "scripts",
+      description: `Script "${c.name}" already exists in ${c.path}`,
+    })),
+    Match.tag("barrelExport", (c) => ({
+      path: c.path,
+      kind: "barrel-export",
+      description: `Re-export of "${c.exportPath}" already exists in ${c.path}`,
+    })),
+    Match.tag("tsconfig", (c) => ({
+      path: c.path,
+      kind: "tsconfig",
+      description: `TypeScript config at ${c.path} already exists and may need manual merging`,
+    })),
+    Match.tag("completeFile", (c) => ({
+      path: c.path,
+      kind: "file-exists",
+      description: `File ${c.path} already exists; review and merge manually`,
+    })),
+    Match.tag("compositionTargetNotFound", (c) => ({
+      path: c.path,
+      kind: "target-not-found",
+      description: `Cannot find \`const ${c.targetVariable} = ${c.functionName}(...)\` in ${c.path}; add the argument manually`,
+    })),
+    Match.exhaustive,
+  );
+
+// =============================================================================
+// Plan Renderer
+// =============================================================================
+
+/**
+ * Render a Plan into LLM-consumable output.
+ *
+ * For `complete` outcomes: pass through contents directly.
+ * For `composed` outcomes: render operations as edit instructions.
+ *
+ * When classification is "create", the LLM should write the seed + apply
+ * instructions. When "modify" or "conflict", the LLM should read the
+ * existing file and apply instructions to it.
+ */
+export const renderPlanForLlm = (plan: {
+  outcomes: ReadonlyArray<typeof PlanOutcome.Type>;
+  conflicts: ReadonlyArray<typeof PlanConflict.Type>;
+  finalize?: ReadonlyArray<{ label: string; command: string }>;
+  summary: LlmPlanSummary;
+  tree: string;
+}): LlmPlanOutput => {
+  const files: Array<LlmFileOutcome> = pipe(
+    plan.outcomes,
+    Array.map((outcome) =>
+      Match.value(outcome).pipe(
+        Match.tag("complete", (o) => ({
+          path: o.path,
+          classification: o.classification,
+          contents: o.contents,
+          instructions: [] as ReadonlyArray<string>,
+        })),
+        Match.tag("composed", (o) => ({
+          path: o.path,
+          classification: o.classification,
+          contents: o.seedContents,
+          instructions: o.operations.map((op) => renderOperation(o.path, op)),
+        })),
+        Match.exhaustive,
+      ),
+    ),
+  );
+
+  const conflicts = pipe(plan.conflicts, Array.map(renderConflict));
+
+  return {
+    summary: plan.summary,
+    tree: plan.tree,
+    files,
+    conflicts,
+    finalize: plan.finalize ?? [],
+  };
+};


### PR DESCRIPTION
## Goals/Scope

Add new CLI commands for interacting with LLM-related data and structured outputs.

## Description

- Add `schema` CLI command to generate schema options for target and module
- Add `plan` CLI command to generate structured LLM output.
- Refactor CLI command descriptions for improved clarity.
- Refactor output for catalog tree and simplify schema.