### PR TITLE
refactor: rename to client-react

### DIFF
--- a/.changeset/rename-client-react.md
+++ b/.changeset/rename-client-react.md
@@ -1,0 +1,9 @@
+---
+"stack-effect": patch
+---
+
+rename `client` target kind to `client-react` and prefix client module IDs with `react`
+
+- `http-api-client` becomes `http-api-react-client`
+- `http-rpc-client` becomes `http-rpc-react-client`
+- `ws-presence-client` becomes `ws-presence-react-client`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ bun run start -- init smoke-app --yes --root "$TMP_REPO"
 bun run start -- add --yes --root "$TMP_REPO" --target package/domain --modules domain-api --dry-run
 
 # 3) Optional negative test: cross-target implication should fail in non-interactive mode
-bun run start -- add --yes --root "$TMP_REPO" --target client/web --modules http-api-client --dry-run
+bun run start -- add --yes --root "$TMP_REPO" --target client-react/web --modules http-api-react-client --dry-run
 ```
 
 Notes:

--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -57,7 +57,7 @@ describe("add", () => {
             "--root",
             root,
             "--target",
-            "client/web",
+            "client-react/web",
             "--modules",
             "http-api-client",
           );
@@ -140,7 +140,7 @@ describe("add", () => {
             "--root",
             root,
             "--target",
-            "client/web",
+            "client-react/web",
             "--modules",
             "http-api-client",
             "--dry-run",

--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -59,7 +59,7 @@ describe("add", () => {
             "--target",
             "client-react/web",
             "--modules",
-            "http-api-client",
+            "http-api-react-client",
           );
           yield* cli.expectExitCode(1);
           yield* cli.expectOutputContaining("implies");
@@ -142,7 +142,7 @@ describe("add", () => {
             "--target",
             "client-react/web",
             "--modules",
-            "http-api-client",
+            "http-api-react-client",
             "--dry-run",
           );
           yield* cli.expectExitCode(0);

--- a/apps/cli/e2e/matrix.test.ts
+++ b/apps/cli/e2e/matrix.test.ts
@@ -25,7 +25,7 @@ interface MatrixEntry {
  */
 const defaultTargetNames = new Map([
   ["server", "api"],
-  ["client", "web"],
+  ["client-react", "web"],
   ["cli", "app"],
   ["package", "domain"], // fallback; overridden by identity modules
 ]);
@@ -105,7 +105,7 @@ const matrix = Effect.runSync(
 
 // Separate entries that have cross-target implications (client modules)
 const singleTargetEntries = matrix.filter(
-  (e) => !e.target.startsWith("client"),
+  (e) => !e.target.startsWith("client-react"),
 );
 
 // ---------------------------------------------------------------------------
@@ -116,7 +116,7 @@ const buildFullStackMatrix = Effect.gen(function* () {
   const catalog = yield* CatalogService;
 
   const clientModules = yield* catalog.getSupportedModules(
-    TargetKind.make("client"),
+    TargetKind.make("client-react"),
   );
 
   return Arr.map(clientModules, (clientMod) => {
@@ -132,7 +132,7 @@ const buildFullStackMatrix = Effect.gen(function* () {
         label: `full-stack: ${clientMod.id} → server [${serverModuleIds.join(", ")}]`,
         serverTarget: `server/${defaultTargetNames.get("server")}`,
         serverModules: serverModuleIds,
-        clientTarget: `client/${defaultTargetNames.get("client")}`,
+        clientTarget: `client-react/${defaultTargetNames.get("client-react")}`,
         clientModules: [clientMod.id],
       };
     }
@@ -279,7 +279,7 @@ describe("matrix", () => {
             "--root",
             root,
             "--target",
-            `client/${defaultTargetNames.get("client")}`,
+            `client-react/${defaultTargetNames.get("client-react")}`,
             "--modules",
             allClientModules.join(","),
           );

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -26,7 +26,7 @@ interface CollectedTarget {
 const targetFlag = Flag.string("target").pipe(
   Flag.optional,
   Flag.withDescription(
-    "Target identity as <targetKind>/<targetName>, e.g. client/web",
+    "Target identity as <targetKind>/<targetName>, e.g. client-react/web",
   ),
 );
 

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -28,7 +28,7 @@ import {
  */
 export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
-    id: ModuleId.make("http-api-client"),
+    id: ModuleId.make("http-api-react-client"),
     title: "HTTP API Client",
     description: "REST API client with Effect Atom and typed HttpApiClient",
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
@@ -89,7 +89,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
   },
   {
-    id: ModuleId.make("http-rpc-client"),
+    id: ModuleId.make("http-rpc-react-client"),
     title: "HTTP RPC Client",
     description: "RPC streaming client with tick atom and UI",
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
@@ -155,7 +155,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
   },
   {
-    id: ModuleId.make("chat-client"),
+    id: ModuleId.make("chat-react-client"),
     title: "Chat Client",
     description: "AI chat UI with streaming, tool calls, and state machine",
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
@@ -225,7 +225,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
   },
   {
-    id: ModuleId.make("ws-presence-client"),
+    id: ModuleId.make("ws-presence-react-client"),
     title: "WebSocket Presence Client",
     description: "Real-time presence UI with WebSocket RPC",
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -31,7 +31,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("http-api-client"),
     title: "HTTP API Client",
     description: "REST API client with Effect Atom and typed HttpApiClient",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client") }],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
     dependencies: [
       {
         _tag: "required-module",
@@ -92,7 +92,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("http-rpc-client"),
     title: "HTTP RPC Client",
     description: "RPC streaming client with tick atom and UI",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client") }],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
     dependencies: [
       {
         _tag: "required-module",
@@ -158,7 +158,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("chat-client"),
     title: "Chat Client",
     description: "AI chat UI with streaming, tool calls, and state machine",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client") }],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
     dependencies: [
       {
         _tag: "required-module",
@@ -228,7 +228,7 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("ws-presence-client"),
     title: "WebSocket Presence Client",
     description: "Real-time presence UI with WebSocket RPC",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client") }],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
     dependencies: [
       {
         _tag: "required-module",

--- a/packages/catalog/src/registry/modules/config.ts
+++ b/packages/catalog/src/registry/modules/config.ts
@@ -10,7 +10,7 @@ import { configTypescriptViteContents } from "../content/client";
  */
 export const configModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
-    id: ModuleId.make("config-typescript-vite"),
+    id: ModuleId.make("config-typescript-react-vite"),
     title: "Config TypeScript Vite",
     description: "Vite TypeScript preset for client applications",
     visibility: "internal",

--- a/packages/catalog/src/registry/modules/config.ts
+++ b/packages/catalog/src/registry/modules/config.ts
@@ -14,7 +14,7 @@ export const configModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     title: "Config TypeScript Vite",
     description: "Vite TypeScript preset for client applications",
     visibility: "internal",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client") }],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
     dependencies: [],
     contributions: [
       {

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -78,9 +78,9 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
   },
 
   {
-    kind: TargetKind.make("client"),
-    title: "Client Application",
-    description: "A frontend application, such as one built with React or Vue",
+    kind: TargetKind.make("client-react"),
+    title: "Client React Application",
+    description: "A frontend application built with React",
     requiredModules: [ModuleId.make("config-typescript-vite")],
     contributions: [
       // Files

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -81,7 +81,7 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     kind: TargetKind.make("client-react"),
     title: "Client React Application",
     description: "A frontend application built with React",
-    requiredModules: [ModuleId.make("config-typescript-vite")],
+    requiredModules: [ModuleId.make("config-typescript-react-vite")],
     contributions: [
       // Files
       {

--- a/packages/domain/src/Blueprint.test.ts
+++ b/packages/domain/src/Blueprint.test.ts
@@ -112,7 +112,7 @@ describe("@repo/domain Blueprint", () => {
       identity.matches({
         _tag: "identity",
         identity: new TargetIdentity({
-          kind: TargetKind.make("client"),
+          kind: TargetKind.make("client-react"),
           name: "api",
         }),
       }),

--- a/packages/domain/src/Scaffold.test.ts
+++ b/packages/domain/src/Scaffold.test.ts
@@ -13,14 +13,14 @@ describe("@repo/domain Scaffold", () => {
       name: "api",
     });
     const clientIdentity = Schema.decodeUnknownSync(TargetIdentity)({
-      kind: "client",
+      kind: "client-react",
       name: "admin-ui",
     });
 
     expect(packageIdentity.toKey()).toBe("packages/domain");
     expect(packageIdentity.toPath()).toBe("packages/domain");
     expect(serverIdentity.toKey()).toBe("apps/server-api");
-    expect(clientIdentity.toPath()).toBe("apps/client-admin-ui");
+    expect(clientIdentity.toPath()).toBe("apps/client-react-admin-ui");
   });
 
   it("accepts empty target names for apps (uses kind only)", () => {
@@ -66,12 +66,12 @@ describe("@repo/domain Scaffold", () => {
 
   it("slugifies names with underscores into canonical keys and paths", () => {
     const identity = Schema.decodeUnknownSync(TargetIdentity)({
-      kind: "client",
+      kind: "client-react",
       name: "admin_ui",
     });
 
-    expect(identity.toKey()).toBe("apps/client-admin-ui");
-    expect(identity.toPath()).toBe("apps/client-admin-ui");
+    expect(identity.toKey()).toBe("apps/client-react-admin-ui");
+    expect(identity.toPath()).toBe("apps/client-react-admin-ui");
   });
 
   it("normalizes surrounding whitespace before deriving canonical keys and paths", () => {
@@ -99,12 +99,12 @@ describe("@repo/domain Scaffold", () => {
         name: "api",
       });
       const clientIdentity = Schema.decodeUnknownSync(TargetIdentity)({
-        kind: "client",
+        kind: "client-react",
         name: "web",
       });
 
       expect(serverIdentity.toPackageName()).toBe("server-api");
-      expect(clientIdentity.toPackageName()).toBe("client-web");
+      expect(clientIdentity.toPackageName()).toBe("client-react-web");
     });
 
     it("returns just kind for apps without names", () => {
@@ -113,12 +113,12 @@ describe("@repo/domain Scaffold", () => {
         name: "",
       });
       const clientIdentity = Schema.decodeUnknownSync(TargetIdentity)({
-        kind: "client",
+        kind: "client-react",
         name: "",
       });
 
       expect(serverIdentity.toPackageName()).toBe("server");
-      expect(clientIdentity.toPackageName()).toBe("client");
+      expect(clientIdentity.toPackageName()).toBe("client-react");
     });
 
     it("slugifies package names", () => {

--- a/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
@@ -244,7 +244,7 @@ describe("BlueprintService", () => {
                 },
                 {
                   identity: new TargetIdentity({
-                    kind: TargetKind.make("client"),
+                    kind: TargetKind.make("client-react"),
                     name: "api",
                   }),
                   modules: [],
@@ -258,7 +258,7 @@ describe("BlueprintService", () => {
                 .filter((node) => node._tag === "target")
                 .map((node) => node.id),
             ).toEqual([
-              "apps/client-api",
+              "apps/client-react-api",
               "apps/server-api",
               "packages/domain",
             ]);
@@ -274,7 +274,7 @@ describe("BlueprintService", () => {
               targets: [
                 {
                   identity: new TargetIdentity({
-                    kind: TargetKind.make("client"),
+                    kind: TargetKind.make("client-react"),
                     name: "app",
                   }),
                   modules: [{ id: ModuleId.make("config-typescript-vite") }],
@@ -287,7 +287,7 @@ describe("BlueprintService", () => {
                 blueprint,
                 toAttachedModuleNodeId(
                   new TargetIdentity({
-                    kind: TargetKind.make("client"),
+                    kind: TargetKind.make("client-react"),
                     name: "app",
                   }).toKey(),
                   ModuleId.make("config-typescript-vite"),
@@ -295,7 +295,7 @@ describe("BlueprintService", () => {
               ),
             ).toMatchObject({
               _tag: "attached-module",
-              targetId: "apps/client-app",
+              targetId: "apps/client-react-app",
               moduleId: "config-typescript-vite",
             });
           }),
@@ -307,7 +307,7 @@ describe("BlueprintService", () => {
           Effect.gen(function* () {
             const blueprintService = yield* BlueprintService;
             const identity = new TargetIdentity({
-              kind: TargetKind.make("client"),
+              kind: TargetKind.make("client-react"),
               name: "required",
             });
             const blueprint = yield* blueprintService.resolve({
@@ -324,7 +324,7 @@ describe("BlueprintService", () => {
               ),
             ).toMatchObject({
               _tag: "attached-module",
-              targetId: "apps/client-required",
+              targetId: "apps/client-react-required",
               moduleId: "config-typescript-vite",
             });
           }),

--- a/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
@@ -277,7 +277,9 @@ describe("BlueprintService", () => {
                     kind: TargetKind.make("client-react"),
                     name: "app",
                   }),
-                  modules: [{ id: ModuleId.make("config-typescript-vite") }],
+                  modules: [
+                    { id: ModuleId.make("config-typescript-react-vite") },
+                  ],
                 },
               ],
             });
@@ -290,13 +292,13 @@ describe("BlueprintService", () => {
                     kind: TargetKind.make("client-react"),
                     name: "app",
                   }).toKey(),
-                  ModuleId.make("config-typescript-vite"),
+                  ModuleId.make("config-typescript-react-vite"),
                 ),
               ),
             ).toMatchObject({
               _tag: "attached-module",
               targetId: "apps/client-react-app",
-              moduleId: "config-typescript-vite",
+              moduleId: "config-typescript-react-vite",
             });
           }),
       );
@@ -319,13 +321,13 @@ describe("BlueprintService", () => {
                 blueprint,
                 toAttachedModuleNodeId(
                   identity.toKey(),
-                  ModuleId.make("config-typescript-vite"),
+                  ModuleId.make("config-typescript-react-vite"),
                 ),
               ),
             ).toMatchObject({
               _tag: "attached-module",
               targetId: "apps/client-react-required",
-              moduleId: "config-typescript-vite",
+              moduleId: "config-typescript-react-vite",
             });
           }),
       );

--- a/packages/scaffold/src/service/finalize/FinalizeService.test.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.test.ts
@@ -24,7 +24,7 @@ const serverIdentity = new TargetIdentity({
 });
 
 const clientIdentity = new TargetIdentity({
-  kind: TargetKind.make("client"),
+  kind: TargetKind.make("client-react"),
   name: "web",
 });
 


### PR DESCRIPTION
## Goals/Scope

Renames the existing client target kind to `client-react` and prefixes all client module IDs with react to make room for alternative frontend targets.


## Description
- Renamed target kind `client` → `client-react` across catalog, scaffold, and CLI
- Renamed module IDs: 
  - `http-api-client` → h`ttp-api-react-client`
  - `http-rpc-client` → `http-rpc-react-client`
  - `ws-presence-client` → `ws-presence-react-client`
  - `chat-client` → `chat-react-client`

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #130 
- <kbd>&nbsp;1&nbsp;</kbd> #129 👈 
<!-- GitButler Footer Boundary Bottom -->

