### PR TITLE
feat: add db-sqlite module

### DIFF
--- a/.changeset/clear-colts-roll.md
+++ b/.changeset/clear-colts-roll.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add module capabilities for module validation

--- a/.changeset/curly-parks-learn.md
+++ b/.changeset/curly-parks-learn.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add `db-sqlite` module

--- a/apps/cli/e2e/matrix.test.ts
+++ b/apps/cli/e2e/matrix.test.ts
@@ -4,19 +4,15 @@ import { ModuleId, TargetKind } from "@repo/domain/Catalog";
 import { Effect } from "effect";
 import { CLI } from "./harness";
 
-// ---------------------------------------------------------------------------
-// Matrix generation – derives valid combos from CatalogService at import time
-// ---------------------------------------------------------------------------
-
 /**
  * Target identity used in CLI --target flag (kind/name).
  * Modules that use identity-based supportedOn dictate the target name.
  * For kind-based modules (server, client), we use a conventional name.
  */
 interface MatrixEntry {
-  readonly target: string; // "kind/name" for --target
-  readonly modules: ReadonlyArray<string>; // module IDs for --modules
-  readonly label: string; // human-readable test name
+  readonly target: string;
+  readonly modules: ReadonlyArray<string>;
+  readonly label: string;
 }
 
 /**
@@ -24,13 +20,27 @@ interface MatrixEntry {
  * Tracks parent module and all optional children to add separately.
  */
 interface ChildrenMatrixEntry {
-  readonly target: string; // "kind/name" for --target
-  readonly parentModule: string; // parent module ID
+  readonly target: string;
+  readonly parentModule: string;
   readonly optionalChildren: ReadonlyArray<{
     readonly moduleId: string;
-    readonly childTarget: string; // target for the child module
+    readonly childTarget: string;
   }>;
-  readonly label: string; // human-readable test name
+  readonly label: string;
+}
+
+/**
+ * Entry for testing a module that requires a catalog capability with a concrete
+ * provider module selected from the current catalog.
+ */
+interface CapabilityMatrixEntry {
+  readonly requiringTarget: string;
+  readonly requiringModule: string;
+  readonly providerTarget: string;
+  readonly providerModule: string;
+  readonly providerCount: number;
+  readonly capability: string;
+  readonly label: string;
 }
 
 /**
@@ -42,7 +52,7 @@ const defaultTargetNames = new Map([
   ["client-react", "web"],
   ["client-foldkit", "app"],
   ["cli", "app"],
-  ["package", "domain"], // fallback; overridden by identity modules
+  ["package", "domain"],
 ]);
 
 /**
@@ -77,21 +87,15 @@ function groupModulesByTarget(
   return groups;
 }
 
-// ---------------------------------------------------------------------------
-// Build the matrix using CatalogService
-// ---------------------------------------------------------------------------
-
 const buildMatrix = Effect.gen(function* () {
   const catalog = yield* CatalogService;
   const entries: Array<MatrixEntry> = [];
 
-  // For each public target kind, get supported modules and group by identity
   for (const kind of catalog.getTargetKinds({ visibility: "public" })) {
     const modules = yield* catalog.getSupportedModules(kind);
     const grouped = groupModulesByTarget(modules);
 
     for (const [target, moduleIds] of grouped) {
-      // Individual module tests
       for (const moduleId of moduleIds) {
         entries.push({
           target,
@@ -100,7 +104,6 @@ const buildMatrix = Effect.gen(function* () {
         });
       }
 
-      // All modules together (only if > 1 module)
       if (moduleIds.length > 1) {
         entries.push({
           target,
@@ -118,20 +121,12 @@ const matrix = Effect.runSync(
   buildMatrix.pipe(Effect.provide(CatalogService.layer)),
 );
 
-// Separate entries that have cross-target implications (client modules)
 const singleTargetEntries = matrix.filter(
   (e) =>
     !e.target.startsWith("client-react") &&
     !e.target.startsWith("client-foldkit"),
 );
 
-// ---------------------------------------------------------------------------
-// Build the optional children matrix - tests modules with all optional children
-// ---------------------------------------------------------------------------
-
-/**
- * Get the target string for a module based on its supportedOn configuration.
- */
 function getModuleTarget(mod: {
   supportedOn: ReadonlyArray<
     | { _tag: "kind"; kind: string }
@@ -145,14 +140,16 @@ function getModuleTarget(mod: {
     : `${s.kind}/${defaultTargetNames.get(s.kind) ?? s.kind}`;
 }
 
+function identityToTarget(identity: { kind: string; name: string }): string {
+  return `${identity.kind}/${identity.name}`;
+}
+
 const buildChildrenMatrix = Effect.gen(function* () {
   const catalog = yield* CatalogService;
   const entries: Array<ChildrenMatrixEntry> = [];
 
-  // Get all modules and find those with optional children
   const allModules = catalog.getModules();
 
-  // Build a lookup map for quick module access
   const moduleMap = new Map(allModules.map((m) => [m.id, m]));
 
   for (const mod of allModules) {
@@ -162,16 +159,13 @@ const buildChildrenMatrix = Effect.gen(function* () {
 
     if (!children || children.length === 0) continue;
 
-    // Filter to only optional children
     const optionalChildren = children.filter(
       (c) => c.requirement === "optional",
     );
     if (optionalChildren.length === 0) continue;
 
-    // Get target for parent module
     const parentTarget = getModuleTarget(mod);
 
-    // Get targets for each optional child
     const childrenWithTargets = optionalChildren.map((child) => {
       const childMod = moduleMap.get(ModuleId.make(child.moduleId));
       return {
@@ -195,9 +189,40 @@ const childrenMatrix = Effect.runSync(
   buildChildrenMatrix.pipe(Effect.provide(CatalogService.layer)),
 );
 
-// ---------------------------------------------------------------------------
-// Full-stack combos: pair each client combo with its required server modules
-// ---------------------------------------------------------------------------
+const buildCapabilityMatrix = Effect.gen(function* () {
+  const catalog = yield* CatalogService;
+  const entries: Array<CapabilityMatrixEntry> = [];
+  const allModules = catalog.getModules();
+
+  for (const mod of allModules) {
+    for (const dependency of mod.dependencies) {
+      if (dependency._tag !== "required-capability") continue;
+
+      const providers = catalog.getCapabilityProviders({
+        capability: dependency.capability,
+        target: dependency.target,
+      });
+
+      for (const provider of providers) {
+        entries.push({
+          requiringTarget: getModuleTarget(mod),
+          requiringModule: mod.id,
+          providerTarget: identityToTarget(dependency.target),
+          providerModule: provider.id,
+          providerCount: providers.length,
+          capability: dependency.capability,
+          label: `${getModuleTarget(mod)} + ${mod.id} with ${dependency.capability} provider ${provider.id}`,
+        });
+      }
+    }
+  }
+
+  return entries;
+});
+
+const capabilityMatrix = Effect.runSync(
+  buildCapabilityMatrix.pipe(Effect.provide(CatalogService.layer)),
+);
 
 const buildFullStackMatrix = Effect.gen(function* () {
   const catalog = yield* CatalogService;
@@ -245,6 +270,27 @@ const fullStackMatrix = Effect.runSync(
   buildFullStackMatrix.pipe(Effect.provide(CatalogService.layer)),
 );
 
+const expectInstallPasses = (project: {
+  install: () => Effect.Effect<{
+    readonly exitCode: number;
+    readonly stdout: string;
+    readonly stderr: string;
+  }>;
+}) =>
+  project
+    .install()
+    .pipe(
+      Effect.flatMap((result) =>
+        result.exitCode === 0
+          ? Effect.void
+          : Effect.die(
+              new Error(
+                `Install failed (exit ${result.exitCode})\nstdout: ${result.stdout.slice(0, 500)}\nstderr: ${result.stderr.slice(0, 500)}`,
+              ),
+            ),
+      ),
+    );
+
 /**
  * Acceptance tests for various module combinations in the matrix.
  *
@@ -264,11 +310,9 @@ describe("matrix", () => {
             const name = `matrix-${entry.target.replace("/", "-")}-${entry.modules.join("-")}`;
             const root = `${cli.workdir}/${name}`;
 
-            // Init project
             yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
-            // Add modules to target
             yield* cli.run(
               "add",
               "--yes",
@@ -281,8 +325,8 @@ describe("matrix", () => {
             );
             yield* cli.expectExitCode(0);
 
-            // Validate
             yield* cli.withinProject(name, function* (project) {
+              yield* expectInstallPasses(project);
               yield* project.expectTypeCheckPasses();
             });
           }).pipe(Effect.provide(CLI.layer)),
@@ -301,11 +345,9 @@ describe("matrix", () => {
             const name = `matrix-fullstack-${entry.clientModules.join("-")}`;
             const root = `${cli.workdir}/${name}`;
 
-            // Init project
             yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
-            // Add server modules first (satisfies implications)
             yield* cli.run(
               "add",
               "--yes",
@@ -318,7 +360,6 @@ describe("matrix", () => {
             );
             yield* cli.expectExitCode(0);
 
-            // Add client modules
             yield* cli.run(
               "add",
               "--yes",
@@ -331,8 +372,8 @@ describe("matrix", () => {
             );
             yield* cli.expectExitCode(0);
 
-            // Validate full project
             yield* cli.withinProject(name, function* (project) {
+              yield* expectInstallPasses(project);
               yield* project.expectTypeCheckPasses();
             });
           }).pipe(Effect.provide(CLI.layer)),
@@ -342,7 +383,6 @@ describe("matrix", () => {
   });
 
   layer(CLI.layer)("full-stack all client modules together", (it) => {
-    // Group full-stack entries by client target kind
     const byClientKind = new Map<
       string,
       { serverModules: Set<string>; clientModules: Set<string> }
@@ -370,11 +410,9 @@ describe("matrix", () => {
             const name = `matrix-fullstack-all-${kindSlug}`;
             const root = `${cli.workdir}/${name}`;
 
-            // Init
             yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
-            // Add all server modules
             yield* cli.run(
               "add",
               "--yes",
@@ -387,7 +425,6 @@ describe("matrix", () => {
             );
             yield* cli.expectExitCode(0);
 
-            // Add all client modules
             yield* cli.run(
               "add",
               "--yes",
@@ -400,8 +437,8 @@ describe("matrix", () => {
             );
             yield* cli.expectExitCode(0);
 
-            // Validate
             yield* cli.withinProject(name, function* (project) {
+              yield* expectInstallPasses(project);
               yield* project.expectTypeCheckPasses();
             });
           }).pipe(Effect.provide(CLI.layer)),
@@ -424,11 +461,9 @@ describe("matrix", () => {
             const name = `matrix-children-${entry.target.replace("/", "-")}-${sluggedModules}`;
             const root = `${cli.workdir}/${name}`;
 
-            // Init project
             yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
-            // Add parent module to its target
             yield* cli.run(
               "add",
               "--yes",
@@ -441,7 +476,6 @@ describe("matrix", () => {
             );
             yield* cli.expectExitCode(0);
 
-            // Add each optional child to its respective target
             for (const child of entry.optionalChildren) {
               yield* cli.run(
                 "add",
@@ -456,8 +490,8 @@ describe("matrix", () => {
               yield* cli.expectExitCode(0);
             }
 
-            // Validate
             yield* cli.withinProject(name, function* (project) {
+              yield* expectInstallPasses(project);
               yield* project.expectTypeCheckPasses();
             });
           }).pipe(Effect.provide(CLI.layer)),
@@ -465,4 +499,46 @@ describe("matrix", () => {
       );
     }
   });
+
+  if (capabilityMatrix.length > 0) {
+    layer(CLI.layer)("modules with required capabilities", (it) => {
+      for (const entry of capabilityMatrix) {
+        it.effect(
+          entry.label,
+          () =>
+            Effect.gen(function* () {
+              const cli = yield* CLI;
+              const name = `matrix-capability-${entry.capability}-${entry.requiringModule}-${entry.providerModule}`;
+              const root = `${cli.workdir}/${name}`;
+
+              yield* cli.run("init", name, "--yes", "--root", cli.workdir);
+              yield* cli.expectExitCode(0);
+
+              yield* cli.run(
+                "add",
+                "--yes",
+                "--root",
+                root,
+                "--target",
+                entry.requiringTarget,
+                "--modules",
+                entry.requiringModule,
+              );
+
+              if (entry.providerCount === 1) {
+                yield* cli.expectExitCode(0);
+
+                yield* cli.withinProject(name, function* (project) {
+                  yield* expectInstallPasses(project);
+                  yield* project.expectTypeCheckPasses();
+                });
+              } else {
+                yield* cli.expectExitCode(1);
+              }
+            }).pipe(Effect.provide(CLI.layer)),
+          { timeout: 180_000 },
+        );
+      }
+    });
+  }
 });

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -36,6 +36,7 @@
     "build:types": "tsc --emitDeclarationOnly",
     "dev": "bun --watch run src/index.ts",
     "start": "bun run src/index.ts",
+    "test": "vitest run src",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "type-check": "tsc --noEmit",
     "clean": "git clean -xdf .cache .turbo dist node_modules"

--- a/apps/cli/src/commands/add.test.ts
+++ b/apps/cli/src/commands/add.test.ts
@@ -1,0 +1,194 @@
+import { assert, describe, it } from "@effect/vitest";
+import { CatalogService } from "@repo/catalog";
+import {
+  CatalogNotFound,
+  ModuleCapability,
+  type ModuleDefinition,
+  ModuleId,
+  TargetIdentity,
+  TargetKind,
+} from "@repo/domain/Catalog";
+import { Array as Arr, Effect, Layer } from "effect";
+import { type CollectedTarget, resolveCapabilitiesNonInteractive } from "./add";
+
+const packageDb = new TargetIdentity({
+  kind: TargetKind.make("package"),
+  name: "db",
+});
+
+const serverApi = new TargetIdentity({
+  kind: TargetKind.make("server"),
+  name: "api",
+});
+
+const dbSql = ModuleCapability.make("db-sql");
+
+const makeModule = (
+  id: string,
+  options: Partial<typeof ModuleDefinition.Type> = {},
+): typeof ModuleDefinition.Type => ({
+  id: ModuleId.make(id),
+  title: id,
+  description: id,
+  supportedOn: [{ _tag: "identity", identity: serverApi }],
+  dependencies: [],
+  contributions: [],
+  ...options,
+});
+
+const makeCatalogLayer = (
+  modules: ReadonlyArray<typeof ModuleDefinition.Type>,
+) =>
+  Layer.succeed(CatalogService, {
+    getModule: Effect.fn("MockCatalog.getModule")(function* (
+      moduleId: typeof ModuleId.Type,
+    ) {
+      const module = Arr.findFirst(modules, (mod) => mod.id === moduleId);
+      if (module._tag === "Some") return module.value;
+      return yield* new CatalogNotFound({
+        catalog: "module",
+        entity: "module",
+        id: moduleId,
+      });
+    }),
+    getCapabilityProviders: (options: {
+      capability: typeof ModuleCapability.Type;
+      target: TargetIdentity;
+      visibility?: "public" | "internal";
+    }) =>
+      Arr.filter(
+        modules,
+        (mod) =>
+          Arr.contains(mod.provides ?? [], options.capability) &&
+          Arr.some(mod.supportedOn, (supportedOn) =>
+            options.target.matches(supportedOn),
+          ) &&
+          (options.visibility === undefined ||
+            (mod.visibility ?? "public") === options.visibility),
+      ),
+    getModules: () => modules,
+    getImplications: Effect.fn("MockCatalog.getImplications")(function* () {
+      return new Set<string>();
+    }),
+    getSupportedModules: Effect.fn("MockCatalog.getSupportedModules")(
+      function* () {
+        return [...modules];
+      },
+    ),
+    getTargetKinds: () => [],
+    getTarget: Effect.fn("MockCatalog.getTarget")(function* (kind) {
+      return {
+        kind,
+        title: kind,
+        description: kind,
+        contributions: [],
+        scripts: [],
+        nextSteps: [],
+        requiredModules: [],
+      };
+    }),
+    isSupportedOn: Effect.fn("MockCatalog.isSupportedOn")(function* () {
+      return true;
+    }),
+    isImpliedByAny: Effect.fn("MockCatalog.isImpliedByAny")(function* () {
+      return false;
+    }),
+    toCatalogTree: { targets: [] },
+    toGraph: undefined as never,
+  });
+
+describe("resolveCapabilitiesNonInteractive", () => {
+  it.effect(
+    "should add the provider module when a required capability has one matching provider then report the target set changed",
+    () => {
+      const requiringModule = makeModule("needs-db", {
+        dependencies: [
+          {
+            _tag: "required-capability",
+            target: packageDb,
+            capability: dbSql,
+          },
+        ],
+      });
+      const providerModule = makeModule("package-db-sqlite", {
+        provides: [dbSql],
+        supportedOn: [{ _tag: "identity", identity: packageDb }],
+      });
+
+      return Effect.gen(function* () {
+        const targets: Array<CollectedTarget> = [
+          {
+            kind: TargetKind.make("server"),
+            name: "api",
+            modules: [requiringModule.id],
+            confirmed: true,
+          },
+        ];
+
+        const changed = yield* resolveCapabilitiesNonInteractive(targets);
+
+        assert.isTrue(changed);
+        assert.deepStrictEqual(targets, [
+          {
+            kind: TargetKind.make("server"),
+            name: "api",
+            modules: [requiringModule.id],
+            confirmed: true,
+          },
+          {
+            kind: TargetKind.make("package"),
+            name: "db",
+            modules: [providerModule.id],
+            confirmed: true,
+          },
+        ]);
+      }).pipe(
+        Effect.provide(makeCatalogLayer([requiringModule, providerModule])),
+      );
+    },
+  );
+
+  it.effect(
+    "should fail when a required capability has multiple matching providers then explain that interactive selection is required",
+    () => {
+      const requiringModule = makeModule("needs-db", {
+        dependencies: [
+          {
+            _tag: "required-capability",
+            target: packageDb,
+            capability: dbSql,
+          },
+        ],
+      });
+      const providerModules = [
+        makeModule("package-db-sqlite", {
+          provides: [dbSql],
+          supportedOn: [{ _tag: "identity", identity: packageDb }],
+        }),
+        makeModule("package-db-postgres", {
+          provides: [dbSql],
+          supportedOn: [{ _tag: "identity", identity: packageDb }],
+        }),
+      ];
+
+      return Effect.gen(function* () {
+        const targets: Array<CollectedTarget> = [
+          {
+            kind: TargetKind.make("server"),
+            name: "api",
+            modules: [requiringModule.id],
+            confirmed: true,
+          },
+        ];
+
+        const error = yield* Effect.flip(
+          resolveCapabilitiesNonInteractive(targets),
+        );
+
+        assert.include(error, "multiple providers are available");
+      }).pipe(
+        Effect.provide(makeCatalogLayer([requiringModule, ...providerModules])),
+      );
+    },
+  );
+});

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -1,6 +1,7 @@
 import { CatalogService } from "@repo/catalog";
 import {
   ModuleDefinition,
+  type ModuleDependency,
   ModuleId,
   TargetIdentity,
   TargetKind,
@@ -36,7 +37,7 @@ import { dryRunFlag, rootFlag, trustFlag, yesFlag } from "../flags";
 import { ConfigureService } from "../service/ConfigureService";
 import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
 
-type CollectedTarget = {
+export type CollectedTarget = {
   kind: typeof TargetKind.Type;
   name: string;
   modules: Array<typeof ModuleId.Type>;
@@ -439,6 +440,164 @@ const removeOrphanedImplications = (
     return changed;
   });
 
+const findTarget = (
+  targets: ReadonlyArray<CollectedTarget>,
+  identity: TargetIdentity,
+) =>
+  Arr.findFirst(
+    targets,
+    (target) => target.kind === identity.kind && target.name === identity.name,
+  );
+
+const ensureTargetModule = (
+  targets: Array<CollectedTarget>,
+  identity: TargetIdentity,
+  moduleId: typeof ModuleId.Type,
+  confirmed: boolean,
+) => {
+  const existing = findTarget(targets, identity);
+
+  return Option.match(existing, {
+    onNone: () => {
+      targets.push({
+        kind: identity.kind,
+        name: identity.name,
+        modules: [moduleId],
+        confirmed,
+      });
+      return true;
+    },
+    onSome: (target) => {
+      if (Arr.contains(target.modules, moduleId)) return false;
+      target.modules.push(moduleId);
+      target.confirmed = confirmed;
+      return true;
+    },
+  });
+};
+
+const resolveCapabilities = <E, R>(
+  targets: Array<CollectedTarget>,
+  confirmed: boolean,
+  selectProvider: (options: {
+    definition: typeof ModuleDefinition.Type;
+    dependency: Extract<
+      typeof ModuleDependency.Type,
+      { _tag: "required-capability" }
+    >;
+    requiredTarget: TargetIdentity;
+    providers: ReadonlyArray<typeof ModuleDefinition.Type>;
+  }) => Effect.Effect<typeof ModuleDefinition.Type, E, R>,
+) =>
+  Effect.gen(function* () {
+    const catalog = yield* CatalogService;
+    let changed = false;
+
+    yield* Effect.forEach([...targets], (target) =>
+      Effect.forEach([...target.modules], (moduleId) =>
+        Effect.gen(function* () {
+          const definition = yield* catalog.getModule(moduleId);
+
+          yield* Effect.forEach(definition.dependencies, (dependency) =>
+            Effect.gen(function* () {
+              if (dependency._tag !== "required-capability") return;
+
+              const requiredTarget = dependency.target;
+              const currentTarget = findTarget(targets, requiredTarget);
+              const providedByCurrentSelection = yield* Option.match(
+                currentTarget,
+                {
+                  onNone: () => Effect.succeed(false),
+                  onSome: (selectedTarget) =>
+                    Effect.gen(function* () {
+                      const providedBy = yield* Effect.filter(
+                        selectedTarget.modules,
+                        (selectedModuleId) =>
+                          Effect.gen(function* () {
+                            const selectedModule =
+                              yield* catalog.getModule(selectedModuleId);
+                            return Arr.contains(
+                              selectedModule.provides ?? [],
+                              dependency.capability,
+                            );
+                          }),
+                      );
+
+                      return Arr.isArrayNonEmpty(providedBy);
+                    }),
+                },
+              );
+
+              if (providedByCurrentSelection) return;
+
+              const providers = catalog.getCapabilityProviders({
+                capability: dependency.capability,
+                target: requiredTarget,
+              });
+
+              if (providers.length === 0) {
+                return yield* Effect.fail(
+                  `Module "${definition.id}" requires capability "${dependency.capability}" on ${requiredTarget.toKey()}, but no compatible provider module exists.`,
+                );
+              }
+
+              const provider =
+                providers.length === 1
+                  ? providers[0]
+                  : yield* selectProvider({
+                      definition,
+                      dependency,
+                      requiredTarget,
+                      providers,
+                    });
+
+              if (!provider) return;
+
+              changed =
+                ensureTargetModule(
+                  targets,
+                  requiredTarget,
+                  provider.id,
+                  confirmed,
+                ) || changed;
+            }),
+          );
+        }),
+      ),
+    );
+
+    return changed;
+  });
+
+export const resolveCapabilitiesNonInteractive = (
+  targets: Array<CollectedTarget>,
+) =>
+  resolveCapabilities(targets, true, (options) =>
+    Effect.fail(
+      `Module "${options.definition.id}" requires capability "${options.dependency.capability}" on ${options.requiredTarget.toKey()}, but multiple providers are available: ${Arr.join(
+        Arr.map(options.providers, (provider) => provider.id),
+        ", ",
+      )}. Use interactive add to choose a provider.`,
+    ),
+  );
+
+const resolveCapabilitiesInteractive = (targets: Array<CollectedTarget>) =>
+  resolveCapabilities(
+    targets,
+    false,
+    ({ definition, dependency, requiredTarget, providers }) =>
+      Effect.gen(function* () {
+        const catalog = yield* CatalogService;
+        return yield* HorizontalSelect({
+          message: `Module "${definition.title}" requires ${dependency.capability}. Which provider should be added to ${requiredTarget.toKey()}?`,
+          choices: Arr.map(providers, (candidate) => ({
+            title: candidate.title,
+            value: candidate.id,
+          })),
+        }).pipe(Effect.flatMap((selectedId) => catalog.getModule(selectedId)));
+      }),
+  );
+
 const resolveImplicationsNonInteractive = (
   targets: Array<CollectedTarget>,
   repoRoot: string,
@@ -532,6 +691,31 @@ const resolveImplicationsNonInteractive = (
           }),
         ),
       );
+    }
+
+    return targets;
+  });
+
+const resolveDependenciesInteractive = (targets: Array<CollectedTarget>) =>
+  Effect.gen(function* () {
+    let changed = true;
+    while (changed) {
+      const implicationsChanged = yield* resolveImplications(targets);
+      const capabilitiesChanged =
+        yield* resolveCapabilitiesInteractive(targets);
+      changed = implicationsChanged || capabilitiesChanged;
+    }
+  });
+
+const resolveDependenciesNonInteractive = (
+  targets: Array<CollectedTarget>,
+  repoRoot: string,
+) =>
+  Effect.gen(function* () {
+    let changed = true;
+    while (changed) {
+      yield* resolveImplicationsNonInteractive(targets, repoRoot);
+      changed = yield* resolveCapabilitiesNonInteractive(targets);
     }
 
     return targets;
@@ -665,7 +849,7 @@ const collectTargetsFromFlags = (
       },
     ];
 
-    yield* resolveImplicationsNonInteractive(targets, repoRoot);
+    yield* resolveDependenciesNonInteractive(targets, repoRoot);
 
     return targets;
   });
@@ -732,11 +916,7 @@ const collectTargetsInteractive = Effect.gen(function* () {
     }),
   );
 
-  // Resolve implications (fixed-point)
-  let implChanged = true;
-  while (implChanged) {
-    implChanged = yield* resolveImplications(targets);
-  }
+  yield* resolveDependenciesInteractive(targets);
 
   // Confirmation loop
   let allConfirmed = false;
@@ -819,10 +999,7 @@ const collectTargetsInteractive = Effect.gen(function* () {
                       Arr.map(newModules, (m) => `${t.kind}:${m}`),
                     );
                     yield* removeOrphanedImplications(targets, pinned);
-                    let changed = true;
-                    while (changed) {
-                      changed = yield* resolveImplications(targets);
-                    }
+                    yield* resolveDependenciesInteractive(targets);
                   } else {
                     t.confirmed = true;
                   }
@@ -835,10 +1012,7 @@ const collectTargetsInteractive = Effect.gen(function* () {
         Effect.gen(function* () {
           yield* addTarget;
 
-          let changed = true;
-          while (changed) {
-            changed = yield* resolveImplications(targets);
-          }
+          yield* resolveDependenciesInteractive(targets);
         }),
       ),
       Match.exhaustive,

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -1,6 +1,7 @@
 import type {
   CatalogGraph,
   CatalogTree,
+  ModuleCapability,
   ModuleCategory,
   ModuleId,
   ModuleImplication,
@@ -35,6 +36,19 @@ export class CatalogService extends Context.Service<CatalogService>()(
     make: Effect.gen(function* () {
       const targetIndex = new Map(targetRegistry.map((t) => [t.kind, t]));
       const moduleIndex = new Map(moduleRegistry.map((m) => [m.id, m]));
+
+      const capabilityProviderIndex = Arr.reduce(
+        moduleRegistry,
+        new Map<string, Array<(typeof moduleRegistry)[number]>>(),
+        (index, definition) => {
+          for (const capability of definition.provides ?? []) {
+            const providers = index.get(capability) ?? [];
+            providers.push(definition);
+            index.set(capability, providers);
+          }
+          return index;
+        },
+      );
 
       const allImplications = Arr.flatMap(
         moduleRegistry,
@@ -140,6 +154,20 @@ export class CatalogService extends Context.Service<CatalogService>()(
         });
       });
 
+      const getCapabilityProviders = (options: {
+        capability: typeof ModuleCapability.Type;
+        target: TargetIdentity;
+        visibility?: typeof Visibility.Type;
+      }) =>
+        Arr.filter(
+          capabilityProviderIndex.get(options.capability) ?? [],
+          (mod) =>
+            hasVisibility(mod, options.visibility) &&
+            Arr.some(mod.supportedOn, (supportedOn) =>
+              options.target.matches(supportedOn),
+            ),
+        );
+
       const toGraph: CatalogGraph = Graph.directed((g) => {
         const targetNodes = new Map<string, number>();
         for (const target of targetRegistry) {
@@ -226,25 +254,23 @@ export class CatalogService extends Context.Service<CatalogService>()(
           modules: Arr.filterMap(
             Arr.fromIterable(moduleIndex.values()),
             (mod) => {
-              const supported = Arr.some(
-                mod.supportedOn,
-                (s) => supportedOnTargetKind(s) === target.kind,
-              );
-              if (!supported) return Result.fail("skip" as const);
+              if (!moduleSupportsTargetKind(mod, target.kind)) {
+                return Result.fail("skip" as const);
+              }
               return Result.succeed({
                 id: mod.id,
                 title: mod.title,
                 description: mod.description,
                 categories: mod.categories ?? [],
-                requires: Arr.filterMap(mod.dependencies, (dep) => {
-                  if (dep._tag !== "required-module")
-                    return Result.fail("skip" as const);
-                  return Result.succeed({
-                    targetKind: dep.target.kind,
-                    targetName: dep.target.name,
-                    moduleId: dep.moduleId,
-                  });
-                }),
+                requires: Arr.filterMap(
+                  mod.dependencies,
+                  requiredModuleDependency,
+                ),
+                requiredCapabilities: Arr.filterMap(
+                  mod.dependencies,
+                  requiredCapabilityDependency,
+                ),
+                provides: mod.provides ?? [],
                 implies: (mod.implies ?? []).map((imp) => ({
                   targetKind: imp.targetKind,
                   moduleId: imp.moduleId,
@@ -257,6 +283,7 @@ export class CatalogService extends Context.Service<CatalogService>()(
 
       return {
         getImplications,
+        getCapabilityProviders,
         getModules,
         getModule,
         getSupportedModules,

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -30,6 +30,48 @@ const supportedOnTargetKind = Match.type<
   Match.exhaustive,
 );
 
+const hasVisibility = (
+  definition: { readonly visibility?: typeof Visibility.Type },
+  visibility: typeof Visibility.Type | undefined,
+): boolean =>
+  visibility === undefined ||
+  (definition.visibility ?? "public") === visibility;
+
+const moduleSupportsTargetKind = (
+  mod: typeof import("@repo/domain/Catalog").ModuleDefinition.Type,
+  kind: typeof TargetKind.Type,
+): boolean =>
+  Arr.some(
+    mod.supportedOn,
+    (supportedOn) => supportedOnTargetKind(supportedOn) === kind,
+  );
+
+const requiredModuleDependency = Match.type<
+  typeof import("@repo/domain/Catalog").ModuleDependency.Type
+>().pipe(
+  Match.tag("required-module", (dep) =>
+    Result.succeed({
+      targetKind: dep.target.kind,
+      targetName: dep.target.name,
+      moduleId: dep.moduleId,
+    }),
+  ),
+  Match.orElse(() => Result.fail("skip" as const)),
+);
+
+const requiredCapabilityDependency = Match.type<
+  typeof import("@repo/domain/Catalog").ModuleDependency.Type
+>().pipe(
+  Match.tag("required-capability", (dep) =>
+    Result.succeed({
+      targetKind: dep.target.kind,
+      targetName: dep.target.name,
+      capability: dep.capability,
+    }),
+  ),
+  Match.orElse(() => Result.fail("skip" as const)),
+);
+
 export class CatalogService extends Context.Service<CatalogService>()(
   "CatalogService",
   {
@@ -124,14 +166,12 @@ export class CatalogService extends Context.Service<CatalogService>()(
       const getTargetKinds = (options?: {
         visibility?: typeof Visibility.Type;
       }): ReadonlyArray<typeof TargetKind.Type> => {
-        const kinds = Arr.fromIterable(targetIndex.keys());
-        if (options?.visibility) {
-          return Arr.filter(kinds, (kind) => {
-            const target = targetIndex.get(kind);
-            return (target?.visibility ?? "public") === options.visibility;
-          });
-        }
-        return kinds;
+        return Arr.map(
+          Arr.filter(Arr.fromIterable(targetIndex.values()), (target) =>
+            hasVisibility(target, options?.visibility),
+          ),
+          (target) => target.kind,
+        );
       };
 
       const getSupportedModules = Effect.fn(
@@ -141,17 +181,12 @@ export class CatalogService extends Context.Service<CatalogService>()(
         options?: { visibility?: typeof Visibility.Type },
       ) {
         yield* getTarget(kind);
-        return Arr.filter(Arr.fromIterable(moduleIndex.values()), (mod) => {
-          const kindMatch = Arr.some(
-            mod.supportedOn,
-            (s) => supportedOnTargetKind(s) === kind,
-          );
-          if (!kindMatch) return false;
-          if (options?.visibility) {
-            return (mod.visibility ?? "public") === options.visibility;
-          }
-          return true;
-        });
+        return Arr.filter(
+          Arr.fromIterable(moduleIndex.values()),
+          (mod) =>
+            moduleSupportsTargetKind(mod, kind) &&
+            hasVisibility(mod, options?.visibility),
+        );
       });
 
       const getCapabilityProviders = (options: {

--- a/packages/catalog/src/registry/content/db.ts
+++ b/packages/catalog/src/registry/content/db.ts
@@ -1,0 +1,124 @@
+export const dbIndexContents = `export * from "./Database";
+export * from "./HealthCheck";
+export * from "./Migrations";
+`;
+
+export const dbDatabaseContents = `{{#if runtime=bun}}import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { SqliteClient } from "@effect/sql-sqlite-bun";{{/if}}{{#if runtime=node}}import { NodeFileSystem, NodePath } from "@effect/platform-node";
+import { SqliteClient } from "@effect/sql-sqlite-node";{{/if}}
+import { Config, Effect, FileSystem, Layer, Path, String } from "effect";
+
+export const DatabaseConfig = Config.all({
+  filename: Config.string("DATABASE_FILE").pipe(
+    Config.withDefault("../../data/app.sqlite"),
+  ),
+});
+
+const ensureDatabaseDirectory = (filename: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directory = path.dirname(filename);
+
+    if (directory !== "." && directory !== "") {
+      yield* fs.makeDirectory(directory, { recursive: true });
+    }
+  });
+
+export const SqliteLive = Layer.unwrap(
+  Effect.gen(function* () {
+    const config = yield* DatabaseConfig;
+    yield* ensureDatabaseDirectory(config.filename);
+
+    return SqliteClient.layer({
+      filename: config.filename,
+      transformQueryNames: String.camelToSnake,
+      transformResultNames: String.snakeToCamel,
+    });
+  }),
+).pipe(Layer.provide({{#if runtime=bun}}[BunFileSystem.layer, BunPath.layer]{{/if}}{{#if runtime=node}}[NodeFileSystem.layer, NodePath.layer]{{/if}}));
+`;
+
+export const dbMigrationsContents = `{{#if runtime=bun}}import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { SqliteMigrator } from "@effect/sql-sqlite-bun";{{/if}}{{#if runtime=node}}import { NodeFileSystem, NodePath } from "@effect/platform-node";
+import { SqliteMigrator } from "@effect/sql-sqlite-node";{{/if}}
+import { Effect, Layer, Path } from "effect";
+import { SqliteLive } from "./Database";
+
+const MigrationsDirectory = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  return path.join(
+    path.dirname(new URL(import.meta.url).pathname),
+    "migrations",
+  );
+});
+
+export const MigrationsLive = Layer.unwrap(
+  Effect.map(MigrationsDirectory, (directory) =>
+    SqliteMigrator.layer({
+      loader: SqliteMigrator.fromFileSystem(directory),
+    }),
+  ),
+).pipe(Layer.provide({{#if runtime=bun}}[BunFileSystem.layer, BunPath.layer]{{/if}}{{#if runtime=node}}[NodeFileSystem.layer, NodePath.layer]{{/if}}));
+
+export const MigratedLive = MigrationsLive.pipe(
+  Layer.provide(SqliteLive),
+  Layer.orDie,
+);
+
+export const DatabaseLive = Layer.mergeAll(SqliteLive, MigratedLive);
+`;
+
+export const dbHealthCheckContents = `import { Effect } from "effect";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
+
+export const checkDatabaseHealth = Effect.gen(function* () {
+  const sql = yield* SqlClient;
+  const rows = yield* sql<{ ok: number }>\`SELECT 1 AS ok\`;
+  return rows[0]?.ok === 1;
+});
+`;
+
+export const dbMigration0001CreateDbHealthContents = `import { Effect } from "effect";
+import { SqlClient } from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient;
+
+  yield* sql\`
+    CREATE TABLE IF NOT EXISTS db_health (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      checked_at TEXT NOT NULL DEFAULT current_timestamp
+    )
+  \`;
+
+  yield* sql\`
+    INSERT INTO db_health (id)
+    VALUES (1)
+    ON CONFLICT(id) DO UPDATE SET checked_at = current_timestamp
+  \`;
+});
+`;
+
+export const dbMigrateScriptContents = `{{#if runtime=bun}}import { BunRuntime } from "@effect/platform-bun";{{/if}}{{#if runtime=node}}import { NodeRuntime } from "@effect/platform-node";{{/if}}
+import { Console, Effect } from "effect";
+import { MigratedLive } from "../src";
+
+const program = Effect.gen(function* () {
+  yield* Console.log("Database migrations completed");
+}).pipe(Effect.provide(MigratedLive));
+
+{{#if runtime=bun}}BunRuntime{{/if}}{{#if runtime=node}}NodeRuntime{{/if}}.runMain(program);
+`;
+
+export const dbHealthScriptContents = `{{#if runtime=bun}}import { BunRuntime } from "@effect/platform-bun";{{/if}}{{#if runtime=node}}import { NodeRuntime } from "@effect/platform-node";{{/if}}
+import { Console, Effect } from "effect";
+import { checkDatabaseHealth, DatabaseLive } from "../src";
+
+const program = Effect.gen(function* () {
+  const healthy = yield* checkDatabaseHealth;
+  yield* Console.log(healthy ? "Database is healthy" : "Database is unhealthy");
+}).pipe(Effect.provide(DatabaseLive));
+
+{{#if runtime=bun}}BunRuntime{{/if}}{{#if runtime=node}}NodeRuntime{{/if}}.runMain(program);
+`;

--- a/packages/catalog/src/registry/moduleRegistry.test.ts
+++ b/packages/catalog/src/registry/moduleRegistry.test.ts
@@ -27,6 +27,38 @@ describe("moduleRegistry", () => {
     expect(missing).toEqual([]);
   });
 
+  it("should only require capabilities with compatible providers", () => {
+    const missing: Array<{
+      module: string;
+      capability: string;
+      target: string;
+    }> = [];
+
+    for (const mod of moduleRegistry) {
+      for (const dep of mod.dependencies) {
+        if (dep._tag !== "required-capability") continue;
+
+        const providers = moduleRegistry.filter(
+          (provider) =>
+            provider.provides?.includes(dep.capability) &&
+            provider.supportedOn.some((supportedOn) =>
+              dep.target.matches(supportedOn),
+            ),
+        );
+
+        if (providers.length === 0) {
+          missing.push({
+            module: mod.id,
+            capability: dep.capability,
+            target: dep.target.toKey(),
+          });
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
   it("should only reference existing modules in implies", () => {
     const missing: Array<{ module: string; references: string }> = [];
 

--- a/packages/catalog/src/registry/modules/packages.ts
+++ b/packages/catalog/src/registry/modules/packages.ts
@@ -1,4 +1,5 @@
 import {
+  ModuleCapability,
   type ModuleDefinition,
   ModuleId,
   TargetIdentity,
@@ -17,6 +18,15 @@ import {
   aiThinkToolkitContents,
   aiWebFetchToolkitContents,
 } from "../content/ai";
+import {
+  dbDatabaseContents,
+  dbHealthCheckContents,
+  dbHealthScriptContents,
+  dbIndexContents,
+  dbMigrateScriptContents,
+  dbMigration0001CreateDbHealthContents,
+  dbMigrationsContents,
+} from "../content/db";
 import {
   presenceClientGeneratorContents,
   presenceIndexContents,
@@ -464,6 +474,103 @@ export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         _tag: "barrel-export",
         barrelPath: "{{targetPath}}/src/index.ts",
         exportPath: "./workflow/AgenticLoop",
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("package-db-sqlite"),
+    title: "SQLite Database",
+    description: "Reusable Effect SQL SQLite package with migrations",
+    provides: [ModuleCapability.make("db-sql")],
+    supportedOn: [
+      {
+        _tag: "identity",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "db",
+        }),
+      },
+    ],
+    dependencies: [],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/index.ts",
+        contents: dbIndexContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/Database.ts",
+        contents: dbDatabaseContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/Migrations.ts",
+        contents: dbMigrationsContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/HealthCheck.ts",
+        contents: dbHealthCheckContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/migrations/0001_create_db_health.ts",
+        contents: dbMigration0001CreateDbHealthContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/scripts/migrate.ts",
+        contents: dbMigrateScriptContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/scripts/health.ts",
+        contents: dbHealthScriptContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "{{#if runtime=bun}}@effect/platform-bun{{/if}}{{#if runtime=node}}@effect/platform-node{{/if}}",
+        value: "4.0.0-beta.80",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "{{#if runtime=bun}}@effect/sql-sqlite-bun{{/if}}{{#if runtime=node}}@effect/sql-sqlite-node{{/if}}",
+        value: "4.0.0-beta.80",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "{{#if runtime=node}}tsx{{/if}}",
+        value: "^4.21.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "exports",
+        name: ".",
+        value: "./src/index.ts",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "db:migrate",
+        value:
+          "{{#if runtime=bun}}bun run scripts/migrate.ts{{/if}}{{#if runtime=node}}node --import tsx scripts/migrate.ts{{/if}}",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "db:health",
+        value:
+          "{{#if runtime=bun}}bun run scripts/health.ts{{/if}}{{#if runtime=node}}node --import tsx scripts/health.ts{{/if}}",
       },
     ],
   },

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -8,6 +8,10 @@ export class CatalogNotFound extends Data.TaggedError("CatalogNotFound")<{
 
 export const ModuleId = Schema.String.pipe(Schema.brand("ModuleId"));
 
+export const ModuleCapability = Schema.String.pipe(
+  Schema.brand("ModuleCapability"),
+);
+
 export const TargetKind = Schema.Union([
   Schema.Literal("workspace"),
   Schema.Literal("package"),
@@ -225,6 +229,9 @@ export const Contribution = Schema.TaggedUnion({
  * - `required-target`: Target must exist as a workspace (no specific module required)
  * - `required-module`: Module must be attached to the specified target
  *                      (target existence is implicit - you can't attach a module to a non-existent target)
+ * - `required-capability`: Target must have a module that provides a capability
+ *                          such as `db-sql`. CLI prompts should resolve this to
+ *                          a concrete provider module before Blueprint resolution.
  */
 export const ModuleDependency = Schema.TaggedUnion({
   /**
@@ -243,6 +250,16 @@ export const ModuleDependency = Schema.TaggedUnion({
   "required-module": {
     target: TargetIdentity,
     moduleId: ModuleId,
+  },
+
+  /**
+   * Target must have a module that provides the requested capability.
+   * Interactive selection resolves this to a concrete provider module before
+   * Blueprint resolution; Blueprint treats unresolved capabilities as invalid.
+   */
+  "required-capability": {
+    target: TargetIdentity,
+    capability: ModuleCapability,
   },
 });
 
@@ -279,6 +296,10 @@ export const ModuleDefinition = Schema.Struct({
     Schema.withConstructorDefault(Effect.succeed("public" as const)),
   ),
   categories: Schema.Array(ModuleCategory).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
+  provides: Schema.Array(ModuleCapability).pipe(
     Schema.optionalKey,
     Schema.withConstructorDefault(Effect.succeed([])),
   ),
@@ -371,6 +392,14 @@ export const CatalogTreeModule = Schema.Struct({
       moduleId: ModuleId,
     }),
   ),
+  requiredCapabilities: Schema.Array(
+    Schema.Struct({
+      targetKind: TargetKind,
+      targetName: Schema.String,
+      capability: ModuleCapability,
+    }),
+  ),
+  provides: Schema.Array(ModuleCapability),
   implies: Schema.Array(ModuleImplication),
 });
 

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -268,6 +268,12 @@ const resolveSelection = Effect.fn("BlueprintService.resolveSelection")(
                 reason: "required-module",
               });
             }),
+          "required-capability": (dep) =>
+            Effect.fail(
+              new BlueprintFailure({
+                message: `Unresolved capability dependency: ${target.toKey()} requires module ${moduleId}, which needs ${dep.capability} on ${dep.target.toKey()}. Select a provider module explicitly.`,
+              }),
+            ),
         });
       }
 

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -96,28 +96,36 @@ const resolveContributionTokens = (
 ): ReadonlyArray<typeof Contribution.Type> => {
   const resolveString = (value: string) => context.resolve(value);
 
-  return Arr.map(
+  return Arr.flatMap(
     contributions,
     Contribution.match({
-      file: (c): typeof Contribution.Type =>
+      file: (c): ReadonlyArray<typeof Contribution.Type> => [
         Contribution.cases.file.make({
           path: resolveString(c.path),
           contents: resolveString(c.contents),
           conflictOnModify: c.conflictOnModify,
         }),
-      "pkg-json-entry": (c): typeof Contribution.Type =>
-        Contribution.cases["pkg-json-entry"].make({
-          path: resolveString(c.path),
-          field: c.field,
-          name: c.name,
-          value: c.value,
-        }),
-      "barrel-export": (c): typeof Contribution.Type =>
+      ],
+      "pkg-json-entry": (c): ReadonlyArray<typeof Contribution.Type> => {
+        const name = resolveString(c.name).trim();
+        if (name.length === 0) return [];
+
+        return [
+          Contribution.cases["pkg-json-entry"].make({
+            path: resolveString(c.path),
+            field: c.field,
+            name,
+            value: resolveString(c.value),
+          }),
+        ];
+      },
+      "barrel-export": (c): ReadonlyArray<typeof Contribution.Type> => [
         Contribution.cases["barrel-export"].make({
           barrelPath: resolveString(c.barrelPath),
           exportPath: c.exportPath,
         }),
-      "ts-call-arg": (c): typeof Contribution.Type =>
+      ],
+      "ts-call-arg": (c): ReadonlyArray<typeof Contribution.Type> => [
         Contribution.cases["ts-call-arg"].make({
           path: resolveString(c.path),
           targetVariable: c.targetVariable,
@@ -125,7 +133,8 @@ const resolveContributionTokens = (
           argument: c.argument,
           import: c.import,
         }),
-      "ts-object-field": (c): typeof Contribution.Type =>
+      ],
+      "ts-object-field": (c): ReadonlyArray<typeof Contribution.Type> => [
         Contribution.cases["ts-object-field"].make({
           path: resolveString(c.path),
           targetVariable: c.targetVariable,
@@ -134,13 +143,15 @@ const resolveContributionTokens = (
           value: c.value,
           import: c.import,
         }),
-      "jsx-slot": (c): typeof Contribution.Type =>
+      ],
+      "jsx-slot": (c): ReadonlyArray<typeof Contribution.Type> => [
         Contribution.cases["jsx-slot"].make({
           path: resolveString(c.path),
           slotId: c.slotId,
           content: c.content,
           import: c.import,
         }),
+      ],
     }),
   );
 };


### PR DESCRIPTION
## Goals/Scope

Add a new SQLite database module.

## Description

- Add catalog support for module capabilities.
- Introduce a new SQLite database module.
- Fix scaffold logic for conditional package entries.
- Update capacity handling (adjust `maxtric` to include capacities).
- Refactor the `add` command to validate capacity inputs.

---

- [x] closes #146