### PR TITLE
feat: add module for ask command in cli

### DIFF
--- a/.changeset/happy-pants-kiss.md
+++ b/.changeset/happy-pants-kiss.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add 'chat-cli-driver`and`chat-ask-command` modules

--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -213,6 +213,53 @@ describe("add", () => {
     );
 
     it.effect(
+      "chat ask command scaffolds CLI driver and AI dependencies",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/ask-test`;
+
+          yield* cli.run("init", "ask-test", "--yes", "--root", cli.workdir);
+          yield* cli.expectExitCode(0);
+
+          yield* cli.run(
+            "add",
+            "--yes",
+            "--root",
+            root,
+            "--target",
+            "cli/app",
+            "--modules",
+            "chat-ask-command",
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject("ask-test", function* (project) {
+            yield* project.expectFileExists("apps/cli-app/src/commands/ask.ts");
+            yield* project.expectFileExists(
+              "apps/cli-app/src/chat/ChatDriver.ts",
+            );
+            yield* project.expectFileExists("packages/ai/package.json");
+            yield* project.expectFileExists("packages/domain/package.json");
+            yield* project.expectFileContaining(
+              "apps/cli-app/src/index.ts",
+              "ask",
+            );
+            yield* project.expectFileContaining(
+              "apps/cli-app/package.json",
+              '"@repo/ai": "workspace:*"',
+            );
+            yield* project.expectFileContaining(
+              "apps/cli-app/package.json",
+              '"@repo/domain": "workspace:*"',
+            );
+            yield* project.expectTypeCheckPasses();
+          });
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 120_000 },
+    );
+
+    it.effect(
       "client-foldkit target scaffolds with rest module when server exists",
       () =>
         Effect.gen(function* () {

--- a/packages/catalog/src/registry/content/ai.ts
+++ b/packages/catalog/src/registry/content/ai.ts
@@ -96,7 +96,7 @@ export class AiChatService extends Context.Service<AiChatService>()("AiChatServi
             \`);
 
         const session = yield* Chat.fromPrompt(
-          Prompt.make(history).pipe(Prompt.setSystem(systemMessage)),
+          Prompt.make(history).pipe(Prompt.appendSystem(systemMessage)),
         );
 
         yield* loop.run({

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -92,3 +92,134 @@ export const hello = Command.make("hello", { name, shout }, ({ name, shout }) =>
   }),
 ).pipe(Command.withDescription("Print a greeting message"));
 `;
+
+export const cliChatDriverContents = `import { AiChatService, AiChatServiceLive, FastModelLive } from "@repo/ai";
+import type { ChatMessage, ChatStreamPart } from "@repo/domain/Chat";
+import { Array, Context, Effect, Layer, Match, pipe, Stream } from "effect";
+import { Prompt } from "effect/unstable/ai";
+
+// The server runtime has a similar helper, but the CLI module must not depend on
+// server/RPC modules. If this duplication grows after the interactive chat command
+// lands, consider moving a pure conversion helper to a shared package boundary.
+const toPromptMessage = (message: ChatMessage) => {
+  return pipe(
+    Match.value(message.role),
+    Match.when("system", () =>
+      Prompt.systemMessage({ content: message.content }),
+    ),
+    Match.when("user", () =>
+      Prompt.userMessage({
+        content: [Prompt.textPart({ text: message.content })],
+      }),
+    ),
+    Match.when("assistant", () =>
+      Prompt.assistantMessage({
+        content: [Prompt.textPart({ text: message.content })],
+      }),
+    ),
+    Match.exhaustive,
+  );
+};
+
+export class TerminalChatDriver extends Context.Service<TerminalChatDriver>()(
+  "TerminalChatDriver",
+  {
+    make: Effect.gen(function* () {
+      const chat = yield* AiChatService;
+
+      const streamTurn = (
+        messages: ReadonlyArray<ChatMessage>,
+      ): Stream.Stream<ChatStreamPart> =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const promptMessages: Array<Prompt.Message> = pipe(
+              messages,
+              Array.map(toPromptMessage),
+            );
+
+            const queue = yield* chat
+              .chat(promptMessages)
+              .pipe(Effect.provide(FastModelLive), Effect.orDie);
+
+            return Stream.fromQueue(queue);
+          }),
+        );
+
+      return {
+        streamTurn,
+      } as const;
+    }),
+  },
+) {}
+
+export const TerminalChatDriverLive = Layer.effect(TerminalChatDriver)(
+  TerminalChatDriver.make,
+).pipe(Layer.provide(AiChatServiceLive));
+`;
+
+export const cliAskCommandContents = `import type { ChatStreamPart } from "@repo/domain/Chat";
+import {
+  Console,
+  Effect,
+  Match,
+  Schema,
+  Stdio,
+  Stream,
+  String,
+} from "effect";
+import { Argument, Command } from "effect/unstable/cli";
+import { TerminalChatDriver, TerminalChatDriverLive } from "../chat/ChatDriver";
+
+const message = Argument.string("message").pipe(
+  Argument.withSchema(Schema.NonEmptyString),
+  Argument.withDescription("Message to send to the assistant"),
+);
+
+const askSystemPrompt = String.stripMargin(\`
+    |You are running inside a non-interactive command-line ask command.
+    |Produce command output, not a conversation.
+    |Return exactly one complete response to the user's request, then stop.
+    |Do not invite the user to continue chatting.
+    |Do not offer further help.
+    |Do not ask follow-up questions unless required for safety or correctness.
+    |If the user's entire request is a greeting, return only a brief greeting and no other sentence.
+    |Be concise and direct.
+  \`);
+
+const failCommand = (message: string) =>
+  Console.error(message).pipe(
+    Effect.andThen(
+      Effect.sync(() => {
+        process.exitCode = 1;
+      }),
+    ),
+  );
+
+export const ask = Command.make("ask", { message }, ({ message }) =>
+  Effect.gen(function* () {
+    const driver = yield* TerminalChatDriver;
+
+    yield* driver
+      .streamTurn([
+        { role: "system", content: askSystemPrompt },
+        { role: "user", content: message },
+      ])
+      .pipe(
+        Stream.runForEach((part: ChatStreamPart) =>
+          Match.value(part).pipe(
+            Match.tag("text", ({ delta }) =>
+              Stdio.Stdio.use((stdio) =>
+                Stream.make(delta).pipe(Stream.run(stdio.stdout())),
+              ),
+            ),
+            Match.tag("error", ({ message }) => failCommand(message)),
+            Match.orElse(() => Effect.void),
+          ),
+        ),
+      );
+  }).pipe(
+    Effect.catch((error) => failCommand(error.message)),
+    Effect.provide(TerminalChatDriverLive),
+  ),
+).pipe(Command.withDescription("Ask the assistant a single question"));
+`;

--- a/packages/catalog/src/registry/modules/cli.ts
+++ b/packages/catalog/src/registry/modules/cli.ts
@@ -1,9 +1,14 @@
 import {
   type ModuleDefinition,
   ModuleId,
+  TargetIdentity,
   TargetKind,
 } from "@repo/domain/Catalog";
-import { cliHelloCommandContents } from "../content/cli";
+import {
+  cliAskCommandContents,
+  cliChatDriverContents,
+  cliHelloCommandContents,
+} from "../content/cli";
 
 /**
  * CLI modules - subcommands and services for CLI applications
@@ -30,6 +35,86 @@ export const cliModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         import: {
           moduleSpecifier: "./commands/hello",
           namedImports: ["hello"],
+        },
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("chat-cli-driver"),
+    title: "Chat CLI Driver",
+    description: "Shared direct-AI chat plumbing for CLI chat commands",
+    visibility: "internal",
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("cli") }],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "domain",
+        }),
+        moduleId: ModuleId.make("domain-chat"),
+      },
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("package"),
+          name: "ai",
+        }),
+        moduleId: ModuleId.make("ai-chat-service"),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/chat/ChatDriver.ts",
+        contents: cliChatDriverContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "@repo/ai",
+        value: "workspace:*",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "@repo/domain",
+        value: "workspace:*",
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("chat-ask-command"),
+    title: "Ask Command",
+    description: "One-shot AI ask command for CLI applications",
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("cli") }],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("cli"),
+          name: "app",
+        }),
+        moduleId: ModuleId.make("chat-cli-driver"),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/commands/ask.ts",
+        contents: cliAskCommandContents,
+      },
+      {
+        _tag: "ts-call-arg",
+        path: "{{targetPath}}/src/index.ts",
+        targetVariable: "AllCommands",
+        functionName: "Command.withSubcommands",
+        argument: "ask",
+        import: {
+          moduleSpecifier: "./commands/ask",
+          namedImports: ["ask"],
         },
       },
     ],

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -374,6 +374,13 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "dev",
+        value: "bun run src/index.ts",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "dev:watch",
         value: "bun --watch run src/index.ts",
       },
       {


### PR DESCRIPTION
## Goals/Scope

Add an `ask` CLI command to enable asking via the CLI.

## Description

- Implemented the `ask` command in the CLI.
- Updated catalog behavior to use `appendSystem` so app-injected system prompts are applied reliably.

---

- [x] closes #157