### PR TITLE
fix: correct shadcn config filename and deduplicate finalize scripts

### DIFF
--- a/.changeset/fine-dragons-worry.md
+++ b/.changeset/fine-dragons-worry.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+correct shadcn config filename and deduplicate finalize scripts

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -94,7 +94,7 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
       },
       {
         _tag: "file",
-        path: "{{targetPath}}/component.json",
+        path: "{{targetPath}}/components.json",
         contents: clientShadcnComponentJson,
       },
       {

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -96,13 +96,28 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
         return [...targetScripts, ...moduleScripts];
       });
 
+      const deduplicateScripts = (
+        scripts: ReadonlyArray<ResolvedScript>,
+      ): ResolvedScript[] => {
+        const seen = new Set<string>();
+        return scripts.filter((s) => {
+          const key = `${s.command}::${s.workdir}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      };
+
       const run = Effect.fn("FinalizeService.run")(function* (
         blueprint: typeof Blueprint.Type,
         config: FinalizeConfig,
       ) {
         const scripts = yield* collectResolvedScripts(blueprint, config);
         const configScripts = buildConfigDerivedScripts(config);
-        const allScripts = orderScripts(scripts, configScripts);
+        const allScripts = orderScripts(
+          deduplicateScripts(scripts),
+          configScripts,
+        );
 
         return allScripts.map((script) => ({
           script,
@@ -116,7 +131,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
       ) {
         const scripts = yield* collectResolvedScripts(blueprint, config);
         const configScripts = buildConfigDerivedScripts(config);
-        return orderScripts(scripts, configScripts).map(
+        return orderScripts(deduplicateScripts(scripts), configScripts).map(
           ({ label, command, phase, origin }) => ({
             label,
             command,


### PR DESCRIPTION
- Correct the Shadcn config filename in the catalog setup
- Deduplicate the “finalize” scripts to avoid repeated execution