### PR TITLE
feat: add managed chat runtime

### DIFF
--- a/.agents/skills/catalog-workspace/SKILL.md
+++ b/.agents/skills/catalog-workspace/SKILL.md
@@ -180,6 +180,23 @@ run, treat that as a network/package-resolution/finalizer failure. If reset
 succeeds, missing package typings such as `vite/client` are real
 generated-workspace validation failures.
 
+When `catalog:reset-workspace` fails during a `bunx shadcn@latest add ...`
+finalizer step with:
+
+```text
+error: bun is unable to write files to tempdir: PermissionDenied
+```
+
+rerun the same reset command with sandbox escalation. The shadcn/bunx finalizer
+needs temp/cache writes outside the repo sandbox even though the generated
+workspace itself lives under `workspace/catalog-built`.
+
+Use this justification:
+
+```text
+catalog workspace reset runs bunx/finalizer steps that need temp/cache writes outside the workspace sandbox
+```
+
 ## Completion Checklist
 
 Before final response:

--- a/.changeset/moody-owls-design.md
+++ b/.changeset/moody-owls-design.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add chat-managed-runtime module for managing multiple chat sessions

--- a/packages/catalog/src/registry/content/chat.ts
+++ b/packages/catalog/src/registry/content/chat.ts
@@ -154,19 +154,139 @@ export class ChatRpc extends RpcGroup.make(
 ) {}
 `;
 
+export const domainChatManagedRpcContents = `import { Schema } from "effect";
+import { Rpc, RpcGroup } from "effect/unstable/rpc";
+import { ChatId, ChatMessage, ChatStreamPart } from "./Chat";
+import { ChatNotFoundError, GenerationInProgressError } from "./ChatRpc";
+
+export const ChatWatchEvent = Schema.TaggedUnion({
+  "user-message": {
+    message: ChatMessage,
+  },
+  "assistant-part": {
+    part: ChatStreamPart,
+  },
+});
+
+export type ChatWatchEvent = Schema.Schema.Type<typeof ChatWatchEvent>;
+
+export class ChatManagedRpc extends RpcGroup.make(
+  Rpc.make("chat_send", {
+    payload: {
+      chatId: ChatId,
+      message: ChatMessage,
+    },
+    success: Schema.Void,
+    error: Schema.Union([ChatNotFoundError, GenerationInProgressError]),
+  }),
+  Rpc.make("chat_watch", {
+    payload: {
+      chatId: ChatId,
+    },
+    success: ChatWatchEvent,
+    error: ChatNotFoundError,
+    stream: true,
+  }),
+  Rpc.make("chat_interrupt", {
+    payload: {
+      chatId: ChatId,
+    },
+    success: Schema.Void,
+    error: ChatNotFoundError,
+  }),
+) {}
+`;
+
 // Server chat handler (separate from EventRpc)
-export const serverChatRuntimeContents = `import { AiChatService, AiChatServiceLive, FastModelLive } from "@repo/ai";
-import { ChatId, type ChatMessage } from "@repo/domain/Chat";
+export const serverChatSessionsContents = `import { ChatId } from "@repo/domain/Chat";
 import {
   ChatNotFoundError,
   GenerationInProgressError,
 } from "@repo/domain/ChatRpc";
-import { Context, Effect, HashMap, Layer, Option, Ref, Stream } from "effect";
-import { Prompt } from "effect/unstable/ai";
+import { Context, Effect, HashMap, Layer, Option, Ref } from "effect";
 
 type ChatSession = {
   readonly active: boolean;
 };
+
+export class ChatSessions extends Context.Service<ChatSessions>()(
+  "ChatSessions",
+  {
+    make: Effect.gen(function* () {
+      const sessions = yield* Ref.make<HashMap.HashMap<ChatId, ChatSession>>(
+        HashMap.empty(),
+      );
+
+      return {
+        start: Effect.gen(function* () {
+          const chatId = ChatId.make(crypto.randomUUID());
+          const session: ChatSession = { active: false };
+          yield* Ref.update(sessions, HashMap.set(chatId, session));
+          return { chatId };
+        }),
+        ensure: (chatId: ChatId) =>
+          Ref.get(sessions).pipe(
+            Effect.flatMap((current) =>
+              Option.match(HashMap.get(current, chatId), {
+                onNone: () => Effect.fail(new ChatNotFoundError({ chatId })),
+                onSome: () => Effect.succeed(void 0),
+              }),
+            ),
+          ),
+        reserve: (chatId: ChatId) =>
+          Ref.modify(
+            sessions,
+            (
+              current,
+            ): readonly [
+              Effect.Effect<
+                void,
+                ChatNotFoundError | GenerationInProgressError
+              >,
+              HashMap.HashMap<ChatId, ChatSession>,
+            ] =>
+              Option.match(HashMap.get(current, chatId), {
+                onNone: () =>
+                  [
+                    Effect.fail(new ChatNotFoundError({ chatId })),
+                    current,
+                  ] as const,
+                onSome: (session) =>
+                  session.active
+                    ? ([
+                        Effect.fail(new GenerationInProgressError({ chatId })),
+                        current,
+                      ] as const)
+                    : ([
+                        Effect.succeed(void 0),
+                        HashMap.set(current, chatId, {
+                          ...session,
+                          active: true,
+                        }),
+                      ] as const),
+              }),
+          ).pipe(Effect.flatten),
+        release: (chatId: ChatId) =>
+          Ref.update(sessions, (current) =>
+            Option.match(HashMap.get(current, chatId), {
+              onNone: () => current,
+              onSome: (session) =>
+                HashMap.set(current, chatId, { ...session, active: false }),
+            }),
+          ),
+      } as const;
+    }),
+  },
+) {}
+
+export const ChatSessionsLive = Layer.effect(ChatSessions)(ChatSessions.make);
+`;
+
+export const serverChatRuntimeContents = `import { AiChatService, AiChatServiceLive, FastModelLive } from "@repo/ai";
+import type { ChatId, ChatMessage } from "@repo/domain/Chat";
+import { Context, Effect, Layer, Stream } from "effect";
+import { Prompt } from "effect/unstable/ai";
+import { ChatSessions } from "./ChatSessions";
 
 const toPromptMessage = (message: ChatMessage) => {
   if (message.role === "system") {
@@ -183,63 +303,27 @@ const toPromptMessage = (message: ChatMessage) => {
 export class ChatRuntime extends Context.Service<ChatRuntime>()("ChatRuntime", {
   make: Effect.gen(function* () {
     const chat = yield* AiChatService;
-    const sessions = yield* Ref.make<HashMap.HashMap<ChatId, ChatSession>>(
-      HashMap.empty(),
-    );
+    const sessions = yield* ChatSessions;
 
-    const release = (chatId: ChatId) =>
-      Ref.update(sessions, (current) =>
-        Option.match(HashMap.get(current, chatId), {
-          onNone: () => current,
-          onSome: (session) =>
-            HashMap.set(current, chatId, { ...session, active: false }),
+    const generate = (messages: ReadonlyArray<ChatMessage>) =>
+      Stream.unwrap(
+        Effect.gen(function* () {
+          const queue = yield* chat
+            .chat(messages.map(toPromptMessage))
+            .pipe(Effect.provide(FastModelLive), Effect.orDie);
+          return Stream.fromQueue(queue);
         }),
       );
 
-    const reserve = (chatId: ChatId) =>
-      Ref.modify(
-        sessions,
-        (
-          current,
-        ): readonly [
-          Effect.Effect<void, ChatNotFoundError | GenerationInProgressError>,
-          HashMap.HashMap<ChatId, ChatSession>,
-        ] =>
-          Option.match(HashMap.get(current, chatId), {
-            onNone: () =>
-              [
-                Effect.fail(new ChatNotFoundError({ chatId })),
-                current,
-              ] as const,
-            onSome: (session) =>
-              session.active
-                ? ([
-                    Effect.fail(new GenerationInProgressError({ chatId })),
-                    current,
-                  ] as const)
-                : ([
-                    Effect.succeed(void 0),
-                    HashMap.set(current, chatId, { ...session, active: true }),
-                  ] as const),
-          }),
-      ).pipe(Effect.flatten);
-
     return {
-      start: Effect.gen(function* () {
-        const chatId = ChatId.make(crypto.randomUUID());
-        const session: ChatSession = { active: false };
-        yield* Ref.update(sessions, HashMap.set(chatId, session));
-        return { chatId };
-      }),
+      start: sessions.start,
+      generate,
       ask: (chatId: ChatId, messages: ReadonlyArray<ChatMessage>) =>
         Stream.unwrap(
           Effect.gen(function* () {
-            yield* reserve(chatId);
-            const queue = yield* chat
-              .chat(messages.map(toPromptMessage))
-              .pipe(Effect.provide(FastModelLive), Effect.orDie);
-            return Stream.fromQueue(queue).pipe(
-              Stream.ensuring(release(chatId)),
+            yield* sessions.reserve(chatId);
+            return generate(messages).pipe(
+              Stream.ensuring(sessions.release(chatId)),
             );
           }),
         ),
@@ -247,9 +331,9 @@ export class ChatRuntime extends Context.Service<ChatRuntime>()("ChatRuntime", {
   }),
 }) {}
 
-export const ChatRuntimeLive = Layer.effect(ChatRuntime)(
-  ChatRuntime.make,
-).pipe(Layer.provide(AiChatServiceLive));
+export const ChatRuntimeLive = Layer.effect(ChatRuntime)(ChatRuntime.make).pipe(
+  Layer.provide(AiChatServiceLive),
+);
 `;
 
 export const serverChatContents = `import { ChatRpc } from "@repo/domain/ChatRpc";
@@ -275,6 +359,174 @@ export const ChatRpcLive = RpcServer.layerHttp({
 }).pipe(
   Layer.provide(ChatRpcHandlers),
   Layer.provide(RpcSerialization.layerNdjson),
+  Layer.provide(ChatRuntimeLive),
+);
+`;
+
+export const serverChatManagedRuntimeContents = `import type { ChatId, ChatMessage } from "@repo/domain/Chat";
+import { ChatWatchEvent } from "@repo/domain/ChatManagedRpc";
+import type {
+  ChatNotFoundError,
+  GenerationInProgressError,
+} from "@repo/domain/ChatRpc";
+import {
+  Context,
+  Effect,
+  Fiber,
+  HashMap,
+  Layer,
+  Option,
+  PubSub,
+  Ref,
+  Stream,
+} from "effect";
+import { ChatRuntime } from "./ChatRuntime";
+import { ChatSessions } from "./ChatSessions";
+
+type LiveEvent = readonly [ChatId, ChatWatchEvent];
+
+export class ChatManagedRuntime extends Context.Service<ChatManagedRuntime>()(
+  "ChatManagedRuntime",
+  {
+    make: Effect.gen(function* () {
+      const runtime = yield* ChatRuntime;
+      const sessions = yield* ChatSessions;
+      const events = yield* Ref.make<
+        HashMap.HashMap<ChatId, ReadonlyArray<ChatWatchEvent>>
+      >(HashMap.empty());
+      const messages = yield* Ref.make<
+        HashMap.HashMap<ChatId, ReadonlyArray<ChatMessage>>
+      >(HashMap.empty());
+      const activeFibers = yield* Ref.make<
+        HashMap.HashMap<ChatId, Fiber.Fiber<void, never>>
+      >(HashMap.empty());
+      const liveEvents = yield* PubSub.unbounded<LiveEvent>();
+
+      const publish = (chatId: ChatId, event: ChatWatchEvent) =>
+        Effect.gen(function* () {
+          yield* Ref.update(events, (current) =>
+            HashMap.set(current, chatId, [
+              ...Option.getOrElse(HashMap.get(current, chatId), () => []),
+              event,
+            ]),
+          );
+          yield* PubSub.publish(liveEvents, [chatId, event] as const);
+        });
+
+      const removeActiveFiber = (chatId: ChatId) =>
+        Ref.update(activeFibers, HashMap.remove(chatId));
+
+      return {
+        send: ({
+          chatId,
+          message,
+        }: {
+          readonly chatId: ChatId;
+          readonly message: ChatMessage;
+        }): Effect.Effect<
+          void,
+          ChatNotFoundError | GenerationInProgressError
+        > =>
+          Effect.gen(function* () {
+            yield* sessions.reserve(chatId);
+
+            const userEvent = ChatWatchEvent.cases["user-message"].make({
+              message,
+            });
+            yield* publish(chatId, userEvent);
+
+            const history = yield* Ref.modify(messages, (current) => {
+              const nextMessages = [
+                ...Option.getOrElse(HashMap.get(current, chatId), () => []),
+                message,
+              ];
+              return [
+                nextMessages,
+                HashMap.set(current, chatId, nextMessages),
+              ] as const;
+            });
+
+            const fiber = yield* runtime.generate(history).pipe(
+              Stream.tap((part) =>
+                publish(
+                  chatId,
+                  ChatWatchEvent.cases["assistant-part"].make({ part }),
+                ),
+              ),
+              Stream.runDrain,
+              Effect.ensuring(sessions.release(chatId)),
+              Effect.ensuring(removeActiveFiber(chatId)),
+              Effect.forkDetach,
+            );
+
+            yield* Ref.update(activeFibers, HashMap.set(chatId, fiber));
+          }),
+        watch: (chatId: ChatId) =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              yield* sessions.ensure(chatId);
+              const replay = yield* Ref.get(events).pipe(
+                Effect.map((current) =>
+                  Option.getOrElse(HashMap.get(current, chatId), () => []),
+                ),
+              );
+              const live = Stream.fromPubSub(liveEvents).pipe(
+                Stream.filter(([eventChatId]) => eventChatId === chatId),
+                Stream.map(([, event]) => event),
+              );
+              return Stream.fromIterable(replay).pipe(Stream.concat(live));
+            }),
+          ),
+        interrupt: (chatId: ChatId) =>
+          Effect.gen(function* () {
+            yield* sessions.ensure(chatId);
+            const fiber = yield* Ref.get(activeFibers).pipe(
+              Effect.map(HashMap.get(chatId)),
+            );
+            yield* Option.match(fiber, {
+              onNone: () => Effect.succeed(void 0),
+              onSome: Fiber.interrupt,
+            });
+          }),
+      } as const;
+    }),
+  },
+) {}
+
+export const ChatManagedRuntimeLive = Layer.effect(ChatManagedRuntime)(
+  ChatManagedRuntime.make,
+);
+`;
+
+export const serverChatManagedContents = `import { ChatManagedRpc } from "@repo/domain/ChatManagedRpc";
+import { Effect, Layer } from "effect";
+import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
+import {
+  ChatManagedRuntime,
+  ChatManagedRuntimeLive,
+} from "../runtime/ChatManagedRuntime";
+import { ChatRuntimeLive } from "../runtime/ChatRuntime";
+
+const ChatManagedRpcHandlers = ChatManagedRpc.toLayer(
+  Effect.gen(function* () {
+    const runtime = yield* ChatManagedRuntime;
+    yield* Effect.logInfo("Starting Chat Managed RPC Live Implementation");
+    return ChatManagedRpc.of({
+      chat_send: ({ chatId, message }) => runtime.send({ chatId, message }),
+      chat_watch: ({ chatId }) => runtime.watch(chatId),
+      chat_interrupt: ({ chatId }) => runtime.interrupt(chatId),
+    });
+  }),
+);
+
+export const ChatManagedRpcLive = RpcServer.layerHttp({
+  group: ChatManagedRpc,
+  path: "/chat-managed-rpc",
+  protocol: "http",
+}).pipe(
+  Layer.provide(ChatManagedRpcHandlers),
+  Layer.provide(RpcSerialization.layerNdjson),
+  Layer.provide(ChatManagedRuntimeLive),
   Layer.provide(ChatRuntimeLive),
 );
 `;

--- a/packages/catalog/src/registry/content/chat.ts
+++ b/packages/catalog/src/registry/content/chat.ts
@@ -1,6 +1,9 @@
 // Domain Chat schema
 export const domainChatContents = `import { Schema } from "effect";
 
+export const ChatId = Schema.String.pipe(Schema.brand("ChatId"));
+export type ChatId = Schema.Schema.Type<typeof ChatId>;
+
 // ============================================================================
 // Wire Protocol: ChatStreamPart
 // ============================================================================
@@ -121,14 +124,31 @@ export type ChatResponse = Schema.Schema.Type<typeof ChatResponse>;
 // Separate ChatRpc group (does NOT touch Rpc.ts)
 export const domainChatRpcContents = `import { Schema } from "effect";
 import { Rpc, RpcGroup } from "effect/unstable/rpc";
-import { ChatMessage, ChatStreamPart } from "./Chat";
+import { ChatId, ChatMessage, ChatStreamPart } from "./Chat";
+
+export class ChatNotFoundError extends Schema.TaggedErrorClass<ChatNotFoundError>()(
+  "ChatNotFoundError",
+  { chatId: ChatId },
+) {}
+
+export class GenerationInProgressError extends Schema.TaggedErrorClass<GenerationInProgressError>()(
+  "GenerationInProgressError",
+  { chatId: ChatId },
+) {}
 
 export class ChatRpc extends RpcGroup.make(
+  Rpc.make("chat_start", {
+    success: Schema.Struct({
+      chatId: ChatId,
+    }),
+  }),
   Rpc.make("chat_ask", {
     payload: {
+      chatId: ChatId,
       messages: Schema.Array(ChatMessage),
     },
     success: ChatStreamPart,
+    error: Schema.Union([ChatNotFoundError, GenerationInProgressError]),
     stream: true,
   }),
 ) {}
@@ -136,9 +156,17 @@ export class ChatRpc extends RpcGroup.make(
 
 // Server chat handler (separate from EventRpc)
 export const serverChatRuntimeContents = `import { AiChatService, AiChatServiceLive, FastModelLive } from "@repo/ai";
-import type { ChatMessage } from "@repo/domain/Chat";
-import { Context, Effect, Layer } from "effect";
+import { ChatId, type ChatMessage } from "@repo/domain/Chat";
+import {
+  ChatNotFoundError,
+  GenerationInProgressError,
+} from "@repo/domain/ChatRpc";
+import { Context, Effect, HashMap, Layer, Option, Ref, Stream } from "effect";
 import { Prompt } from "effect/unstable/ai";
+
+type ChatSession = {
+  readonly active: boolean;
+};
 
 const toPromptMessage = (message: ChatMessage) => {
   if (message.role === "system") {
@@ -155,12 +183,66 @@ const toPromptMessage = (message: ChatMessage) => {
 export class ChatRuntime extends Context.Service<ChatRuntime>()("ChatRuntime", {
   make: Effect.gen(function* () {
     const chat = yield* AiChatService;
+    const sessions = yield* Ref.make<HashMap.HashMap<ChatId, ChatSession>>(
+      HashMap.empty(),
+    );
+
+    const release = (chatId: ChatId) =>
+      Ref.update(sessions, (current) =>
+        Option.match(HashMap.get(current, chatId), {
+          onNone: () => current,
+          onSome: (session) =>
+            HashMap.set(current, chatId, { ...session, active: false }),
+        }),
+      );
+
+    const reserve = (chatId: ChatId) =>
+      Ref.modify(
+        sessions,
+        (
+          current,
+        ): readonly [
+          Effect.Effect<void, ChatNotFoundError | GenerationInProgressError>,
+          HashMap.HashMap<ChatId, ChatSession>,
+        ] =>
+          Option.match(HashMap.get(current, chatId), {
+            onNone: () =>
+              [
+                Effect.fail(new ChatNotFoundError({ chatId })),
+                current,
+              ] as const,
+            onSome: (session) =>
+              session.active
+                ? ([
+                    Effect.fail(new GenerationInProgressError({ chatId })),
+                    current,
+                  ] as const)
+                : ([
+                    Effect.succeed(void 0),
+                    HashMap.set(current, chatId, { ...session, active: true }),
+                  ] as const),
+          }),
+      ).pipe(Effect.flatten);
 
     return {
-      ask: (messages: ReadonlyArray<ChatMessage>) =>
-        chat
-          .chat(messages.map(toPromptMessage))
-          .pipe(Effect.provide(FastModelLive), Effect.orDie),
+      start: Effect.gen(function* () {
+        const chatId = ChatId.make(crypto.randomUUID());
+        const session: ChatSession = { active: false };
+        yield* Ref.update(sessions, HashMap.set(chatId, session));
+        return { chatId };
+      }),
+      ask: (chatId: ChatId, messages: ReadonlyArray<ChatMessage>) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            yield* reserve(chatId);
+            const queue = yield* chat
+              .chat(messages.map(toPromptMessage))
+              .pipe(Effect.provide(FastModelLive), Effect.orDie);
+            return Stream.fromQueue(queue).pipe(
+              Stream.ensuring(release(chatId)),
+            );
+          }),
+        ),
     } as const;
   }),
 }) {}
@@ -180,7 +262,8 @@ const ChatRpcHandlers = ChatRpc.toLayer(
     const runtime = yield* ChatRuntime;
     yield* Effect.logInfo("Starting Chat RPC Live Implementation");
     return ChatRpc.of({
-      chat_ask: ({ messages }) => runtime.ask(messages),
+      chat_start: () => runtime.start,
+      chat_ask: ({ chatId, messages }) => runtime.ask(chatId, messages),
     });
   }),
 );

--- a/packages/catalog/src/registry/content/client-chat.ts
+++ b/packages/catalog/src/registry/content/client-chat.ts
@@ -30,12 +30,23 @@ export class ChatRpcClient extends Context.Service<ChatRpcClient>()("ChatRpcClie
 `;
 
 // Client chat atom (uses ChatRpcClient instead of RpcClient)
-export const clientChatAtomContents = `import { ChatStreamPart, type ChatMessage, type ChatResponse, type ToolCall } from "@repo/domain/Chat";
+export const clientChatAtomContents = `import { ChatStreamPart, type ChatId, type ChatMessage, type ChatResponse, type ToolCall } from "@repo/domain/Chat";
 import { Effect, Stream } from "effect";
 import { Atom, type Atom as AtomType } from "effect/unstable/reactivity";
 import { ChatRpcClient } from "../chat-rpc-client";
 
 const chatRuntime = Atom.runtime(ChatRpcClient.layer);
+
+export const chatStartAtom: AtomType.AtomResultFn<
+  void,
+  { readonly chatId: ChatId },
+  unknown
+> = chatRuntime.fn(() =>
+  Effect.gen(function* () {
+    const rpc = yield* ChatRpcClient;
+    return yield* rpc.client.chat_start();
+  }),
+);
 
 export const accumulateChatResponse = (
   state: ChatResponse,
@@ -169,14 +180,17 @@ const updateToolResult = (
 };
 
 export const chatAtom: AtomType.AtomResultFn<
-  readonly ChatMessage[],
+  {
+    readonly chatId: ChatId;
+    readonly messages: readonly ChatMessage[];
+  },
   ChatResponse,
   unknown
-> = chatRuntime.fn((messages: readonly ChatMessage[]) => {
+> = chatRuntime.fn(({ chatId, messages }) => {
   return Stream.unwrap(
     Effect.gen(function* () {
       const rpc = yield* ChatRpcClient;
-      return rpc.client.chat_ask({ messages });
+      return rpc.client.chat_ask({ chatId, messages });
     }),
   ).pipe(
     Stream.tapError((error: unknown) =>
@@ -210,10 +224,10 @@ export const chatAtom: AtomType.AtomResultFn<
 
 // Client chat box component (unchanged from before)
 export const clientChatBoxContents = `import { useAtom } from "@effect/atom-react";
-import type { ChatResponse, MessageSegment } from "@repo/domain/Chat";
+import type { ChatId, ChatResponse, MessageSegment } from "@repo/domain/Chat";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { chatAtom } from "@/lib/atoms/chat-atom";
+import { chatAtom, chatStartAtom } from "@/lib/atoms/chat-atom";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -235,6 +249,8 @@ type Message = {
 
 export function ChatBox() {
   const [result, runChat] = useAtom(chatAtom);
+  const [startResult, startChat] = useAtom(chatStartAtom);
+  const [chatId, setChatId] = useState<ChatId | null>(null);
   const [input, setInput] = useState("");
   const [history, setHistory] = useState<Message[]>([]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -244,6 +260,9 @@ export function ChatBox() {
       content: string;
     }>
   >([]);
+  const pendingMessagesRef = useRef<typeof lastSentMessagesRef.current | null>(
+    null,
+  );
   const readinessAttemptRef = useRef(0);
   const lastCompletionKeyRef = useRef<string | null>(null);
 
@@ -256,8 +275,19 @@ export function ChatBox() {
     currentResult._tag === "initial" ? [] : currentResult.segments;
 
   const isWaiting = AsyncResult.isWaiting(result);
+  const isStarting = AsyncResult.isWaiting(startResult);
   const isFailure = AsyncResult.isFailure(result);
   const isStreaming = currentResult._tag === "streaming";
+
+  useEffect(() => {
+    const started = AsyncResult.getOrElse(startResult, () => null);
+    if (!started) return;
+    setChatId(started.chatId);
+    const pending = pendingMessagesRef.current;
+    if (!pending) return;
+    pendingMessagesRef.current = null;
+    runChat({ chatId: started.chatId, messages: pending });
+  }, [runChat, startResult]);
 
   const sendMessages = (
     messages: Array<{
@@ -267,7 +297,12 @@ export function ChatBox() {
   ) => {
     lastSentMessagesRef.current = messages;
     readinessAttemptRef.current = 0;
-    runChat(messages);
+    if (chatId) {
+      runChat({ chatId, messages });
+      return;
+    }
+    pendingMessagesRef.current = messages;
+    startChat();
   };
 
   useEffect(() => {
@@ -280,11 +315,16 @@ export function ChatBox() {
 
     readinessAttemptRef.current += 1;
     const timeoutId = window.setTimeout(() => {
-      runChat(lastSentMessagesRef.current);
+      if (chatId) {
+        runChat({ chatId, messages: lastSentMessagesRef.current });
+        return;
+      }
+      pendingMessagesRef.current = lastSentMessagesRef.current;
+      startChat();
     }, 600 * readinessAttemptRef.current);
 
     return () => window.clearTimeout(timeoutId);
-  }, [currentResult, isFailure, runChat]);
+  }, [chatId, currentResult, isFailure, runChat, startChat]);
 
   const handleSend = () => {
     if (!input.trim()) return;
@@ -358,6 +398,16 @@ export function ChatBox() {
       <CardHeader>
         <CardTitle>Chat (RPC)</CardTitle>
         <div className="flex gap-2 mt-1">
+          {chatId && (
+            <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-[0.65rem] text-muted-foreground">
+              {chatId}
+            </span>
+          )}
+          {isStarting && (
+            <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+              Starting
+            </span>
+          )}
           {isStreaming && (
             <span className="inline-flex items-center rounded-full border border-border bg-secondary px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.2em] text-secondary-foreground">
               Streaming
@@ -475,15 +525,15 @@ export function ChatBox() {
           <Input
             type="text"
             placeholder="Send a message"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleSend()}
-            disabled={isWaiting || isStreaming}
-          />
-          <Button
-            onClick={handleSend}
-            disabled={!input.trim() || isWaiting || isStreaming}
-          >
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSend()}
+              disabled={isStarting || isWaiting || isStreaming}
+            />
+            <Button
+              onClick={handleSend}
+              disabled={!input.trim() || isStarting || isWaiting || isStreaming}
+            >
             Send
           </Button>
         </div>

--- a/packages/catalog/src/registry/content/client-foldkit-chat.ts
+++ b/packages/catalog/src/registry/content/client-foldkit-chat.ts
@@ -22,6 +22,7 @@ export const ChatClientLive = Layer.effect(
 `;
 
 export const foldkitChatFeatureContents = `import {
+  ChatId,
   ChatMessage,
   ChatStreamPart,
   MessageSegment,
@@ -53,6 +54,7 @@ const ChatStateSchema = Schema.Literals([
 ]);
 
 export const Model = Schema.Struct({
+  chatId: Schema.Option(ChatId),
   chatInput: Schema.String,
   chatHistory: Schema.Array(ChatMessageSchema),
   chatState: ChatStateSchema,
@@ -67,6 +69,11 @@ export type Model = typeof Model.Type;
 
 export const UpdatedChatInput = m("UpdatedChatInput", { value: Schema.String });
 export const SubmittedChatMessage = m("SubmittedChatMessage");
+export const StartedChat = m("StartedChat", {
+  chatId: ChatId,
+  messagesJson: Schema.String,
+});
+export const FailedStartChat = m("FailedStartChat", { error: Schema.String });
 export const ReceivedChatPart = m("ReceivedChatPart", {
   part: ChatStreamPart,
 });
@@ -76,6 +83,8 @@ export const FailedChatStream = m("FailedChatStream", { error: Schema.String });
 export const Message = Schema.Union([
   UpdatedChatInput,
   SubmittedChatMessage,
+  StartedChat,
+  FailedStartChat,
   ReceivedChatPart,
   CompletedChatStream,
   FailedChatStream,
@@ -93,6 +102,7 @@ export const init = (): readonly [
   ReadonlyArray<Command.Command<Message>>,
 ] => [
   {
+    chatId: Option.none(),
     chatInput: "",
     chatHistory: [],
     chatState: "idle",
@@ -227,27 +237,54 @@ export const update = (
     SubmittedChatMessage: () => {
       const trimmed = model.chatInput.trim();
       if (trimmed === "") return [model, []] as const;
+      const nextHistory = [
+        ...model.chatHistory,
+        {
+          role: "user" as const,
+          content: trimmed,
+          segments: Option.none(),
+        },
+      ];
+      const messagesJson = Schema.encodeUnknownSync(ChatMessagesJson)(
+        nextHistory.map((msg) => ({
+          role: msg.role,
+          content: msg.content,
+        })),
+      );
 
       return [
         evo(model, {
           chatInput: () => "",
-          chatHistory: (prev) => [
-            ...prev,
-            {
-              role: "user" as const,
-              content: trimmed,
-              segments: Option.none(),
-            },
-          ],
+          chatHistory: () => nextHistory,
           chatState: () => "streaming" as const,
-          chatStreaming: () => true,
+          chatStreaming: () => Option.isSome(model.chatId),
           chatSegments: () => [],
           chatReasoning: () => Option.none(),
           chatError: () => Option.none(),
         }),
-        [],
+        Option.match(model.chatId, {
+          onNone: () => [StartChat({ messagesJson })],
+          onSome: () => [],
+        }),
       ] as const;
     },
+    StartedChat: ({ chatId }) =>
+      [
+        evo(model, {
+          chatId: () => Option.some(chatId),
+          chatStreaming: () => true,
+        }),
+        [],
+      ] as const,
+    FailedStartChat: ({ error }) =>
+      [
+        evo(model, {
+          chatState: () => "error" as const,
+          chatStreaming: () => false,
+          chatError: () => Option.some(error),
+        }),
+        [],
+      ] as const,
     ReceivedChatPart: ({ part }) => [applyChatPart(model, part), []] as const,
     CompletedChatStream: () =>
       [
@@ -279,13 +316,38 @@ export const update = (
   });
 };
 
+// COMMAND
+
+export const StartChat = Command.define(
+  "StartChat",
+  { messagesJson: Schema.String },
+  StartedChat,
+  FailedStartChat,
+)(({ messagesJson }) =>
+  Effect.gen(function* () {
+    const client = yield* ChatClient;
+    const { chatId } = yield* client.chat_start();
+    return StartedChat({ chatId, messagesJson });
+  }).pipe(
+    Effect.catch(() =>
+      Effect.succeed(FailedStartChat({ error: "Failed to start chat" })),
+    ),
+    Effect.provide(ChatClientLive),
+  ),
+);
+
 // SUBSCRIPTION
 
 export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
   chatStream: entry(
-    { isStreaming: Schema.Boolean, messagesJson: Schema.String },
+    {
+      chatId: Schema.Option(ChatId),
+      isStreaming: Schema.Boolean,
+      messagesJson: Schema.String,
+    },
     {
       modelToDependencies: (model) => ({
+        chatId: model.chatId,
         isStreaming: model.chatStreaming,
         messagesJson: model.chatStreaming
           ? Schema.encodeUnknownSync(ChatMessagesJson)(
@@ -296,7 +358,7 @@ export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
             )
           : "[]",
       }),
-      dependenciesToStream: ({ isStreaming, messagesJson }) =>
+      dependenciesToStream: ({ chatId, isStreaming, messagesJson }) =>
         isStreaming
           ? Effect.gen(function* () {
               const client = yield* ChatClient;
@@ -304,10 +366,14 @@ export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
                 yield* Schema.decodeUnknownEffect(ChatMessagesJson)(
                   messagesJson,
                 );
-              return client.chat_ask({ messages }).pipe(
-                Stream.map((part) => ReceivedChatPart({ part })),
-                Stream.concat(Stream.make(CompletedChatStream())),
-              );
+              return Option.match(chatId, {
+                onNone: () => Stream.empty,
+                onSome: (id) =>
+                  client.chat_ask({ chatId: id, messages }).pipe(
+                    Stream.map((part) => ReceivedChatPart({ part })),
+                    Stream.concat(Stream.make(CompletedChatStream())),
+                  ),
+              });
             }).pipe(
               Stream.unwrap,
               Stream.catch(() =>
@@ -351,6 +417,19 @@ export const view = <ParentMessage>(
           h.div(
             [h.Class("flex gap-2")],
             [
+              ...Option.match(model.chatId, {
+                onNone: (): Array<Html> => [],
+                onSome: (chatId) => [
+                  h.span(
+                    [
+                      h.Class(
+                        "inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-[0.65rem] text-muted-foreground",
+                      ),
+                    ],
+                    [chatId],
+                  ),
+                ],
+              }),
               ...(isStreaming
                 ? [
                     h.span(

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -74,7 +74,10 @@ const ApiRouter = HttpApiBuilder.layer(Api).pipe(
 );
 
 // All Routers - modules append additional routers here via Layer.mergeAll
-const AllRouters = Layer.mergeAll(ApiRouter);
+const RouterDependencies = Layer.mergeAll(Layer.empty);
+const AllRouters = Layer.mergeAll(ApiRouter).pipe(
+  Layer.provide(RouterDependencies),
+);
 
 // ============================================================================
 // Server Launch

--- a/packages/catalog/src/registry/modules/domain.ts
+++ b/packages/catalog/src/registry/modules/domain.ts
@@ -5,7 +5,11 @@ import {
   TargetKind,
 } from "@repo/domain/Catalog";
 import { domainApiContents } from "../content/api";
-import { domainChatContents, domainChatRpcContents } from "../content/chat";
+import {
+  domainChatContents,
+  domainChatManagedRpcContents,
+  domainChatRpcContents,
+} from "../content/chat";
 import { domainRpcContents } from "../content/rpc";
 import { domainWebSocketContents } from "../content/websocket";
 
@@ -133,6 +137,50 @@ export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         _tag: "barrel-export",
         barrelPath: "{{targetPath}}/src/index.ts",
         exportPath: "./ChatRpc",
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("domain-chat-managed"),
+    title: "Domain Managed Chat",
+    description: "Managed chat send, watch, and interrupt RPC definitions",
+    visibility: "internal",
+    supportedOn: [
+      {
+        _tag: "identity",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "domain",
+        }),
+      },
+    ],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "domain",
+        }),
+        moduleId: ModuleId.make("domain-chat"),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/ChatManagedRpc.ts",
+        contents: domainChatManagedRpcContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "exports",
+        name: "./ChatManagedRpc",
+        value: "./src/ChatManagedRpc.ts",
+      },
+      {
+        _tag: "barrel-export",
+        barrelPath: "{{targetPath}}/src/index.ts",
+        exportPath: "./ChatManagedRpc",
       },
     ],
   },

--- a/packages/catalog/src/registry/modules/server.ts
+++ b/packages/catalog/src/registry/modules/server.ts
@@ -5,7 +5,13 @@ import {
   TargetKind,
 } from "@repo/domain/Catalog";
 import { serverHealthContents, serverHelloContents } from "../content/api";
-import { serverChatContents, serverChatRuntimeContents } from "../content/chat";
+import {
+  serverChatContents,
+  serverChatManagedContents,
+  serverChatManagedRuntimeContents,
+  serverChatRuntimeContents,
+  serverChatSessionsContents,
+} from "../content/chat";
 import { serverTickContents } from "../content/rpc";
 import { serverPresenceContents } from "../content/websocket";
 
@@ -120,6 +126,11 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       },
       {
         _tag: "file",
+        path: "{{targetPath}}/src/runtime/ChatSessions.ts",
+        contents: serverChatSessionsContents,
+      },
+      {
+        _tag: "file",
         path: "{{targetPath}}/src/runtime/ChatRuntime.ts",
         contents: serverChatRuntimeContents,
       },
@@ -146,6 +157,64 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         import: {
           moduleSpecifier: "./Rpc/Chat",
           namedImports: ["ChatRpcLive"],
+        },
+      },
+      {
+        _tag: "ts-call-arg",
+        path: "{{targetPath}}/src/index.ts",
+        targetVariable: "RouterDependencies",
+        functionName: "Layer.mergeAll",
+        argument: "ChatSessionsLive",
+        import: {
+          moduleSpecifier: "./runtime/ChatSessions",
+          namedImports: ["ChatSessionsLive"],
+        },
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("chat-managed-runtime"),
+    title: "Managed Chat Runtime",
+    description: "In-memory managed chat send, watch, and interrupt runtime",
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("server") }],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "domain",
+        }),
+        moduleId: ModuleId.make("domain-chat-managed"),
+      },
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("server"),
+          name: "api",
+        }),
+        moduleId: ModuleId.make("chat-server"),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/Rpc/ChatManaged.ts",
+        contents: serverChatManagedContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/runtime/ChatManagedRuntime.ts",
+        contents: serverChatManagedRuntimeContents,
+      },
+      {
+        _tag: "ts-call-arg",
+        path: "{{targetPath}}/src/index.ts",
+        targetVariable: "AllRouters",
+        functionName: "Layer.mergeAll",
+        argument: "ChatManagedRpcLive",
+        import: {
+          moduleSpecifier: "./Rpc/ChatManaged",
+          namedImports: ["ChatManagedRpcLive"],
         },
       },
     ],


### PR DESCRIPTION
## Goals/Scope

Add a **managed chat runtime** to support chatId tracking and lifecycle management.

## Description

- Introduce **managed chat runtime** functionality.
- Refactor the runtime to **track `chatId`** in the simple chat runtime.
- Update documentation for the **reset-workflow skill**.

---

- [x] closes #142
- [x] closes #143
- [x] closes #144