### PR TITLE
refactor: add durable context tidy up APIs

### DIFF
--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -50,7 +50,6 @@ describe("add", () => {
           yield* cli.run("init", "impl-test", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
-          // client-react-http-api implies server-http-api on server — rejected non-interactively
           yield* cli.run(
             "add",
             "--yes",
@@ -107,7 +106,6 @@ describe("add", () => {
           yield* cli.run("init", "impl-exists", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
-          // First add domain-api-contracts (required by server)
           yield* cli.run(
             "add",
             "--yes",
@@ -120,7 +118,6 @@ describe("add", () => {
           );
           yield* cli.expectExitCode(0);
 
-          // Add server module first
           yield* cli.run(
             "add",
             "--yes",
@@ -133,7 +130,6 @@ describe("add", () => {
           );
           yield* cli.expectExitCode(0);
 
-          // Now add client module — should succeed since server already exists
           yield* cli.run(
             "add",
             "--yes",
@@ -160,7 +156,6 @@ describe("add", () => {
           yield* cli.run("init", "dep-test", "--yes", "--root", cli.workdir);
           yield* cli.expectExitCode(0);
 
-          // Add server-chat-rpc which depends on domain-chat-contracts on package/domain
           yield* cli.run(
             "add",
             "--yes",
@@ -343,7 +338,6 @@ describe("add", () => {
           );
           yield* cli.expectExitCode(0);
 
-          // Add domain-api-contracts (required by server and foldkit rest)
           yield* cli.run(
             "add",
             "--yes",
@@ -356,7 +350,6 @@ describe("add", () => {
           );
           yield* cli.expectExitCode(0);
 
-          // Add server (satisfies implication)
           yield* cli.run(
             "add",
             "--yes",
@@ -369,7 +362,6 @@ describe("add", () => {
           );
           yield* cli.expectExitCode(0);
 
-          // Add client-foldkit with rest module
           yield* cli.run(
             "add",
             "--yes",
@@ -414,7 +406,6 @@ describe("add", () => {
           );
           yield* cli.expectExitCode(0);
 
-          // client-foldkit-http-api implies server-http-api — rejected non-interactively
           yield* cli.run(
             "add",
             "--yes",

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -37,20 +37,12 @@ import {
 import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 
-// ---------------------------------------------------------------------------
-// Helpers – process spawning via Effect ChildProcess
-// ---------------------------------------------------------------------------
-
 export interface CommandResult {
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
 }
 
-/**
- * Spawn a command capturing stdout, stderr, and exit code.
- * Requires ChildProcessSpawner in context.
- */
 const spawnCommand = (
   spawner: ChildProcessSpawner["Service"],
   args: ReadonlyArray<string>,
@@ -70,10 +62,6 @@ const spawnCommand = (
     }),
   ).pipe(Effect.orDie);
 };
-
-// ---------------------------------------------------------------------------
-// WorkspaceContainer – isolated temp directory with lifecycle
-// ---------------------------------------------------------------------------
 
 export class WorkspaceContainer extends Context.Service<WorkspaceContainer>()(
   "e2e/WorkspaceContainer",
@@ -101,10 +89,6 @@ export class WorkspaceContainer extends Context.Service<WorkspaceContainer>()(
     WorkspaceContainer.make,
   ).pipe(Layer.provide(NodeServices.layer));
 }
-
-// ---------------------------------------------------------------------------
-// ProjectContext – assertions within a generated project
-// ---------------------------------------------------------------------------
 
 export interface ProjectContext {
   readonly dir: string;
@@ -244,10 +228,6 @@ const makeProjectContext = (
       ),
   };
 };
-
-// ---------------------------------------------------------------------------
-// CLI Service – the primary DSL interface
-// ---------------------------------------------------------------------------
 
 const cliEntrypoint = new URL("../src/index.ts", import.meta.url).pathname;
 

--- a/apps/cli/e2e/matrix.test.ts
+++ b/apps/cli/e2e/matrix.test.ts
@@ -132,7 +132,7 @@ function getModuleTarget(mod: {
     | { _tag: "kind"; kind: string }
     | { _tag: "identity"; identity: { kind: string; name: string } }
   >;
-}): string {
+}) {
   const s = mod.supportedOn[0];
   if (!s) return "unknown/unknown";
   return s._tag === "identity"
@@ -140,7 +140,7 @@ function getModuleTarget(mod: {
     : `${s.kind}/${defaultTargetNames.get(s.kind) ?? s.kind}`;
 }
 
-function identityToTarget(identity: { kind: string; name: string }): string {
+function identityToTarget(identity: { kind: string; name: string }) {
   return `${identity.kind}/${identity.name}`;
 }
 

--- a/apps/cli/scratchpad-layout.ts
+++ b/apps/cli/scratchpad-layout.ts
@@ -10,8 +10,6 @@ import * as Box from "effect-boxes/Box";
 import { Panel } from "./src/components/Panel";
 import { Breakpoint, Container, Flex, Grid } from "./src/lib/Layout";
 
-// ─── Styling Helpers ─────────────────────────────────────────────────────────
-
 const title = (text: string) =>
   Box.text(text).pipe(Box.annotate(Ansi.combine(Ansi.bold, Ansi.white)));
 
@@ -32,8 +30,6 @@ const propNote = (prop: string, explanation: string) =>
     1,
     Box.left,
   );
-
-// ─── 1. Flex ─────────────────────────────────────────────────────────────────
 
 const flexDemo = (termWidth: number) =>
   Container.make({ width: termWidth - 4, padding: 0 }, (ctx) => {
@@ -112,13 +108,10 @@ const flexDemo = (termWidth: number) =>
     );
   });
 
-// ─── 2. Grid ─────────────────────────────────────────────────────────────────
-
 const gridLabels = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"];
 
 const gridDemo = (termWidth: number) =>
   Container.make({ width: termWidth - 4, padding: 0 }, (ctx) => {
-    // Build items with target width so borders span the full cell
     const makeGridItems = (colWidth: number) =>
       gridLabels.map((name) =>
         Panel.make(Box.text(name).pipe(Box.minWidth(colWidth - 4)), {
@@ -170,8 +163,6 @@ const gridDemo = (termWidth: number) =>
     );
   });
 
-// ─── 3. Panel ────────────────────────────────────────────────────────────────
-
 const panelDemo = Box.vcat(
   [
     sectionTitle("Panel.make"),
@@ -212,8 +203,6 @@ const panelDemo = Box.vcat(
   Box.top,
 );
 
-// ─── 4. Breakpoint ───────────────────────────────────────────────────────────
-
 const breakpointDemo = (termWidth: number) =>
   Container.make({ width: termWidth - 4, padding: 0 }, (ctx) => {
     const current = Breakpoint.select(ctx.width, [
@@ -243,8 +232,6 @@ const breakpointDemo = (termWidth: number) =>
       Box.top,
     );
   });
-
-// ─── 5. Container ────────────────────────────────────────────────────────────
 
 const containerDemo = (termWidth: number) =>
   Container.make({ width: termWidth - 4, padding: 0 }, (ctx) =>
@@ -282,8 +269,6 @@ const containerDemo = (termWidth: number) =>
     ),
   );
 
-// ─── Main ────────────────────────────────────────────────────────────────────
-
 const main = Effect.gen(function* () {
   const terminal = yield* Terminal.Terminal;
   const termWidth = yield* terminal.columns;
@@ -316,8 +301,6 @@ const main = Effect.gen(function* () {
 
   yield* Console.log(Box.renderPrettySync(layout));
 });
-
-// ─── Run ─────────────────────────────────────────────────────────────────────
 
 void Effect.runPromise(main.pipe(Effect.provide(BunServices.layer))).catch(
   (error) => {

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -34,6 +34,8 @@ import {
 import { Command, Flag } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import { dryRunFlag, rootFlag, trustFlag, yesFlag } from "../flags";
+import { buildSelectionFrom } from "../lib/routing";
+import { duplicatedValues, splitCommaSeparated } from "../lib/utils";
 import { ConfigureService } from "../service/ConfigureService";
 import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
 
@@ -108,9 +110,9 @@ const formatTargetSummary = (
 };
 
 /**
- * Build a tree structure for nested module selection showing the full
- * cross-target dependency graph. Each module shows its required dependencies
- * and implied modules as nested children.
+ * Build the nested module picker from catalog dependency metadata. Cross-target
+ * children are shown for visibility, but Selection construction routes each
+ * chosen module back to its owning target.
  */
 const buildModuleTree = (
   modules: ReadonlyArray<typeof ModuleDefinition.Type>,
@@ -122,16 +124,12 @@ const buildModuleTree = (
   Effect.gen(function* () {
     const catalog = yield* CatalogService;
 
-    // Collect all module IDs that appear as children of other modules
-    // so they are excluded from the top-level list (they appear nested instead)
     const childModuleIds = new Set(
       Arr.flatMap(modules, (mod) =>
         Arr.map(mod.children ?? [], (child) => child.moduleId),
       ),
     );
 
-    // Build tree node recursively, following dependencies and implies
-    // visited is a Ref for mutable tracking across sibling branches
     const buildNode = (
       mod: typeof ModuleDefinition.Type,
       requirement: "root" | "required" | "optional",
@@ -144,7 +142,6 @@ const buildModuleTree = (
       Effect.gen(function* () {
         const visited = yield* Ref.get(visitedRef);
 
-        // Skip if already visited (cycle prevention)
         if (visited.has(mod.id)) {
           return {
             node: {
@@ -157,12 +154,8 @@ const buildModuleTree = (
           };
         }
 
-        // Mark as visited before processing children
         yield* Ref.update(visitedRef, (s) => new Set([...s, mod.id]));
 
-        // Process required dependencies (cross-target required-module deps)
-        // These are included in the tree for visibility, but are filtered out
-        // when building the Selection (BlueprintService resolves them automatically).
         const depChildren = yield* pipe(
           mod.dependencies,
           Arr.filter(
@@ -198,7 +191,6 @@ const buildModuleTree = (
           Effect.map(Arr.filterMap((x) => x)),
         );
 
-        // Process implied modules (cross-target)
         const impChildren = yield* pipe(
           mod.implies ?? [],
           Effect.forEach((imp) =>
@@ -230,7 +222,6 @@ const buildModuleTree = (
           Effect.map(Arr.filterMap((x) => x)),
         );
 
-        // Process same-target children (optional sub-modules)
         const subChildren = yield* pipe(
           mod.children ?? [],
           Effect.forEach((child) =>
@@ -272,8 +263,6 @@ const buildModuleTree = (
         };
       });
 
-    // Build tree for each top-level module (each with fresh visited Ref)
-    // Exclude modules that are children of other modules in this set
     const topLevelModules = Arr.filter(
       modules,
       (mod) => !childModuleIds.has(mod.id),
@@ -302,6 +291,7 @@ const resolveImplications = (targets: Array<CollectedTarget>) =>
         Effect.gen(function* () {
           const definition = yield* catalog.getModule(moduleId);
 
+          // NOTE: BlueprintService resolves required-module deps; this prompt only places implied modules.
           yield* Effect.forEach(definition.implies ?? [], (implication) =>
             Effect.gen(function* () {
               const candidates = Arr.filter(
@@ -428,7 +418,6 @@ const removeOrphanedImplications = (
       }),
     );
 
-    // Remove empty targets
     const before = targets.length;
     const remaining = Arr.filter(targets, (t) =>
       Arr.isArrayNonEmpty(t.modules),
@@ -626,7 +615,6 @@ const resolveImplicationsNonInteractive = (
                   Match.value(candidates.length),
                   Match.when(0, () =>
                     Effect.gen(function* () {
-                      // Check if the implied target/module already exists on disk
                       const appsDir = `${repoRoot}/apps`;
                       const packagesDir = `${repoRoot}/packages`;
                       const searchDir =
@@ -756,16 +744,7 @@ const parseTargetIdentity = (targetId: string) =>
 
 const parseModuleInputs = (rawModules: ReadonlyArray<string>) =>
   Effect.gen(function* () {
-    const parts = pipe(
-      rawModules,
-      Arr.flatMap((entry) =>
-        pipe(
-          entry.split(","),
-          Arr.map((part) => part.trim()),
-          Arr.filter((part) => part.length > 0),
-        ),
-      ),
-    );
+    const parts = splitCommaSeparated(rawModules);
 
     if (Arr.isArrayEmpty(parts)) {
       return yield* Effect.fail(
@@ -773,13 +752,7 @@ const parseModuleInputs = (rawModules: ReadonlyArray<string>) =>
       );
     }
 
-    // Find duplicates using Array.groupBy
-    const grouped = Arr.groupBy(parts, (id) => id);
-    const duplicates = pipe(
-      Object.entries(grouped),
-      Arr.filter(([, items]) => items.length > 1),
-      Arr.map(([id]) => id),
-    );
+    const duplicates = duplicatedValues(parts);
 
     if (Arr.isArrayNonEmpty(duplicates)) {
       return yield* Effect.fail(
@@ -814,7 +787,6 @@ const collectTargetsFromFlags = (
 
     const moduleIds = yield* parseModuleInputs(rawModules);
 
-    // Validate modules and collect unsupported ones
     const unsupported = yield* pipe(
       moduleIds,
       Effect.filter((moduleId) =>
@@ -863,7 +835,6 @@ const collectTargetsInteractive = Effect.gen(function* () {
   const catalog = yield* CatalogService;
   const terminal = yield* Terminal.Terminal;
 
-  // Build target kind choices from catalog (public targets only)
   const targetChoices = yield* pipe(
     catalog.getTargetKinds({ visibility: "public" }),
     Effect.forEach((kind) =>
@@ -891,7 +862,6 @@ const collectTargetsInteractive = Effect.gen(function* () {
       visibility: "public",
     });
 
-    // Build nested tree structure for module selection
     const moduleTree = yield* buildModuleTree(availableModules);
 
     const modules = Arr.isReadonlyArrayNonEmpty(moduleTree)
@@ -904,10 +874,8 @@ const collectTargetsInteractive = Effect.gen(function* () {
     targets.push({ kind, name, modules: [...modules], confirmed: false });
   });
 
-  // Collect first target
   yield* addTarget;
 
-  // The user explicitly chose modules for the first target, mark it confirmed
   pipe(
     Option.fromNullishOr(targets[0]),
     Option.filter((t) => Arr.isArrayNonEmpty(t.modules)),
@@ -918,7 +886,6 @@ const collectTargetsInteractive = Effect.gen(function* () {
 
   yield* resolveDependenciesInteractive(targets);
 
-  // Confirmation loop
   let allConfirmed = false;
   while (!allConfirmed) {
     const terminalWidth = yield* terminal.columns;
@@ -994,7 +961,7 @@ const collectTargetsInteractive = Effect.gen(function* () {
                     t.modules = [...newModules];
                     t.confirmed = true;
 
-                    // Cascade: remove orphaned implications then re-resolve
+                    // NOTE: Prune implied modules that were invalidated by explicit edits before resolving again.
                     const pinned = new Set(
                       Arr.map(newModules, (m) => `${t.kind}:${m}`),
                     );
@@ -1040,7 +1007,6 @@ export const add = Command.make(
 
       const repoRoot = Option.getOrElse(flags.root, () => process.cwd());
 
-      // Require init
       const config = yield* configure.requireConfig(repoRoot);
 
       const hasTarget = Option.isSome(flags.target);
@@ -1052,7 +1018,6 @@ export const add = Command.make(
         );
       }
 
-      // Collect targets: use flags if provided, otherwise interactive loop
       const collected =
         hasTarget && hasModules
           ? yield* collectTargetsFromFlags(
@@ -1062,85 +1027,10 @@ export const add = Command.make(
             )
           : yield* collectTargetsInteractive;
 
-      // Build selection, routing each module to the target it's supported on.
-      // Cross-target module IDs that appeared in the TUI tree (e.g., toolkit
-      // children of a parent on another target) are placed on the correct target.
-      // BlueprintService will also resolve required-module deps automatically.
-      const selectionTargets = new Map<
-        string,
-        { identity: TargetIdentity; modules: Set<string> }
-      >();
-
-      // Seed with collected targets
-      for (const t of collected) {
-        const identity = new TargetIdentity({ kind: t.kind, name: t.name });
-        selectionTargets.set(identity.toKey(), {
-          identity,
-          modules: new Set(),
-        });
-      }
-
-      // Route each module to its supported target
-      yield* Effect.forEach(collected, (t) =>
-        Effect.gen(function* () {
-          const identity = new TargetIdentity({ kind: t.kind, name: t.name });
-          yield* Effect.forEach(Arr.dedupe(t.modules), (id) =>
-            Effect.gen(function* () {
-              // Check if supported on the collected target first
-              const ownSupported = yield* catalog
-                .isSupportedOn(id, identity)
-                .pipe(Effect.orElseSucceed(() => false));
-              if (ownSupported) {
-                selectionTargets.get(identity.toKey())!.modules.add(id);
-                return;
-              }
-
-              // Find which target this module belongs to
-              const mod = yield* catalog
-                .getModule(id)
-                .pipe(Effect.orElseSucceed(() => null));
-              if (!mod) return;
-
-              for (const rule of mod.supportedOn) {
-                if (rule._tag === "identity") {
-                  const targetKey = new TargetIdentity(rule.identity).toKey();
-                  if (!selectionTargets.has(targetKey)) {
-                    selectionTargets.set(targetKey, {
-                      identity: new TargetIdentity(rule.identity),
-                      modules: new Set(),
-                    });
-                  }
-                  selectionTargets.get(targetKey)!.modules.add(id);
-                  return;
-                }
-                if (rule._tag === "kind") {
-                  // Find existing target of this kind
-                  const existing = Arr.findFirst(collected, (c) =>
-                    c.kind === rule.kind ? true : false,
-                  );
-                  if (Option.isSome(existing)) {
-                    const key = new TargetIdentity({
-                      kind: existing.value.kind,
-                      name: existing.value.name,
-                    }).toKey();
-                    selectionTargets.get(key)!.modules.add(id);
-                    return;
-                  }
-                }
-              }
-            }),
-          );
-        }),
-      );
-
-      const selection: typeof Selection.Type = {
-        targets: Arr.fromIterable(selectionTargets.values()).map((entry) => ({
-          identity: entry.identity,
-          modules: Arr.fromIterable(entry.modules).map((id) => ({
-            id: id as typeof ModuleId.Type,
-          })),
-        })),
-      };
+      const selection = yield* buildSelectionFrom({
+        catalog,
+        collected,
+      });
 
       yield* pipeline.run({
         selection,

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -73,7 +73,7 @@ const validateTargetName = (value: string) =>
 const formatTargetSummary = (
   targets: ReadonlyArray<CollectedTarget>,
   width: number,
-): Box.Box<Ansi.AnsiStyle> => {
+) => {
   const labelWidth = Math.max(
     ...targets.map((t) => `${t.kind}/${t.name}`.length),
     0,
@@ -116,11 +116,7 @@ const formatTargetSummary = (
  */
 const buildModuleTree = (
   modules: ReadonlyArray<typeof ModuleDefinition.Type>,
-): Effect.Effect<
-  ReadonlyArray<NestedModuleNode<typeof ModuleId.Type>>,
-  never,
-  CatalogService
-> =>
+) =>
   Effect.gen(function* () {
     const catalog = yield* CatalogService;
 

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -89,7 +89,7 @@ const targetIdentityFrom = (supportedOn: typeof SupportedOn.Type) =>
         name: defaultTargetNames.get(supportedOn.kind) ?? supportedOn.kind,
       });
 
-const contributionPath = (contribution: typeof Contribution.Type): string =>
+const contributionPath = (contribution: typeof Contribution.Type) =>
   contribution._tag === "barrel-export"
     ? contribution.barrelPath
     : contribution.path;
@@ -241,9 +241,7 @@ const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
   });
 });
 
-const annotationFor = (
-  file: typeof ManifestFile.Type,
-): Option.Option<string> => {
+const annotationFor = (file: typeof ManifestFile.Type) => {
   const sourceLines = pipe(
     file.contributors,
     Arr.map((contributor) =>

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -81,7 +81,7 @@ class WorkspaceValidationFailed extends Data.TaggedError(
   exitCode: number;
 }> {}
 
-const targetIdentityForSupportedOn = (supportedOn: typeof SupportedOn.Type) =>
+const targetIdentityFrom = (supportedOn: typeof SupportedOn.Type) =>
   supportedOn._tag === "identity"
     ? supportedOn.identity
     : new TargetIdentity({
@@ -94,90 +94,90 @@ const contributionPath = (contribution: typeof Contribution.Type): string =>
     ? contribution.barrelPath
     : contribution.path;
 
-const buildCatalogWorkspaceSelection = Effect.fn(
-  "catalog.workspace.buildSelection",
-)(function* () {
-  const catalog = yield* CatalogService;
-  const targets = new Map<
-    string,
-    {
-      identity: TargetIdentity;
-      modules: Set<typeof ModuleId.Type>;
-    }
-  >();
-
-  const ensureTarget = (identity: TargetIdentity) => {
-    const key = identity.toKey();
-    const current = targets.get(key);
-    if (current) return current;
-    const next = {
-      identity,
-      modules: new Set<typeof ModuleId.Type>(),
-    };
-    targets.set(key, next);
-    return next;
-  };
-
-  for (const targetKind of catalog.getTargetKinds()) {
-    ensureTarget(
-      new TargetIdentity({
-        kind: targetKind,
-        name:
-          targetKind === "workspace"
-            ? "catalog-built"
-            : (defaultTargetNames.get(targetKind) ?? targetKind),
-      }),
-    );
-  }
-
-  const initDefaultModules = [
-    ModuleCategory.make("monorepo"),
-    ModuleCategory.make("lint"),
-    ModuleCategory.make("format"),
-    ModuleCategory.make("test"),
-  ].flatMap((category) =>
-    pipe(
-      catalog.getModules({ category }),
-      Arr.head,
-      Option.match({
-        onNone: () => [],
-        onSome: (moduleDefinition) => [moduleDefinition.id],
-      }),
-    ),
-  );
-
-  const initTarget = ensureTarget(
-    new TargetIdentity({
-      kind: TargetKind.make("workspace"),
-      name: "catalog-built",
-    }),
-  );
-  for (const moduleId of initDefaultModules) {
-    initTarget.modules.add(moduleId);
-  }
-
-  for (const moduleDefinition of catalog.getModules()) {
-    for (const supportedOn of moduleDefinition.supportedOn) {
-      if (supportedOn._tag === "kind" && supportedOn.kind === "workspace") {
-        continue;
+const buildWorkspaceSelection = Effect.fn("catalog.workspace.buildSelection")(
+  function* () {
+    const catalog = yield* CatalogService;
+    const targets = new Map<
+      string,
+      {
+        identity: TargetIdentity;
+        modules: Set<typeof ModuleId.Type>;
       }
-      ensureTarget(targetIdentityForSupportedOn(supportedOn)).modules.add(
-        moduleDefinition.id,
+    >();
+
+    const ensureTarget = (identity: TargetIdentity) => {
+      const key = identity.toKey();
+      const current = targets.get(key);
+      if (current) return current;
+      const next = {
+        identity,
+        modules: new Set<typeof ModuleId.Type>(),
+      };
+      targets.set(key, next);
+      return next;
+    };
+
+    for (const targetKind of catalog.getTargetKinds()) {
+      ensureTarget(
+        new TargetIdentity({
+          kind: targetKind,
+          name:
+            targetKind === "workspace"
+              ? "catalog-built"
+              : (defaultTargetNames.get(targetKind) ?? targetKind),
+        }),
       );
     }
-  }
 
-  const selectedTargets = Array.from(targets.values())
-    .map((target) => ({
-      identity: target.identity,
-      modules: Array.from(target.modules)
-        .sort((a, b) => a.localeCompare(b))
-        .map((id) => ({ id })),
-    }))
-    .sort((a, b) => a.identity.toKey().localeCompare(b.identity.toKey()));
+    const initDefaultModules = [
+      ModuleCategory.make("monorepo"),
+      ModuleCategory.make("lint"),
+      ModuleCategory.make("format"),
+      ModuleCategory.make("test"),
+    ].flatMap((category) =>
+      pipe(
+        catalog.getModules({ category }),
+        Arr.head,
+        Option.match({
+          onNone: () => [],
+          onSome: (moduleDefinition) => [moduleDefinition.id],
+        }),
+      ),
+    );
 
-  return { targets: selectedTargets } satisfies typeof Selection.Type;
-});
+    const initTarget = ensureTarget(
+      new TargetIdentity({
+        kind: TargetKind.make("workspace"),
+        name: "catalog-built",
+      }),
+    );
+    for (const moduleId of initDefaultModules) {
+      initTarget.modules.add(moduleId);
+    }
+
+    for (const moduleDefinition of catalog.getModules()) {
+      for (const supportedOn of moduleDefinition.supportedOn) {
+        if (supportedOn._tag === "kind" && supportedOn.kind === "workspace") {
+          continue;
+        }
+        ensureTarget(targetIdentityFrom(supportedOn)).modules.add(
+          moduleDefinition.id,
+        );
+      }
+    }
+
+    const selectedTargets = Array.from(targets.values())
+      .map((target) => ({
+        identity: target.identity,
+        modules: Array.from(target.modules)
+          .sort((a, b) => a.localeCompare(b))
+          .map((id) => ({ id })),
+      }))
+      .sort((a, b) => a.identity.toKey().localeCompare(b.identity.toKey()));
+
+    return { targets: selectedTargets } satisfies typeof Selection.Type;
+  },
+);
 
 const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
   blueprint,
@@ -503,7 +503,7 @@ const reset = Command.make("reset", { root: rootFlag }, (flags) =>
       monorepo: "turbo",
     });
 
-    const selection = yield* buildCatalogWorkspaceSelection();
+    const selection = yield* buildWorkspaceSelection();
     const blueprintService = yield* BlueprintService;
     const blueprint = yield* blueprintService.resolve(selection);
     const planService = yield* PlanService;

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -242,11 +242,10 @@ const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
 });
 
 const annotationFor = (
-  path: string,
-  contributors: ReadonlyArray<ManifestContributor>,
+  file: typeof ManifestFile.Type,
 ): Option.Option<string> => {
   const sourceLines = pipe(
-    contributors,
+    file.contributors,
     Arr.map((contributor) =>
       contributor.origin === "module"
         ? `${contributor.targetKey}#${contributor.moduleId}:${contributor.contributionTag}`
@@ -260,21 +259,21 @@ const annotationFor = (
   ];
 
   if (
-    path.endsWith(".ts") ||
-    path.endsWith(".tsx") ||
-    path.endsWith(".js") ||
-    path.endsWith(".jsx")
+    file.path.endsWith(".ts") ||
+    file.path.endsWith(".tsx") ||
+    file.path.endsWith(".js") ||
+    file.path.endsWith(".jsx")
   ) {
     return Option.some(`${body.map((line) => `// ${line}`).join("\n")}\n\n`);
   }
 
-  if (path.endsWith(".css")) {
+  if (file.path.endsWith(".css")) {
     return Option.some(
       `/*\n${body.map((line) => ` * ${line}`).join("\n")}\n */\n\n`,
     );
   }
 
-  if (path.endsWith(".html")) {
+  if (file.path.endsWith(".html")) {
     return Option.some(
       `<!--\n${body.map((line) => `  ${line}`).join("\n")}\n-->\n`,
     );
@@ -297,7 +296,7 @@ const annotateWorkspace = Effect.fn("catalog.workspace.annotate")(function* ({
     manifest.files,
     (file) =>
       Effect.gen(function* () {
-        const annotation = annotationFor(file.path, file.contributors);
+        const annotation = annotationFor(file);
         if (Option.isNone(annotation)) return;
 
         const filePath = path.join(repoRoot, file.path);

--- a/apps/cli/src/commands/graph.ts
+++ b/apps/cli/src/commands/graph.ts
@@ -23,8 +23,6 @@ const formatFlag = Flag.choice("format", ["table", "mermaid", "dot"]).pipe(
   Flag.withDescription("Output format: table (default), mermaid, or dot"),
 );
 
-// ── Helpers ──────────────────────────────────────────────────────────
-
 type IndexedNode = readonly [idx: number, node: typeof CatalogNode.Type];
 
 const nodeLabel = Match.type<typeof CatalogNode.Type>().pipe(
@@ -46,8 +44,6 @@ const splitByTag = (nodes: ReadonlyArray<IndexedNode>) => ({
 
 const labelsOf = (nodes: ReadonlyArray<IndexedNode>): string =>
   Arr.map(nodes, ([, n]) => nodeLabel(n)).join(", ");
-
-// ── Edge classification ─────────────────────────────────────────────
 
 interface RowData {
   readonly node: typeof CatalogNode.Type;
@@ -91,8 +87,6 @@ const collectRowData = (g: CatalogGraph): Array<RowData> => {
   });
 };
 
-// ── Compute dependency layers ───────────────────────────────────────
-
 const computeLayers = (g: CatalogGraph): Array<Array<IndexedNode>> => {
   const allNodes = collectNodes(g);
   const allEdges = collectEdges(g);
@@ -101,7 +95,6 @@ const computeLayers = (g: CatalogGraph): Array<Array<IndexedNode>> => {
 
   const topoOrder = Array.from(Graph.indices(Graph.topo(g)));
 
-  // Longest path depth per node (reversed topo = dependencies first)
   const depth = new Map<number, number>();
   for (const idx of topoOrder.reverse()) {
     const deps = (outgoing[String(idx)] ?? []).map(([, e]) => e.target);
@@ -125,13 +118,10 @@ const computeLayers = (g: CatalogGraph): Array<Array<IndexedNode>> => {
   });
 };
 
-// ── Compute connected clusters ──────────────────────────────────────
-
 const computeClusters = (g: CatalogGraph): Array<Array<IndexedNode>> => {
   const allNodes = collectNodes(g);
   const allEdges = collectEdges(g);
 
-  // Build undirected adjacency via groupBy on both directions
   const adj = new Map<number, Set<number>>();
   for (const [idx] of allNodes) adj.set(idx, new Set());
   for (const [, edge] of allEdges) {
@@ -162,8 +152,6 @@ const computeClusters = (g: CatalogGraph): Array<Array<IndexedNode>> => {
     return Result.succeed(cluster);
   });
 };
-
-// ── Render sections ─────────────────────────────────────────────────
 
 const renderLayers = (g: CatalogGraph): Box.Box<Ansi.AnsiStyle> => {
   const layerRows = Arr.map(computeLayers(g), (layer, i) => {
@@ -228,8 +216,6 @@ const renderClusters = (g: CatalogGraph): Box.Box<Ansi.AnsiStyle> => {
   );
 };
 
-// ── Edge count summary ──────────────────────────────────────────────
-
 const countEdges = (g: CatalogGraph) => {
   const edges = collectEdges(g);
   const counts = Arr.groupBy(edges, ([, e]) => e.data);
@@ -240,8 +226,6 @@ const countEdges = (g: CatalogGraph) => {
     childOf: (counts["childOf"] ?? []).length,
   };
 };
-
-// ── Main render ─────────────────────────────────────────────────────
 
 const renderTable = (g: CatalogGraph) => {
   const nodeCount = Graph.nodeCount(g);
@@ -271,7 +255,6 @@ const renderTable = (g: CatalogGraph) => {
         Box.annotate(Ansi.yellow),
       );
 
-  // Adjacency table
   const columns = [
     { header: "Node", width: 24 },
     { header: "Type", width: 8 },
@@ -321,8 +304,6 @@ const renderTable = (g: CatalogGraph) => {
     Box.left,
   ).pipe(Box.pad(0, 1), Box.border("rounded"));
 };
-
-// ── Command ─────────────────────────────────────────────────────────
 
 export const graph = Command.make("graph", { format: formatFlag }, (flags) =>
   Effect.gen(function* () {

--- a/apps/cli/src/commands/graph.ts
+++ b/apps/cli/src/commands/graph.ts
@@ -31,7 +31,7 @@ const nodeLabel = Match.type<typeof CatalogNode.Type>().pipe(
   Match.exhaustive,
 );
 
-const collectNodes = (g: CatalogGraph): Array<IndexedNode> =>
+const collectNodes = (g: CatalogGraph) =>
   Array.from(Graph.entries(Graph.nodes(g)));
 
 const collectEdges = (g: CatalogGraph) =>
@@ -42,7 +42,7 @@ const splitByTag = (nodes: ReadonlyArray<IndexedNode>) => ({
   modules: Arr.filter(nodes, ([, n]) => n._tag === "module"),
 });
 
-const labelsOf = (nodes: ReadonlyArray<IndexedNode>): string =>
+const labelsOf = (nodes: ReadonlyArray<IndexedNode>) =>
   Arr.map(nodes, ([, n]) => nodeLabel(n)).join(", ");
 
 interface RowData {
@@ -153,7 +153,7 @@ const computeClusters = (g: CatalogGraph): Array<Array<IndexedNode>> => {
   });
 };
 
-const renderLayers = (g: CatalogGraph): Box.Box<Ansi.AnsiStyle> => {
+const renderLayers = (g: CatalogGraph) => {
   const layerRows = Arr.map(computeLayers(g), (layer, i) => {
     const { targets, modules } = splitByTag(layer);
     const parts = [labelsOf(targets), labelsOf(modules)].filter(Boolean);
@@ -183,7 +183,7 @@ const renderLayers = (g: CatalogGraph): Box.Box<Ansi.AnsiStyle> => {
   );
 };
 
-const renderClusters = (g: CatalogGraph): Box.Box<Ansi.AnsiStyle> => {
+const renderClusters = (g: CatalogGraph) => {
   const clusterRows = Arr.map(computeClusters(g), (cluster, i) => {
     const { targets, modules } = splitByTag(cluster);
     const label =

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -7,10 +7,19 @@ import {
 } from "@repo/domain/Catalog";
 import type { Selection } from "@repo/domain/Selection";
 import { Confirm, MultiSelect, Select, TextInput } from "@repo/tui";
-import { Array as Arr, Console, Effect, Option, Path, Schema } from "effect";
+import {
+  Array as Arr,
+  Console,
+  Effect,
+  Option,
+  Path,
+  pipe,
+  Schema,
+} from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import { dryRunFlag, noGitFlag, rootFlag, trustFlag, yesFlag } from "../flags";
+import { toWorkspaceModuleId, toWorkspaceToolValue } from "../lib/workspace";
 import {
   CONFIG_FILENAME,
   ConfigureService,
@@ -22,21 +31,12 @@ const buildInitSelection = (
   config: typeof StackConfig.Type,
   extraModules: ReadonlyArray<string> = [],
 ): typeof Selection.Type => {
-  // Collect unique module IDs from all category fields
-  const moduleIds = new Set<string>();
-  for (const field of [
-    config.monorepo,
-    config.lint,
-    config.format,
-    config.test,
-  ]) {
-    if (field !== undefined) moduleIds.add(toWorkspaceModuleId(field));
-  }
-
-  // Add optional DX modules
-  for (const id of extraModules) {
-    moduleIds.add(id);
-  }
+  const moduleIds = pipe(
+    [config.monorepo, config.lint, config.format, config.test, ...extraModules],
+    Arr.filter((moduleId): moduleId is string => moduleId !== undefined),
+    Arr.map(toWorkspaceModuleId),
+    Arr.dedupe,
+  );
 
   return {
     targets: [
@@ -45,7 +45,7 @@ const buildInitSelection = (
           kind: TargetKind.make("workspace"),
           name: config.name,
         }),
-        modules: Arr.fromIterable(moduleIds).map((id) => ({
+        modules: moduleIds.map((id) => ({
           id: ModuleId.make(id),
         })),
       },
@@ -99,39 +99,40 @@ const optionalSelect = <A extends string>(
     return v === "none" ? Option.none<A>() : Option.some(v);
   });
 
-const toWorkspaceToolValue = (moduleId: string): string => {
-  switch (moduleId) {
-    case "workspace-monorepo-turbo":
-      return "turbo";
-    case "workspace-quality-biome":
-      return "biome";
-    case "workspace-quality-dprint":
-      return "dprint";
-    case "workspace-quality-oxlint":
-      return "oxlint";
-    case "workspace-test-vitest":
-      return "vitest";
-    default:
-      return moduleId;
-  }
-};
+const workspaceChoices = (
+  catalog: typeof CatalogService.Service,
+  category: typeof ModuleCategory.Type,
+) =>
+  catalog.getModules({ category }).map((m) => ({
+    title: m.title,
+    description: m.description,
+    value: toWorkspaceToolValue(m.id),
+  }));
 
-const toWorkspaceModuleId = (toolValue: string): string => {
-  switch (toolValue) {
-    case "turbo":
-      return "workspace-monorepo-turbo";
-    case "biome":
-      return "workspace-quality-biome";
-    case "dprint":
-      return "workspace-quality-dprint";
-    case "oxlint":
-      return "workspace-quality-oxlint";
-    case "vitest":
-      return "workspace-test-vitest";
-    default:
-      return toolValue;
-  }
-};
+const moduleChoices = (
+  catalog: typeof CatalogService.Service,
+  category: typeof ModuleCategory.Type,
+) =>
+  catalog.getModules({ category }).map((m) => ({
+    title: m.title,
+    description: m.description,
+    value: m.id,
+  }));
+
+const defaultChoice = <A extends string>(
+  choices: ReadonlyArray<{ value: A }>,
+  fallback: A,
+) => choices[0]?.value ?? fallback;
+
+const chooseOptionalTool = <A extends string>(
+  yes: boolean,
+  message: string,
+  choices: ReadonlyArray<{ title: string; value: A }>,
+  fallback: A,
+) =>
+  yes
+    ? Effect.succeed(Option.some(defaultChoice(choices, fallback)))
+    : optionalSelect(message, choices);
 
 export const init = Command.make(
   "init",
@@ -149,44 +150,27 @@ export const init = Command.make(
       const configure = yield* ConfigureService;
       const catalog = yield* CatalogService;
 
-      // Build choices from catalog for each init category
-      const monorepoChoices = catalog
-        .getModules({ category: ModuleCategory.make("monorepo") })
-        .map((m) => ({
-          title: m.title,
-          description: m.description,
-          value: toWorkspaceToolValue(m.id),
-        }));
-      const lintChoices = catalog
-        .getModules({ category: ModuleCategory.make("lint") })
-        .map((m) => ({
-          title: m.title,
-          description: m.description,
-          value: toWorkspaceToolValue(m.id),
-        }));
-      const formatChoices = catalog
-        .getModules({ category: ModuleCategory.make("format") })
-        .map((m) => ({
-          title: m.title,
-          description: m.description,
-          value: toWorkspaceToolValue(m.id),
-        }));
-      const testChoices = catalog
-        .getModules({ category: ModuleCategory.make("test") })
-        .map((m) => ({
-          title: m.title,
-          description: m.description,
-          value: toWorkspaceToolValue(m.id),
-        }));
-      const devenvChoices = catalog
-        .getModules({ category: ModuleCategory.make("devenv") })
-        .map((m) => ({
-          title: m.title,
-          description: m.description,
-          value: m.id,
-        }));
+      const monorepoChoices = workspaceChoices(
+        catalog,
+        ModuleCategory.make("monorepo"),
+      );
+      const lintChoices = workspaceChoices(
+        catalog,
+        ModuleCategory.make("lint"),
+      );
+      const formatChoices = workspaceChoices(
+        catalog,
+        ModuleCategory.make("format"),
+      );
+      const testChoices = workspaceChoices(
+        catalog,
+        ModuleCategory.make("test"),
+      );
+      const devenvChoices = moduleChoices(
+        catalog,
+        ModuleCategory.make("devenv"),
+      );
 
-      // Project name and output directory
       if (flags.yes && Option.isNone(flags.name)) {
         return yield* Effect.fail(
           "When using --yes with init, provide a project name as the positional argument.",
@@ -208,7 +192,6 @@ export const init = Command.make(
         flags.root,
       );
 
-      // Check if already initialized
       const existing = yield* configure
         .readConfig(repoRoot)
         .pipe(Effect.option);
@@ -233,7 +216,6 @@ export const init = Command.make(
         }
       }
 
-      // Runtime
       const runtimeChoice = Option.isSome(flags.packageManager)
         ? flags.packageManager.value
         : flags.yes
@@ -262,36 +244,31 @@ export const init = Command.make(
         runtime = { _tag: "node", packageManager: pm };
       }
 
-      // Monorepo
-      const monorepo = flags.yes
-        ? Option.some(monorepoChoices[0]?.value ?? "turbo")
-        : yield* optionalSelect(
-            "What monorepo tool will you use?",
-            monorepoChoices,
-          );
+      const monorepo = yield* chooseOptionalTool(
+        flags.yes,
+        "What monorepo tool will you use?",
+        monorepoChoices,
+        "turbo",
+      );
+      const lint = yield* chooseOptionalTool(
+        flags.yes,
+        "What will you use for linting?",
+        lintChoices,
+        "biome",
+      );
+      const format_ = yield* chooseOptionalTool(
+        flags.yes,
+        "What will you use for formatting?",
+        formatChoices,
+        "biome",
+      );
+      const test = yield* chooseOptionalTool(
+        flags.yes,
+        "What test framework will you use?",
+        testChoices,
+        "vitest",
+      );
 
-      // Lint
-      const lint = flags.yes
-        ? Option.some(lintChoices[0]?.value ?? "biome")
-        : yield* optionalSelect("What will you use for linting?", lintChoices);
-
-      // Format
-      const format_ = flags.yes
-        ? Option.some(formatChoices[0]?.value ?? "biome")
-        : yield* optionalSelect(
-            "What will you use for formatting?",
-            formatChoices,
-          );
-
-      // Test
-      const test = flags.yes
-        ? Option.some(testChoices[0]?.value ?? "vitest")
-        : yield* optionalSelect(
-            "What test framework will you use?",
-            testChoices,
-          );
-
-      // Git
       const git = flags.noGit
         ? false
         : flags.yes
@@ -301,12 +278,11 @@ export const init = Command.make(
               initial: true,
             });
 
-      // DX Extras (optional modules for developer experience)
       const dxExtras =
         devenvChoices.length === 0
           ? []
           : flags.yes
-            ? devenvChoices.map((c) => c.value) // Select all DX modules in non-interactive mode
+            ? devenvChoices.map((c) => c.value)
             : yield* MultiSelect({
                 message: "Developer experience extras (optional)",
                 choices: devenvChoices.map((c) => ({
@@ -336,7 +312,6 @@ export const init = Command.make(
         }),
       });
 
-      // Preview
       const dxExtrasDisplay =
         dxExtras.length === 0 ? "none" : dxExtras.join(", ");
       const configBox = Box.vsep(
@@ -404,7 +379,6 @@ export const init = Command.make(
         yield* Console.log(`\nWritten ${CONFIG_FILENAME}`);
       }
 
-      // Scaffold root monorepo files
       const pipeline = yield* ScaffoldPipeline;
       const selection = buildInitSelection(config, [
         ...(git ? [ModuleId.make("workspace-devenv-git")] : []),

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs/promises";
 import { StackConfig } from "@repo/domain/Scaffold";
 import { Selection } from "@repo/domain/Selection";
 import {
@@ -71,7 +70,6 @@ export const plan = Command.make(
       const repoRoot = Option.getOrElse(flags.root, () => process.cwd());
       const format = Option.getOrElse(flags.format, () => "llm" as const);
 
-      // Read PlanInput from stdin
       const stdio = yield* Stdio;
       const stdin = yield* stdio.stdin.pipe(
         Stream.decodeText(),
@@ -81,11 +79,10 @@ export const plan = Command.make(
         Schema.fromJsonString(PlanInput),
       )(stdin);
 
-      // Resolve config: stdin > file > fail
       const configureService = yield* ConfigureService;
       const fileConfig = yield* configureService
         .readConfig(repoRoot)
-        .pipe(Effect.catch(() => Effect.succeed(undefined)));
+        .pipe(Effect.catch(() => Effect.void));
 
       const config = input.config ?? fileConfig;
       if (!config) {
@@ -94,11 +91,9 @@ export const plan = Command.make(
         );
       }
 
-      // Blueprint: resolve dependency closure from Selection
       const blueprintService = yield* BlueprintService;
       const blueprint = yield* blueprintService.resolve(input.selection);
 
-      // Plan: assess outcomes against repo state
       const planService = yield* PlanService;
       const planResult = yield* planService.build({
         blueprint,
@@ -106,7 +101,6 @@ export const plan = Command.make(
         config,
       });
 
-      // Finalize: collect post-scaffold scripts
       const finalizeService = yield* FinalizeService;
       const scripts = yield* finalizeService
         .preview(blueprint, { repoRoot, config })
@@ -121,7 +115,6 @@ export const plan = Command.make(
         command: s.command,
       }));
 
-      // Compute summary and tree
       const formatter = yield* ScaffoldFormatter;
       const formattedPlan = yield* formatter.formatPlan(planResult);
       const tree = Box.renderPlainSync(formattedPlan.tree);
@@ -136,7 +129,6 @@ export const plan = Command.make(
         }),
       );
 
-      // Output based on format
       const outputText = yield* Match.value(format).pipe(
         Match.when("tree", () =>
           Box.renderPlain(

--- a/apps/cli/src/components/DryRunPreview.ts
+++ b/apps/cli/src/components/DryRunPreview.ts
@@ -27,14 +27,12 @@ export const DryRunPreview = ({
 }): Box.Box<Ansi.AnsiStyle> => {
   const terminalWidth = process.stdout.columns ?? 80;
 
-  // Blueprint panel
   const blueprintContent = Box.vsep(
     [sectionTitle("Blueprint"), blueprint],
     1,
     Box.left,
   );
 
-  // Apply panel
   const changesStats = Flex.row(
     [
       Flex.fixed(
@@ -60,7 +58,6 @@ export const DryRunPreview = ({
     Box.left,
   );
 
-  // Finalize panel
   const phaseLabels: Record<string, string> = {
     finalize: "Finalize",
     config: "Install & Format",
@@ -109,15 +106,13 @@ export const DryRunPreview = ({
     Box.left,
   );
 
-  // Footer
   const footer = Box.text("No changes written.").pipe(Box.annotate(Ansi.dim));
 
-  // Natural width needed for horizontal layout
   const naturalHorizontalWidth =
     Box.cols(blueprintContent) +
     Box.cols(applyContent) +
     Box.cols(finalizeContent) +
-    18; // padding + borders overhead
+    18;
 
   const panels = Breakpoint.select(terminalWidth, [
     {

--- a/apps/cli/src/components/DryRunPreview.ts
+++ b/apps/cli/src/components/DryRunPreview.ts
@@ -24,7 +24,7 @@ export const DryRunPreview = ({
     phase: string;
     origin: string;
   }>;
-}): Box.Box<Ansi.AnsiStyle> => {
+}) => {
   const terminalWidth = process.stdout.columns ?? 80;
 
   const blueprintContent = Box.vsep(

--- a/apps/cli/src/components/NextStepsPreview.ts
+++ b/apps/cli/src/components/NextStepsPreview.ts
@@ -12,7 +12,7 @@ export const NextStepsPreview = ({
   conflicts: ReadonlyArray<string>;
   skippedScripts: ReadonlyArray<{ label: string; command: string }>;
   steps: ReadonlyArray<string>;
-}): Box.Box<Ansi.AnsiStyle> => {
+}) => {
   const sections: Box.Box<Ansi.AnsiStyle>[] = [];
 
   if (conflicts.length > 0) {

--- a/apps/cli/src/components/NextStepsPreview.ts
+++ b/apps/cli/src/components/NextStepsPreview.ts
@@ -15,7 +15,6 @@ export const NextStepsPreview = ({
 }): Box.Box<Ansi.AnsiStyle> => {
   const sections: Box.Box<Ansi.AnsiStyle>[] = [];
 
-  // Conflicts section
   if (conflicts.length > 0) {
     const items = conflicts.map((path) =>
       Flex.row(
@@ -36,7 +35,6 @@ export const NextStepsPreview = ({
     );
   }
 
-  // Skipped scripts section
   if (skippedScripts.length > 0) {
     const items = skippedScripts.map((s) =>
       Flex.row(
@@ -53,7 +51,6 @@ export const NextStepsPreview = ({
     );
   }
 
-  // Next steps section
   if (steps.length > 0) {
     const items = steps.map((step, i) =>
       Flex.row(
@@ -74,7 +71,6 @@ export const NextStepsPreview = ({
     return Box.text("");
   }
 
-  // Stack sections vertically with borders
   const terminalWidth = process.stdout.columns ?? 80;
 
   return Container.make({ width: terminalWidth, padding: [0, 2] }, (ctx) => {

--- a/apps/cli/src/lib/routing.ts
+++ b/apps/cli/src/lib/routing.ts
@@ -1,0 +1,117 @@
+import { CatalogService } from "@repo/catalog";
+import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
+import type { Selection } from "@repo/domain/Selection";
+import { Array as Arr, Effect, Option } from "effect";
+
+export type CollectedSelectionTarget = {
+  readonly kind: typeof TargetKind.Type;
+  readonly name: string;
+  readonly modules: ReadonlyArray<typeof ModuleId.Type>;
+};
+
+export type SeedSelectionTarget = {
+  readonly identity: TargetIdentity;
+  readonly modules: ReadonlyArray<typeof ModuleId.Type>;
+};
+
+export const buildSelectionFrom = Effect.fnUntraced(function* ({
+  catalog,
+  collected,
+  seedTargets = [],
+}: {
+  catalog: typeof CatalogService.Service;
+  collected: ReadonlyArray<CollectedSelectionTarget>;
+  seedTargets?: ReadonlyArray<SeedSelectionTarget>;
+}) {
+  const selectionTargets = new Map<
+    string,
+    { identity: TargetIdentity; modules: Set<string> }
+  >();
+
+  const ensureSelectionTarget = (identity: TargetIdentity) => {
+    const key = identity.toKey();
+    const existing = selectionTargets.get(key);
+    if (existing) return existing;
+
+    const entry = { identity, modules: new Set<string>() };
+    selectionTargets.set(key, entry);
+    return entry;
+  };
+
+  for (const seedTarget of seedTargets) {
+    const entry = ensureSelectionTarget(seedTarget.identity);
+    for (const moduleId of seedTarget.modules) {
+      entry.modules.add(moduleId);
+    }
+  }
+
+  for (const target of collected) {
+    ensureSelectionTarget(
+      new TargetIdentity({ kind: target.kind, name: target.name }),
+    );
+  }
+
+  yield* Effect.forEach(collected, (target) =>
+    Effect.gen(function* () {
+      const identity = new TargetIdentity({
+        kind: target.kind,
+        name: target.name,
+      });
+
+      yield* Effect.forEach(Arr.dedupe(target.modules), (moduleId) =>
+        Effect.gen(function* () {
+          const ownSupported = yield* catalog
+            .isSupportedOn(moduleId, identity)
+            .pipe(Effect.orElseSucceed(() => false));
+
+          if (ownSupported) {
+            ensureSelectionTarget(identity).modules.add(moduleId);
+            return;
+          }
+
+          const mod = yield* catalog
+            .getModule(moduleId)
+            .pipe(Effect.orElseSucceed(() => null));
+          if (!mod) return;
+
+          for (const rule of mod.supportedOn) {
+            if (rule._tag === "identity") {
+              ensureSelectionTarget(
+                new TargetIdentity(rule.identity),
+              ).modules.add(moduleId);
+              return;
+            }
+
+            if (rule._tag === "kind") {
+              const existing = Arr.findFirst(
+                collected,
+                (candidate) => candidate.kind === rule.kind,
+              );
+              if (Option.isSome(existing)) {
+                ensureSelectionTarget(
+                  new TargetIdentity({
+                    kind: existing.value.kind,
+                    name: existing.value.name,
+                  }),
+                ).modules.add(moduleId);
+                return;
+              }
+            }
+          }
+        }),
+      );
+    }),
+  );
+
+  return {
+    targets: Arr.map(
+      Arr.fromIterable(selectionTargets.values()),
+      ({ identity, modules }) => ({
+        identity,
+        modules: Arr.map(Arr.fromIterable(modules), (id) => ({
+          id: ModuleId.make(id),
+        })),
+      }),
+    ),
+  } satisfies typeof Selection.Type;
+});

--- a/apps/cli/src/lib/utils.ts
+++ b/apps/cli/src/lib/utils.ts
@@ -1,0 +1,25 @@
+import { Array as Arr, pipe } from "effect";
+
+export const splitCommaSeparated = (
+  values: ReadonlyArray<string>,
+): Array<string> =>
+  pipe(
+    values,
+    Arr.flatMap((value) =>
+      pipe(
+        value.split(","),
+        Arr.map((part) => part.trim()),
+        Arr.filter((part) => part.length > 0),
+      ),
+    ),
+  );
+
+export const duplicatedValues = (
+  values: ReadonlyArray<string>,
+): Array<string> =>
+  pipe(
+    Arr.groupBy(values, (value) => value),
+    Object.entries,
+    Arr.filter(([, grouped]) => grouped.length > 1),
+    Arr.map(([value]) => value),
+  );

--- a/apps/cli/src/lib/workspace.ts
+++ b/apps/cli/src/lib/workspace.ts
@@ -1,0 +1,21 @@
+const workspaceToolModules = {
+  turbo: "workspace-monorepo-turbo",
+  biome: "workspace-quality-biome",
+  dprint: "workspace-quality-dprint",
+  oxlint: "workspace-quality-oxlint",
+  vitest: "workspace-test-vitest",
+} as const;
+
+const moduleToolValues = Object.fromEntries(
+  Object.entries(workspaceToolModules).map(([tool, moduleId]) => [
+    moduleId,
+    tool,
+  ]),
+);
+
+export const toWorkspaceModuleId = (toolValue: string): string =>
+  workspaceToolModules[toolValue as keyof typeof workspaceToolModules] ??
+  toolValue;
+
+export const toWorkspaceToolValue = (moduleId: string): string =>
+  moduleToolValues[moduleId] ?? moduleId;

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -22,6 +22,18 @@ class ScaffoldAborted extends Data.TaggedError("ScaffoldAborted")<{
   retry?: boolean;
 }> {}
 
+const selectedCommandSet = (
+  scripts: ReadonlyArray<{ command: string }>,
+): ReadonlySet<string> => new Set(scripts.map((script) => script.command));
+
+const skippedFinalizeScripts = (
+  previewScripts: ReadonlyArray<{ label: string; command: string }>,
+  selectedCommands: ReadonlySet<string>,
+) =>
+  previewScripts
+    .filter((script) => !selectedCommands.has(script.command))
+    .map((script) => ({ label: script.label, command: script.command }));
+
 export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
   "ScaffoldPipeline",
   {
@@ -66,7 +78,6 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
           const finalizeService = yield* FinalizeService;
           const applyService = yield* ApplyService;
 
-          // Blueprint
           const blueprint = yield* blueprintService.resolve(selection);
 
           const formattedBlueprint =
@@ -98,11 +109,6 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             }
           }
 
-          if (dryRun) {
-            // no-op: blueprint shown inside DryRunPreview
-          }
-
-          // Plan
           const plan = yield* planService.build({
             blueprint,
             repoRoot,
@@ -123,15 +129,12 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             Box.left,
           );
 
-          // Dry run: show full preview without writing or executing
           if (dryRun) {
-            // Preview apply outcomes
             const result = yield* applyService.preview({
               apply: new Apply({ plan, decisions: [] }),
               repoRoot,
             });
 
-            // Preview finalize scripts
             const finalizeConfig: FinalizeConfig = {
               config,
               repoRoot,
@@ -154,10 +157,8 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             return;
           }
 
-          // Resolve conflicts
           const decisions = yield* resolveConflicts(plan, yes);
 
-          // Confirm
           if (!yes) {
             const proceed = yield* Confirm({
               message: "Apply changes?",
@@ -172,7 +173,6 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             }
           }
 
-          // Apply
           const result = yield* applyService.apply({
             apply: new Apply({ plan, decisions }),
             repoRoot,
@@ -185,7 +185,6 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             yield* Console.log(`Failed: ${result.failed.length} files`);
           }
 
-          // Finalize
           const finalizeConfig: FinalizeConfig = {
             config,
             repoRoot,
@@ -197,7 +196,6 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
           if (previewScripts.length > 0) {
             const skipPrompt = yes || trust;
 
-            // Determine which scripts to run
             const selectedScripts = skipPrompt
               ? previewScripts
               : yield* MultiSelect({
@@ -216,7 +214,7 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
                   })),
                 });
 
-            // Print script list for non-interactive (audit trail)
+            // NOTE: Non-interactive runs still print the script list as an audit trail.
             if (skipPrompt) {
               yield* Console.log("\nFinalize scripts:");
               for (const script of previewScripts) {
@@ -235,10 +233,7 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
                 finalizeConfig,
               );
 
-              // Filter executables to only selected scripts
-              const selectedCommands = new Set(
-                selectedScripts.map((s) => s.command),
-              );
+              const selectedCommands = selectedCommandSet(selectedScripts);
               const filteredExecutables = executables.filter((e) =>
                 selectedCommands.has(e.script.command),
               );
@@ -282,15 +277,11 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
               }
             }
 
-            // Determine skipped scripts (deselected by user)
-            const selectedCommands = new Set(
-              selectedScripts.map((s) => s.command),
+            const skippedScripts = skippedFinalizeScripts(
+              previewScripts,
+              selectedCommandSet(selectedScripts),
             );
-            const skippedScripts = previewScripts
-              .filter((s) => !selectedCommands.has(s.command))
-              .map((s) => ({ label: s.label, command: s.command }));
 
-            // Collect and render post-scaffold summary
             const nextSteps = yield* finalizeService.collectNextSteps(
               blueprint,
               finalizeConfig,

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -33,14 +33,14 @@ const supportedOnTargetKind = Match.type<
 const hasVisibility = (
   definition: { readonly visibility?: typeof Visibility.Type },
   visibility: typeof Visibility.Type | undefined,
-): boolean =>
+) =>
   visibility === undefined ||
   (definition.visibility ?? "public") === visibility;
 
 const moduleSupportsTargetKind = (
   mod: typeof import("@repo/domain/Catalog").ModuleDefinition.Type,
   kind: typeof TargetKind.Type,
-): boolean =>
+) =>
   Arr.some(
     mod.supportedOn,
     (supportedOn) => supportedOnTargetKind(supportedOn) === kind,

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -251,7 +251,7 @@ export class CatalogService extends Context.Service<CatalogService>()(
           for (const child of mod.children ?? []) {
             const childIdx = moduleNodes.get(child.moduleId);
             if (childIdx !== undefined) {
-              // Edge direction: child points to parent (childOf relationship)
+              // NOTE: Child edges point to parents so graph consumers can traverse childOf relationships directly.
               Graph.addEdge(g, childIdx, modIdx, "childOf");
             }
           }
@@ -264,21 +264,13 @@ export class CatalogService extends Context.Service<CatalogService>()(
       }): ReadonlyArray<
         typeof import("@repo/domain/Catalog").ModuleDefinition.Type
       > =>
-        Arr.filter(Arr.fromIterable(moduleIndex.values()), (mod) => {
-          if (
-            options?.category &&
-            !Arr.contains(mod.categories ?? [], options.category)
-          ) {
-            return false;
-          }
-          if (
-            options?.visibility &&
-            (mod.visibility ?? "public") !== options.visibility
-          ) {
-            return false;
-          }
-          return true;
-        });
+        Arr.filter(
+          Arr.fromIterable(moduleIndex.values()),
+          (mod) =>
+            (options?.category === undefined ||
+              Arr.contains(mod.categories ?? [], options.category)) &&
+            hasVisibility(mod, options?.visibility),
+        );
 
       const toCatalogTree: typeof CatalogTree.Type = {
         targets: Arr.map(Arr.fromIterable(targetIndex.values()), (target) => ({

--- a/packages/catalog/src/registry/content/ai.ts
+++ b/packages/catalog/src/registry/content/ai.ts
@@ -64,12 +64,10 @@ import {
   AgenticLoopServiceLive,
 } from "../workflow/AgenticLoop";
 
-// ChatToolkit - Merged toolkit for the chat service
-// AST can append additional toolkits to this merge call
+// NOTE: Catalog composition appends additional toolkits to this merge call.
 export const ChatToolkit = Toolkit.merge(ThinkToolkit);
 
-// ChatToolkitLive - Merged layer providing handlers for all toolkits
-// AST can append additional toolkit layers to this merge call
+// NOTE: Catalog composition appends additional toolkit layers to this merge call.
 export const ChatToolkitLive = Layer.mergeAll(ThinkToolkitLive);
 
 export class AiChatService extends Context.Service<AiChatService>()("AiChatService", {

--- a/packages/catalog/src/registry/content/api.ts
+++ b/packages/catalog/src/registry/content/api.ts
@@ -10,7 +10,6 @@ export const ApiResponse = Schema.Struct({
   success: Schema.Literal(true),
 });
 
-// Define Domain of API
 export class HealthGroup extends HttpApiGroup.make("health")
   .add(HttpApiEndpoint.get("get", "/", { success: Schema.String }))
   .prefix("/") {}

--- a/packages/catalog/src/registry/content/chat.ts
+++ b/packages/catalog/src/registry/content/chat.ts
@@ -1,12 +1,7 @@
-// Domain Chat schema
 export const domainChatContents = `import { Schema } from "effect";
 
 export const ChatId = Schema.String.pipe(Schema.brand("ChatId"));
 export type ChatId = Schema.Schema.Type<typeof ChatId>;
-
-// ============================================================================
-// Wire Protocol: ChatStreamPart
-// ============================================================================
 
 export const ChatStreamPart = Schema.TaggedUnion({
   text: {
@@ -49,20 +44,12 @@ export const ChatStreamPart = Schema.TaggedUnion({
 
 export type ChatStreamPart = Schema.Schema.Type<typeof ChatStreamPart>;
 
-// ============================================================================
-// Chat Message (sent from client to server)
-// ============================================================================
-
 export const ChatMessage = Schema.Struct({
   role: Schema.Literals(["user", "assistant", "system"]),
   content: Schema.String,
 });
 
 export type ChatMessage = Schema.Schema.Type<typeof ChatMessage>;
-
-// ============================================================================
-// Client-Side State Machine: ChatResponse
-// ============================================================================
 
 export const ToolCall = Schema.Struct({
   id: Schema.String,

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -47,17 +47,9 @@ export const cliIndexContents = `import { BunRuntime, BunServices } from "@effec
 import { Effect } from "effect";
 import { Command } from "effect/unstable/cli";
 
-// ============================================================================
-// Root Command
-// ============================================================================
-
 const root = Command.make("{{packageName}}");
 
-// ============================================================================
-// Program
-// ============================================================================
-
-// Subcommands - modules inject additional subcommands via Command.withSubcommands
+// NOTE: Modules inject additional subcommands through Command.withSubcommands.
 const AllCommands = Command.withSubcommands([]);
 
 root.pipe(
@@ -98,9 +90,7 @@ import type { ChatMessage, ChatStreamPart } from "@repo/domain/Chat";
 import { Array, Context, Effect, Layer, Match, pipe, Stream } from "effect";
 import { Prompt } from "effect/unstable/ai";
 
-// The server runtime has a similar helper, but the CLI module must not depend on
-// server/RPC modules. If this duplication grows after the interactive chat command
-// lands, consider moving a pure conversion helper to a shared package boundary.
+// NOTE: CLI chat keeps this converter local to avoid depending on server/RPC modules.
 const toPromptMessage = (message: ChatMessage) => {
   return pipe(
     Match.value(message.role),

--- a/packages/catalog/src/registry/content/client-chat.ts
+++ b/packages/catalog/src/registry/content/client-chat.ts
@@ -1,4 +1,3 @@
-// Client chat RPC client
 export const clientChatRpcClientContents = `import { ChatRpc } from "@repo/domain/ChatRpc";
 import { Context, Effect, Layer } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
@@ -222,7 +221,6 @@ export const chatAtom: AtomType.AtomResultFn<
 });
 `;
 
-// Client chat box component (unchanged from before)
 export const clientChatBoxContents = `import { useAtom } from "@effect/atom-react";
 import type { ChatId, ChatResponse, MessageSegment } from "@repo/domain/Chat";
 import { AsyncResult } from "effect/unstable/reactivity";

--- a/packages/catalog/src/registry/content/client-foldkit-api.ts
+++ b/packages/catalog/src/registry/content/client-foldkit-api.ts
@@ -14,8 +14,6 @@ import { evo } from "foldkit/struct";
 
 const SERVER_URL = "http://localhost:9000";
 
-// MODEL
-
 const ApiInit = ts("ApiInit");
 const ApiLoading = ts("ApiLoading");
 const ApiSuccess = ts("ApiSuccess", { data: ApiResponse });
@@ -34,8 +32,6 @@ export const Model = Schema.Struct({
 });
 export type Model = typeof Model.Type;
 
-// MESSAGE
-
 export const ClickedFetchHello = m("ClickedFetchHello");
 export const SucceededFetchHello = m("SucceededFetchHello", {
   data: ApiResponse,
@@ -49,18 +45,12 @@ export const Message = Schema.Union([
 ]);
 export type Message = typeof Message.Type;
 
-// GOT MESSAGE (parent wrapper)
-
 export const GotMessage = m("GotRestMessage", { message: Message });
-
-// INIT
 
 export const init = (): readonly [
   Model,
   ReadonlyArray<Command.Command<Message>>,
 ] => [{ api: ApiInit() }, []];
-
-// UPDATE
 
 export const update = (model: Model, message: Message) =>
   Match.valueTags(message, {
@@ -71,8 +61,6 @@ export const update = (model: Model, message: Message) =>
     FailedFetchHello: ({ error }) =>
       [evo(model, { api: () => ApiFailure({ error }) }), []] as const,
   });
-
-// COMMAND
 
 export const FetchHello = Command.define(
   "FetchHello",
@@ -103,8 +91,6 @@ export const FetchHello = Command.define(
     Effect.provide(FetchHttpClient.layer),
   ),
 );
-
-// VIEW
 
 export const view = <ParentMessage>(
   model: Model,

--- a/packages/catalog/src/registry/content/client-foldkit-chat.ts
+++ b/packages/catalog/src/registry/content/client-foldkit-chat.ts
@@ -36,8 +36,6 @@ import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
 import { ChatClient, ChatClientLive } from "../services/chat-client";
 
-// MODEL
-
 const ChatMessageSchema = Schema.Struct({
   role: Schema.Literals(["user", "assistant", "system"]),
   content: Schema.String,
@@ -65,8 +63,6 @@ export const Model = Schema.Struct({
 });
 export type Model = typeof Model.Type;
 
-// MESSAGE
-
 export const UpdatedChatInput = m("UpdatedChatInput", { value: Schema.String });
 export const SubmittedChatMessage = m("SubmittedChatMessage");
 export const StartedChat = m("StartedChat", {
@@ -91,11 +87,7 @@ export const Message = Schema.Union([
 ]);
 export type Message = typeof Message.Type;
 
-// GOT MESSAGE (parent wrapper)
-
 export const GotMessage = m("GotChatMessage", { message: Message });
-
-// INIT
 
 export const init = (): readonly [
   Model,
@@ -113,8 +105,6 @@ export const init = (): readonly [
   },
   [],
 ];
-
-// HELPERS
 
 type MutableSegment =
   | { _tag: "text"; content: string; isComplete: boolean }
@@ -225,8 +215,6 @@ const extractTextFromSegments = (
     .map((seg) => seg.content)
     .join("");
 
-// UPDATE
-
 export const update = (
   model: Model,
   message: Message,
@@ -316,8 +304,6 @@ export const update = (
   });
 };
 
-// COMMAND
-
 export const StartChat = Command.define(
   "StartChat",
   { messagesJson: Schema.String },
@@ -335,8 +321,6 @@ export const StartChat = Command.define(
     Effect.provide(ChatClientLive),
   ),
 );
-
-// SUBSCRIPTION
 
 export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
   chatStream: entry(
@@ -385,8 +369,6 @@ export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
     },
   ),
 }));
-
-// VIEW
 
 export const view = <ParentMessage>(
   model: Model,
@@ -526,8 +508,6 @@ export const view = <ParentMessage>(
     ],
   );
 };
-
-// VIEW HELPERS
 
 const emptyStateView = <ParentMessage>(
   h: ReturnType<typeof html<ParentMessage>>,

--- a/packages/catalog/src/registry/content/client-foldkit-rpc.ts
+++ b/packages/catalog/src/registry/content/client-foldkit-rpc.ts
@@ -40,16 +40,12 @@ import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
 import { RpcClient, RpcClientLive } from "../services/rpc-client";
 
-// MODEL
-
 export const Model = Schema.Struct({
   ticksEnabled: Schema.Boolean,
   tickProgress: Schema.String,
   tickCount: Schema.Number,
 });
 export type Model = typeof Model.Type;
-
-// MESSAGE
 
 export const ClickedStartTicks = m("ClickedStartTicks");
 export const ClickedStopTicks = m("ClickedStopTicks");
@@ -64,18 +60,12 @@ export const Message = Schema.Union([
 ]);
 export type Message = typeof Message.Type;
 
-// GOT MESSAGE (parent wrapper)
-
 export const GotMessage = m("GotTicksMessage", { message: Message });
-
-// INIT
 
 export const init = (): readonly [
   Model,
   ReadonlyArray<Command.Command<Message>>,
 ] => [{ ticksEnabled: false, tickProgress: "", tickCount: 0 }, []];
-
-// UPDATE
 
 export const update = (
   model: Model,
@@ -120,8 +110,6 @@ export const update = (
       ] as const,
   });
 
-// SUBSCRIPTION
-
 export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
   tickStream: entry(
     { isEnabled: Schema.Boolean },
@@ -140,8 +128,6 @@ export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
     },
   ),
 }));
-
-// VIEW
 
 export const view = <ParentMessage>(
   model: Model,

--- a/packages/catalog/src/registry/content/client-foldkit-websocket.ts
+++ b/packages/catalog/src/registry/content/client-foldkit-websocket.ts
@@ -48,8 +48,6 @@ import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
 import { WsClient, WsClientLive } from "../services/ws-client";
 
-// MODEL
-
 const PresenceClient = Schema.Struct({
   clientId: Schema.String,
   status: Schema.String,
@@ -63,8 +61,6 @@ export const Model = Schema.Struct({
   myStatus: Schema.String,
 });
 export type Model = typeof Model.Type;
-
-// MESSAGE
 
 export const ClickedConnectPresence = m("ClickedConnectPresence");
 export const ClickedDisconnectPresence = m("ClickedDisconnectPresence");
@@ -91,11 +87,7 @@ export const Message = Schema.Union([
 ]);
 export type Message = typeof Message.Type;
 
-// GOT MESSAGE (parent wrapper)
-
 export const GotMessage = m("GotPresenceMessage", { message: Message });
-
-// INIT
 
 export const init = (): readonly [
   Model,
@@ -109,8 +101,6 @@ export const init = (): readonly [
   },
   [],
 ];
-
-// UPDATE
 
 const applyPresenceEvent = (
   model: Model,
@@ -196,8 +186,6 @@ export const update = (model: Model, message: Message) => {
   });
 };
 
-// COMMAND
-
 export const SetStatus = Command.define(
   "SetStatus",
   { clientId: ClientId, status: ClientStatus },
@@ -215,8 +203,6 @@ export const SetStatus = Command.define(
     Effect.provide(WsClientLive),
   ),
 );
-
-// SUBSCRIPTION
 
 export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
   presenceStream: entry(
@@ -236,8 +222,6 @@ export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
     },
   ),
 }));
-
-// VIEW
 
 export const view = <ParentMessage>(
   model: Model,

--- a/packages/catalog/src/registry/content/client-foldkit.ts
+++ b/packages/catalog/src/registry/content/client-foldkit.ts
@@ -161,21 +161,15 @@ import { type Document, html } from "foldkit/html";
 import * as Theme from "./features/theme";
 import { Init, Views } from "./lib/compose";
 
-// MODEL
-
 export const Model = S.Struct({
   theme: Theme.Model,
 });
 export type Model = typeof Model.Type;
 
-// MESSAGE
-
 export const Message = S.Union([
   Theme.GotMessage,
 ]);
 export type Message = typeof Message.Type;
-
-// UPDATE
 
 export const update = (model: Model, message: Message) =>
   M.value(message).pipe(
@@ -195,18 +189,12 @@ export const update = (model: Model, message: Message) =>
     }),
   );
 
-// INIT
-
 export const init: Runtime.ProgramInit<Model, Message> = () =>
   Init.compose(
     Init.child(Theme, "theme", Theme.GotMessage),
   );
 
-// SUBSCRIPTIONS
-
 export const subscriptions = Subscription.aggregate<Model, Message>()();
-
-// VIEW
 
 export const view = (model: Model): Document => {
   const h = html<Message>();
@@ -254,8 +242,6 @@ import { html } from "foldkit/html";
 import { m } from "foldkit/message";
 import { evo } from "foldkit/struct";
 
-// MODEL
-
 const ThemeSchema = Schema.Literals(["Light", "Dark"]);
 export type Theme = typeof ThemeSchema.Type;
 
@@ -264,19 +250,13 @@ export const Model = Schema.Struct({
 });
 export type Model = typeof Model.Type;
 
-// MESSAGE
-
 export const ClickedToggleTheme = m("ClickedToggleTheme");
 export const CompletedSaveTheme = m("CompletedSaveTheme");
 
 export const Message = Schema.Union([ClickedToggleTheme, CompletedSaveTheme]);
 export type Message = typeof Message.Type;
 
-// GOT MESSAGE (parent wrapper)
-
 export const GotMessage = m("GotThemeMessage", { message: Message });
-
-// INIT
 
 export const init = (): readonly [
   Model,
@@ -290,8 +270,6 @@ export const init = (): readonly [
   return [{ theme }, [ApplyTheme({ theme })]];
 };
 
-// UPDATE
-
 export const update = (model: Model, message: Message) =>
   Match.valueTags(message, {
     ClickedToggleTheme: () => {
@@ -303,8 +281,6 @@ export const update = (model: Model, message: Message) =>
     },
     CompletedSaveTheme: () => [model, []] as const,
   });
-
-// COMMAND
 
 const resolveTheme = (theme: Theme): boolean => theme === "Dark";
 
@@ -331,8 +307,6 @@ export const ApplyTheme = Command.define(
     return CompletedSaveTheme();
   }),
 );
-
-// VIEW
 
 export const view = <ParentMessage>(
   model: Model,
@@ -393,10 +367,6 @@ import type { Html } from "foldkit/html";
  * Used by the scaffold to compose child features into the root main.ts.
  */
 
-// =============================================================================
-// Init Composition
-// =============================================================================
-
 /** Structural shape of a Command without the conditional type indirection. */
 type AnyCommand<T> = Readonly<{
   name: string;
@@ -445,10 +415,6 @@ export const Init = {
     return [model, commands] as const;
   },
 };
-
-// =============================================================================
-// View Composition
-// =============================================================================
 
 export const Views = {
   compose: (...children: ReadonlyArray<Html>): ReadonlyArray<Html> => children,

--- a/packages/catalog/src/registry/content/client-rpc.ts
+++ b/packages/catalog/src/registry/content/client-rpc.ts
@@ -1,4 +1,3 @@
-// Client RPC service
 export const clientRpcClientContents = `import { EventRpc } from "@repo/domain/Rpc";
 import { Context, Effect, Layer } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
@@ -29,7 +28,6 @@ export class RpcClient extends Context.Service<RpcClient>()("RpcClient", {
 }
 `;
 
-// Client tick atom
 export const clientTickAtomContents = `import type { TickEvent } from "@repo/domain/Rpc";
 import { Effect, Layer, Stream } from "effect";
 import { DevTools } from "effect/unstable/devtools";
@@ -88,7 +86,6 @@ export const tickAtom = runtime.fn(
 );
 `;
 
-// Client RPC card component
 export const clientRpcCardContents = `import { useAtom } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { tickAtom } from "@/lib/atoms/tick-atom";

--- a/packages/catalog/src/registry/content/client-websocket.ts
+++ b/packages/catalog/src/registry/content/client-websocket.ts
@@ -1,4 +1,3 @@
-// Client WebSocket RPC service + presence atom
 export const clientWebSocketClientContents = `import { BrowserSocket } from "@effect/platform-browser";
 import type { WebSocketEvent } from "@repo/domain/WebSocket";
 import { WebSocketRpc } from "@repo/domain/WebSocket";
@@ -38,7 +37,7 @@ export const presenceSubscriptionAtom: Atom.AtomResultFn<
   }).pipe(
     Effect.map((stream) =>
       stream.pipe(
-        // Cap event accumulation at 100 to prevent memory growth in long sessions
+        // NOTE: Cap event accumulation at 100 to prevent memory growth in long sessions.
         Stream.scan<WebSocketEvent[], WebSocketEvent>([], (acc, event) => {
           const updated = [...acc, event];
           return updated.length > 100 ? updated.slice(-100) : updated;
@@ -50,7 +49,6 @@ export const presenceSubscriptionAtom: Atom.AtomResultFn<
 );
 `;
 
-// Client presence panel component
 export const clientPresencePanelContents = `import { useAtom, useAtomSet } from "@effect/atom-react";
 import type {
   ClientId,

--- a/packages/catalog/src/registry/content/presence.ts
+++ b/packages/catalog/src/registry/content/presence.ts
@@ -1,5 +1,3 @@
-// Presence package: PresenceService, ClientGenerator
-
 export const presenceIndexContents = `export * from "./services/ClientGenerator";
 export * from "./services/PresenceService";
 `;

--- a/packages/catalog/src/registry/content/rpc.ts
+++ b/packages/catalog/src/registry/content/rpc.ts
@@ -1,8 +1,5 @@
-// Domain RPC schema (tick only — chat is separate module)
 export const domainRpcContents = `import { Schema } from "effect";
 import { Rpc, RpcGroup } from "effect/unstable/rpc";
-
-// Define Event RPC
 
 export const TickEvent = Schema.Union([
   Schema.TaggedStruct("starting", {}),
@@ -21,7 +18,6 @@ export class EventRpc extends RpcGroup.make(
 ) {}
 `;
 
-// Server tick handler
 export const serverTickContents = `import { EventRpc, type TickEvent } from "@repo/domain/Rpc";
 import { Effect, Layer, Queue } from "effect";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -50,10 +50,6 @@ import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { HealthGroupLive } from "./Api/Health";
 import { HelloGroupLive } from "./Api/Hello";
 
-// ============================================================================
-// Server Configuration
-// ============================================================================
-
 const ServerConfig = Config.all({
   port: Config.number("PORT").pipe(Config.withDefault(9000)),
   hostname: Config.string("HOST").pipe(Config.withDefault("0.0.0.0")),
@@ -64,24 +60,16 @@ const ServerConfig = Config.all({
   enableDevTools: Config.boolean("DEVTOOLS").pipe(Config.withDefault(false)),
 });
 
-// ============================================================================
-// Router Composition
-// ============================================================================
-
 // HTTP API Router
 const ApiRouter = HttpApiBuilder.layer(Api).pipe(
   Layer.provide([HealthGroupLive, HelloGroupLive]),
 );
 
-// All Routers - modules append additional routers here via Layer.mergeAll
+// NOTE: Modules append additional routers through Layer.mergeAll.
 const RouterDependencies = Layer.mergeAll(Layer.empty);
 const AllRouters = Layer.mergeAll(ApiRouter).pipe(
   Layer.provide(RouterDependencies),
 );
-
-// ============================================================================
-// Server Launch
-// ============================================================================
 
 const DevToolsLive = Effect.gen(function* () {
   const config = yield* ServerConfig;

--- a/packages/catalog/src/registry/modules/cli.ts
+++ b/packages/catalog/src/registry/modules/cli.ts
@@ -12,9 +12,6 @@ import {
   cliTerminalChatContents,
 } from "../content/cli";
 
-/**
- * CLI modules - subcommands and services for CLI applications
- */
 export const cliModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("cli-command-hello"),

--- a/packages/catalog/src/registry/modules/client-foldkit.ts
+++ b/packages/catalog/src/registry/modules/client-foldkit.ts
@@ -24,9 +24,6 @@ const domainTarget = new TargetIdentity({
   name: "domain",
 });
 
-/**
- * Helper to generate the update case body for a foldkit child feature module.
- */
 const updateCaseValue = (namespace: string, modelField: string) =>
   `({ message }) => {
   const [nextChild, cmds] = ${namespace}.update(model.${modelField}, message);
@@ -38,9 +35,6 @@ const updateCaseValue = (namespace: string, modelField: string) =>
   return [{ ...model, ${modelField}: nextChild }, mappedCommands];
 }`;
 
-/**
- * Client Foldkit modules - TEA-based frontend features
- */
 export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
   [
     {
@@ -74,7 +68,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
           name: "@repo/domain",
           value: "workspace:*",
         },
-        // Model composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -87,7 +80,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Rest",
           },
         },
-        // Message composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -99,7 +91,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Rest",
           },
         },
-        // Update composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -112,7 +103,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Rest",
           },
         },
-        // Init composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -124,7 +114,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Rest",
           },
         },
-        // View composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -174,7 +163,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
           name: "@repo/domain",
           value: "workspace:*",
         },
-        // Model composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -187,7 +175,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Ticks",
           },
         },
-        // Message composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -199,7 +186,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Ticks",
           },
         },
-        // Update composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -212,7 +198,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Ticks",
           },
         },
-        // Init composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -224,7 +209,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Ticks",
           },
         },
-        // Subscription composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -239,7 +223,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Ticks",
           },
         },
-        // View composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -289,7 +272,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
           name: "@repo/domain",
           value: "workspace:*",
         },
-        // Model composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -302,7 +284,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Presence",
           },
         },
-        // Message composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -314,7 +295,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Presence",
           },
         },
-        // Update composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -327,7 +307,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Presence",
           },
         },
-        // Init composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -339,7 +318,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Presence",
           },
         },
-        // Subscription composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -354,7 +332,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Presence",
           },
         },
-        // View composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -414,7 +391,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
           name: "@repo/domain",
           value: "workspace:*",
         },
-        // Model composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -427,7 +403,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Chat",
           },
         },
-        // Message composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -439,7 +414,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Chat",
           },
         },
-        // Update composition
         {
           _tag: "ts-object-field",
           path: "{{targetPath}}/src/main.ts",
@@ -452,7 +426,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Chat",
           },
         },
-        // Init composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -464,7 +437,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Chat",
           },
         },
-        // Subscription composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",
@@ -479,7 +451,6 @@ export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
             namespaceImport: "Chat",
           },
         },
-        // View composition
         {
           _tag: "ts-call-arg",
           path: "{{targetPath}}/src/main.ts",

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -23,28 +23,29 @@ import {
   clientWebSocketClientContents,
 } from "../content/client-websocket";
 
-/**
- * Client modules - frontend UI components and API clients
- */
+const clientReactKind = TargetKind.make("client-react");
+const serverKind = TargetKind.make("server");
+const domainTarget = new TargetIdentity({
+  kind: TargetKind.make("package"),
+  name: "domain",
+});
+
 export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("client-react-http-api"),
     title: "HTTP API Client",
     description: "REST API client with Effect Atom and typed HttpApiClient",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
+    supportedOn: [{ _tag: "kind", kind: clientReactKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-api-contracts"),
       },
     ],
     implies: [
       {
-        targetKind: TargetKind.make("server"),
+        targetKind: serverKind,
         moduleId: ModuleId.make("server-http-api"),
       },
     ],
@@ -92,20 +93,17 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("client-react-http-rpc"),
     title: "HTTP RPC Client",
     description: "RPC streaming client with tick atom and UI",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
+    supportedOn: [{ _tag: "kind", kind: clientReactKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-rpc-contracts"),
       },
     ],
     implies: [
       {
-        targetKind: TargetKind.make("server"),
+        targetKind: serverKind,
         moduleId: ModuleId.make("server-http-rpc"),
       },
     ],
@@ -158,20 +156,17 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("client-react-chat"),
     title: "Chat Client",
     description: "AI chat UI with streaming, tool calls, and state machine",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
+    supportedOn: [{ _tag: "kind", kind: clientReactKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-chat-contracts"),
       },
     ],
     implies: [
       {
-        targetKind: TargetKind.make("server"),
+        targetKind: serverKind,
         moduleId: ModuleId.make("server-chat-rpc"),
       },
     ],
@@ -228,20 +223,17 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("client-react-ws-presence"),
     title: "WebSocket Presence Client",
     description: "Real-time presence UI with WebSocket RPC",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("client-react") }],
+    supportedOn: [{ _tag: "kind", kind: clientReactKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-ws-contracts"),
       },
     ],
     implies: [
       {
-        targetKind: TargetKind.make("server"),
+        targetKind: serverKind,
         moduleId: ModuleId.make("server-ws-presence"),
       },
     ],

--- a/packages/catalog/src/registry/modules/config.ts
+++ b/packages/catalog/src/registry/modules/config.ts
@@ -5,9 +5,6 @@ import {
 } from "@repo/domain/Catalog";
 import { configTypescriptViteContents } from "../content/client";
 
-/**
- * Config modules - shared TypeScript configurations
- */
 export const configModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("config-typescript-vite"),

--- a/packages/catalog/src/registry/modules/domain.ts
+++ b/packages/catalog/src/registry/modules/domain.ts
@@ -13,9 +13,12 @@ import {
 import { domainRpcContents } from "../content/rpc";
 import { domainWebSocketContents } from "../content/websocket";
 
-/**
- * Domain modules - shared domain schemas and RPC definitions
- */
+const packageKind = TargetKind.make("package");
+const domainTarget = new TargetIdentity({
+  kind: packageKind,
+  name: "domain",
+});
+
 export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("domain-api-contracts"),
@@ -25,10 +28,7 @@ export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     supportedOn: [
       {
         _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        identity: domainTarget,
       },
     ],
     dependencies: [],
@@ -60,10 +60,7 @@ export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     supportedOn: [
       {
         _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        identity: domainTarget,
       },
     ],
     dependencies: [],
@@ -96,10 +93,7 @@ export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     supportedOn: [
       {
         _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        identity: domainTarget,
       },
     ],
     dependencies: [],
@@ -148,19 +142,13 @@ export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     supportedOn: [
       {
         _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        identity: domainTarget,
       },
     ],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-chat-contracts"),
       },
     ],
@@ -192,10 +180,7 @@ export const domainModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     supportedOn: [
       {
         _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        identity: domainTarget,
       },
     ],
     dependencies: [],

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -16,9 +16,6 @@ import {
   vitestConfigContents,
 } from "../content/init";
 
-/**
- * Workspace modules - project-wide tooling (turbo, biome, vitest)
- */
 const gitInitModule: typeof ModuleDefinition.Type = {
   id: ModuleId.make("workspace-devenv-git"),
   title: "Git",

--- a/packages/catalog/src/registry/modules/packages.ts
+++ b/packages/catalog/src/registry/modules/packages.ts
@@ -33,9 +33,6 @@ import {
   presenceServiceContents,
 } from "../content/presence";
 
-/**
- * Package modules - infrastructure packages (ai, presence)
- */
 export const packageModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("package-ai-core"),

--- a/packages/catalog/src/registry/modules/server.ts
+++ b/packages/catalog/src/registry/modules/server.ts
@@ -15,22 +15,31 @@ import {
 import { serverTickContents } from "../content/rpc";
 import { serverPresenceContents } from "../content/websocket";
 
-/**
- * Server modules - backend API handlers and services
- */
+const serverKind = TargetKind.make("server");
+const packageKind = TargetKind.make("package");
+const domainTarget = new TargetIdentity({
+  kind: packageKind,
+  name: "domain",
+});
+const aiTarget = new TargetIdentity({
+  kind: packageKind,
+  name: "ai",
+});
+const presenceTarget = new TargetIdentity({
+  kind: packageKind,
+  name: "presence",
+});
+
 export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("server-http-api"),
     title: "HTTP API Server",
     description: "REST API endpoints with Effect HTTP",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("server") }],
+    supportedOn: [{ _tag: "kind", kind: serverKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-api-contracts"),
       },
     ],
@@ -58,14 +67,11 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("server-http-rpc"),
     title: "HTTP RPC Server",
     description: "RPC streaming server with tick handler",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("server") }],
+    supportedOn: [{ _tag: "kind", kind: serverKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-rpc-contracts"),
       },
     ],
@@ -99,22 +105,16 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("server-chat-rpc"),
     title: "Chat Server",
     description: "AI chat RPC handler with tool support",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("server") }],
+    supportedOn: [{ _tag: "kind", kind: serverKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-chat-contracts"),
       },
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "ai",
-        }),
+        target: aiTarget,
         moduleId: ModuleId.make("package-ai-chat-service"),
       },
     ],
@@ -176,14 +176,11 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("server-chat-runtime-managed"),
     title: "Managed Chat Runtime",
     description: "In-memory managed chat send, watch, and interrupt runtime",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("server") }],
+    supportedOn: [{ _tag: "kind", kind: serverKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-chat-managed-contracts"),
       },
       {
@@ -223,22 +220,16 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     id: ModuleId.make("server-ws-presence"),
     title: "WebSocket Presence Server",
     description: "Real-time presence tracking over WebSocket RPC",
-    supportedOn: [{ _tag: "kind", kind: TargetKind.make("server") }],
+    supportedOn: [{ _tag: "kind", kind: serverKind }],
     dependencies: [
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "domain",
-        }),
+        target: domainTarget,
         moduleId: ModuleId.make("domain-ws-contracts"),
       },
       {
         _tag: "required-module",
-        target: new TargetIdentity({
-          kind: TargetKind.make("package"),
-          name: "presence",
-        }),
+        target: presenceTarget,
         moduleId: ModuleId.make("package-presence-service"),
       },
     ],

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -96,7 +96,6 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     description: "A frontend application built with React",
     requiredModules: [ModuleId.make("config-typescript-vite")],
     contributions: [
-      // Files
       {
         _tag: "file",
         path: "{{targetPath}}/package.json",
@@ -157,14 +156,12 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/src/vite-env.d.ts",
         contents: clientViteEnvContents,
       },
-      // TSConfig (conflict on modify)
       {
         _tag: "file",
         path: "{{targetPath}}/tsconfig.json",
         contents: clientTsconfigContents,
         conflictOnModify: true,
       },
-      // Scripts
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
@@ -226,7 +223,6 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     description: "A frontend application built with Foldkit (Elm Architecture)",
     requiredModules: [ModuleId.make("config-typescript-vite")],
     contributions: [
-      // Files
       {
         _tag: "file",
         path: "{{targetPath}}/package.json",
@@ -277,14 +273,12 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/tsconfig.config.json",
         contents: foldkitTsconfigConfigContents,
       },
-      // TSConfig (conflict on modify)
       {
         _tag: "file",
         path: "{{targetPath}}/tsconfig.json",
         contents: foldkitTsconfigContents,
         conflictOnModify: true,
       },
-      // Scripts
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
@@ -336,7 +330,6 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     description: "A backend application, such as an API server",
     requiredModules: [ModuleId.make("server-http-api")],
     contributions: [
-      // Files
       {
         _tag: "file",
         path: "{{targetPath}}/package.json",
@@ -347,14 +340,12 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/src/index.ts",
         contents: serverIndexContents,
       },
-      // TSConfig (conflict on modify)
       {
         _tag: "file",
         path: "{{targetPath}}/tsconfig.json",
         contents: serverTsconfigContents,
         conflictOnModify: true,
       },
-      // Scripts
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
@@ -413,7 +404,6 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     description: "A command-line interface application",
     requiredModules: [ModuleId.make("cli-command-hello")],
     contributions: [
-      // Files
       {
         _tag: "file",
         path: "{{targetPath}}/package.json",
@@ -424,14 +414,12 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/src/index.ts",
         contents: cliIndexContents,
       },
-      // TSConfig (conflict on modify)
       {
         _tag: "file",
         path: "{{targetPath}}/tsconfig.json",
         contents: cliTsconfigContents,
         conflictOnModify: true,
       },
-      // Scripts
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
@@ -484,20 +472,17 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     visibility: "internal",
     requiredModules: [],
     contributions: [
-      // Files
       {
         _tag: "file",
         path: "{{targetPath}}/package.json",
         contents: packagePackageJsonContents,
       },
-      // TSConfig (conflict on modify)
       {
         _tag: "file",
         path: "{{targetPath}}/tsconfig.json",
         contents: packageDomainTsconfigContents,
         conflictOnModify: true,
       },
-      // Scripts
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",

--- a/packages/domain/src/Blueprint.test.ts
+++ b/packages/domain/src/Blueprint.test.ts
@@ -206,8 +206,7 @@ describe("@repo/domain Blueprint", () => {
   });
 
   it("should enforce canonical target key formatting", async () => {
-    // TargetKey is a branded string that accepts any string value.
-    // Format validation is done at a higher level (e.g., during blueprint construction).
+    // NOTE: TargetKey is only branded here; blueprint construction owns format validation.
     await expect(
       Schema.decodeUnknownPromise(TargetKey)("apps/server-api"),
     ).resolves.toBe("apps/server-api");

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -28,29 +28,11 @@ export class TargetIdentity extends Schema.Class<TargetIdentity>(
   name: Schema.String,
 }) {
   toPath(): typeof TargetPath.Type {
-    switch (this.kind) {
-      case "workspace":
-        return TargetPath.make(".");
-      case "package":
-        return TargetPath.make(`packages/${Str.kebabCase(this.name.trim())}`);
-      default:
-        return TargetPath.make(
-          `apps/${this.kind}${this.name ? `-${Str.kebabCase(this.name.trim())}` : ""}`,
-        );
-    }
+    return TargetPath.make(toTargetPathString(this));
   }
 
   toKey(): typeof TargetKey.Type {
-    switch (this.kind) {
-      case "workspace":
-        return TargetKey.make(".");
-      case "package":
-        return TargetKey.make(`packages/${Str.kebabCase(this.name.trim())}`);
-      default:
-        return TargetKey.make(
-          `apps/${this.kind}${this.name ? `-${Str.kebabCase(this.name.trim())}` : ""}`,
-        );
-    }
+    return TargetKey.make(toTargetPathString(this));
   }
 
   /**
@@ -80,6 +62,19 @@ export class TargetIdentity extends Schema.Class<TargetIdentity>(
   }
 }
 
+const toTargetPathString = (identity: TargetIdentity): string => {
+  const trimmedName = identity.name.trim();
+
+  switch (identity.kind) {
+    case "workspace":
+      return ".";
+    case "package":
+      return `packages/${Str.kebabCase(trimmedName)}`;
+    default:
+      return `apps/${identity.kind}${identity.name ? `-${Str.kebabCase(trimmedName)}` : ""}`;
+  }
+};
+
 export const SupportedOn = Schema.TaggedUnion({
   kind: {
     kind: TargetKind,
@@ -108,10 +103,6 @@ export const ModuleImplication = Schema.Struct({
   targetKind: TargetKind,
   moduleId: ModuleId,
 });
-
-// =============================================================================
-// Contributions
-// =============================================================================
 
 /**
  * A Contribution declares a single unit of desired repository state.
@@ -371,10 +362,6 @@ export type CatalogGraph = Graph.DirectedGraph<
   typeof CatalogNode.Type,
   typeof CatalogEdge.Type
 >;
-
-// =============================================================================
-// Catalog Tree (selection-oriented view)
-// =============================================================================
 
 /**
  * A module entry within the catalog tree, showing what it requires and implies

--- a/packages/domain/src/Plan.ts
+++ b/packages/domain/src/Plan.ts
@@ -1,10 +1,6 @@
 import { Order, Schema } from "effect";
 import { pathOrd } from "./Order";
 
-// =============================================================================
-// RepoSnapshot Path States
-// =============================================================================
-
 export const RepoSnapshotPath = Schema.TaggedUnion({
   missing: {
     path: Schema.String,
@@ -29,10 +25,6 @@ export class PlanFailure extends Schema.TaggedErrorClass<PlanFailure>()(
     message: Schema.String,
   },
 ) {}
-
-// =============================================================================
-// Composition Operations
-// =============================================================================
 
 export const JsonPkgExportsOp = Schema.TaggedStruct("json-pkg-exports", {
   fileType: Schema.tag("json"),
@@ -106,21 +98,15 @@ export const TsJsxSlotOp = Schema.TaggedStruct("ts-jsx-slot", {
 });
 
 export const CompositionOperation = Schema.Union([
-  // JSON operations
   JsonPkgExportsOp,
   JsonPkgDepsOp,
   JsonPkgScriptsOp,
-  // TypeScript operations
   TsAddImportOp,
   TsAddReexportOp,
   TsAppendCallArgOp,
   TsObjectFieldOp,
   TsJsxSlotOp,
 ]).pipe(Schema.toTaggedUnion("fileType"));
-
-// =============================================================================
-// Plan Classification and Outcomes
-// =============================================================================
 
 export const PlanEntryClassification = Schema.Literals([
   "create",

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -90,14 +90,12 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
 
     const targetPath = this.identity.toPath();
 
-    // When targetPath is "." (workspace target), avoid producing "./foo" paths —
-    // strip the leading "./" so paths stay consistent with module contributions.
+    // NOTE: Workspace targets omit "./" so token output matches contribution paths.
     const resolveTargetToken = (t: string, token: string) =>
       targetPath === "."
         ? t.replaceAll(`${token}/`, "").replaceAll(token, "")
         : t.replaceAll(token, targetPath);
 
-    // Config field lookup for conditionals and tokens
     const getConfigValue = (field: string): string => {
       switch (field) {
         case "runtime":
@@ -117,22 +115,18 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
       }
     };
 
-    // Process conditionals: {{#if field}}...{{/if}} or {{#if field=value}}...{{/if}}
     const resolveConditionals = (t: string): string => {
       const conditionalRegex =
         /\{\{#if\s+(\w+)(?:=(\w+))?\}\}([\s\S]*?)\{\{\/if\}\}/g;
       return t.replace(conditionalRegex, (_, field, value, content) => {
         const configValue = getConfigValue(field);
         if (value !== undefined) {
-          // Equality check: {{#if field=value}}
           return configValue === value ? content : "";
         }
-        // Truthy check: {{#if field}}
         return configValue.length > 0 ? content : "";
       });
     };
 
-    // First resolve conditionals, then simple tokens
     const withConditionals = resolveConditionals(template);
 
     return resolveTargetToken(

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -53,10 +53,6 @@ type FormattedPlan = {
   readonly tree: Box.Box<Ansi.AnsiStyle>;
 };
 
-// ============================================================================
-// Generic Tree Rendering
-// ============================================================================
-
 /**
  * Generic tree node that can represent any hierarchical data.
  * Used by both Blueprint and Plan formatters for consistent tree rendering.
@@ -298,7 +294,6 @@ const buildNodes = (
 ): ReadonlyArray<TreeNode<Ansi.AnsiStyle>> => {
   if (entries.length === 0) return [];
 
-  // Group entries by their segment at current depth
   const groups = Arr.reduce<
     (typeof entries)[number],
     Array<{
@@ -317,18 +312,15 @@ const buildNodes = (
     return groups;
   });
 
-  // Classify each group as directory-only, file-only, or mixed
-  // Sort: directories first, then files, both case-insensitive alphabetically
+  // NOTE: Directory groups sort before file leaves so paths render like a filesystem tree.
   const classified = Arr.map(groups, (group) => {
     const hasDeep = group.items.some((e) => e.segments.length > depth + 1);
     return { ...group, hasDeep };
   });
 
   const sorted = [...classified].sort((a, b) => {
-    // Directories before files
     if (a.hasDeep && !b.hasDeep) return -1;
     if (!a.hasDeep && b.hasDeep) return 1;
-    // Then alphabetical case-insensitive
     return a.key.toLowerCase().localeCompare(b.key.toLowerCase());
   });
 

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -363,7 +363,7 @@ const buildNodes = (
 
 const formatPlanClassificationBadge = (
   classification: typeof PlanEntryClassification.Type,
-): Box.Box<Ansi.AnsiStyle> => {
+) => {
   const [text, style] = Match.value(classification).pipe(
     Match.when("create", () => ["[+]", Ansi.green] as const),
     Match.when("modify", () => ["[~]", Ansi.yellow] as const),
@@ -374,9 +374,7 @@ const formatPlanClassificationBadge = (
   return Box.text(text).pipe(Box.annotate(style));
 };
 
-const formatConflictLine = (
-  conflict: typeof PlanConflict.Type,
-): Box.Box<Ansi.AnsiStyle> =>
+const formatConflictLine = (conflict: typeof PlanConflict.Type) =>
   Box.text(
     Match.value(conflict).pipe(
       Match.tags({

--- a/packages/scaffold/src/service/ScaffoldFormatter.test.ts
+++ b/packages/scaffold/src/service/ScaffoldFormatter.test.ts
@@ -219,7 +219,7 @@ describe("ScaffoldFormatter", () => {
           expect(result.summary).toBe(
             "1 create  1 modify  1 unchanged  2 merge",
           );
-          // Box.renderPlainSync pads lines to equal width; trim trailing spaces per line
+          // NOTE: Box.renderPlainSync pads lines to equal width, so assertions trim trailing spaces.
           const trimmedTree = Box.renderPlainSync(result.tree)
             .split("\n")
             .map((line) => line.trimEnd())

--- a/packages/scaffold/src/service/apply/ApplyService.test.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.test.ts
@@ -64,7 +64,7 @@ const makeFileInfo = (type: FileSystem.File.Type): FileSystem.File.Info => ({
 });
 
 const makeFileSystemLayer = (entries: Record<string, MockPathEntry>) => {
-  const getEntry = (absolutePath: string): MockPathEntry =>
+  const getEntry = (absolutePath: string) =>
     entries[absolutePath] ?? { _tag: "missing" };
 
   return FileSystem.layerNoop({

--- a/packages/scaffold/src/service/apply/ApplyService.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.ts
@@ -37,6 +37,11 @@ const MaterializedPlannedOutcomeAction = Schema.TaggedUnion({
   },
 });
 
+type WriteComposedAction = Extract<
+  typeof MaterializedPlannedOutcomeAction.Type,
+  { readonly _tag: "write-composed" }
+>;
+
 const PreparedApplyAction = Schema.TaggedUnion({
   skip: {
     path: Schema.String,
@@ -173,6 +178,35 @@ export class ApplyService extends Context.Service<ApplyService>()(
         },
       );
 
+      const loadComposedBaseContents = Effect.fn(
+        "ApplyService.loadComposedBaseContents",
+      )(function* ({
+        action,
+        repoRoot,
+      }: {
+        action: WriteComposedAction;
+        repoRoot: string;
+      }) {
+        const fullPath = path.join(repoRoot, action.path);
+        const existingContents =
+          action.writeMode === "modify"
+            ? yield* loadFileContents(fullPath)
+            : Option.none<string>();
+
+        if (Option.isSome(existingContents)) {
+          return existingContents.value;
+        }
+
+        if (action.seedContents !== undefined) {
+          return action.seedContents;
+        }
+
+        const fallbackContents = yield* loadFileContents(fullPath);
+        return Option.getOrElse(fallbackContents, () =>
+          action.path.endsWith(".json") ? "{}" : "",
+        );
+      });
+
       const prepare = Effect.fn("ApplyService.prepare")(function* ({
         action,
         repoRoot,
@@ -194,37 +228,11 @@ export class ApplyService extends Context.Service<ApplyService>()(
               },
             });
           case "write-composed": {
-            // Get base contents:
-            // For "modify" mode, always prefer the existing file so we don't
-            // overwrite fields added by prior apply runs. Fall back to
-            // seedContents (used for "create") or a sensible default.
-            let baseContents: string;
-            const existingContents =
-              action.writeMode === "modify"
-                ? yield* loadFileContents(path.join(repoRoot, action.path))
-                : Option.none<string>();
-
-            if (Option.isSome(existingContents)) {
-              baseContents = existingContents.value;
-            } else if (action.seedContents !== undefined) {
-              baseContents = action.seedContents;
-            } else {
-              const fallbackContents = yield* loadFileContents(
-                path.join(repoRoot, action.path),
-              );
-              if (Option.isNone(fallbackContents)) {
-                // No existing file and no seed - start with empty for JSON, fail for TS
-                if (action.path.endsWith(".json")) {
-                  baseContents = "{}";
-                } else {
-                  baseContents = "";
-                }
-              } else {
-                baseContents = fallbackContents.value;
-              }
-            }
-
-            // Apply composition operations
+            // NOTE: Modify composes from disk first so repeat applies preserve unrelated fields.
+            const baseContents = yield* loadComposedBaseContents({
+              action,
+              repoRoot,
+            });
             const composedContents = yield* compositionEngine.compose(
               action.path,
               baseContents,

--- a/packages/scaffold/src/service/apply/CompositionEngine.ts
+++ b/packages/scaffold/src/service/apply/CompositionEngine.ts
@@ -58,9 +58,9 @@ export class CompositionEngine extends Context.Service<CompositionEngine>()(
   );
 }
 
-const isJsonFile = (path: string): boolean => path.endsWith(".json");
+const isJsonFile = (path: string) => path.endsWith(".json");
 
-const isTypeScriptFile = (path: string): boolean =>
+const isTypeScriptFile = (path: string) =>
   path.endsWith(".ts") ||
   path.endsWith(".tsx") ||
   path.endsWith(".js") ||

--- a/packages/scaffold/src/service/apply/CompositionEngine.ts
+++ b/packages/scaffold/src/service/apply/CompositionEngine.ts
@@ -3,17 +3,7 @@ import { Array, Context, Effect, Layer } from "effect";
 import { JsonComposer } from "./JsonComposer";
 import { TypeScriptComposer } from "./TypeScriptComposer";
 
-// =============================================================================
-// Type Guards
-// =============================================================================
-
-/**
- * Check if an operation targets JSON files.
- *
- * Note: We use a simple field check instead of Schema.toTaggedUnion guards
- * because the guards only match the last schema member for each tag value,
- * not all members with the same tag.
- */
+// NOTE: Use fileType instead of Schema.toTaggedUnion guards; those only match the last member per tag value.
 const isJsonOp = (
   op: typeof CompositionOperation.Type,
 ): op is typeof CompositionOperation.cases.json.Type => op.fileType === "json";
@@ -22,10 +12,6 @@ const isTypeScriptOp = (
   op: typeof CompositionOperation.Type,
 ): op is typeof CompositionOperation.cases.typescript.Type =>
   op.fileType === "typescript";
-
-// =============================================================================
-// Service Definition
-// =============================================================================
 
 export class CompositionEngine extends Context.Service<CompositionEngine>()(
   "CompositionEngine",
@@ -46,14 +32,12 @@ export class CompositionEngine extends Context.Service<CompositionEngine>()(
 
           let result = contents;
 
-          // Filter and apply JSON operations if this is a JSON file
           const jsonOps = Array.filter(operations, isJsonOp);
 
           if (isJsonFile(path) && jsonOps.length > 0) {
             result = yield* jsonComposer.compose(result, jsonOps);
           }
 
-          // Filter and apply TypeScript operations if this is a TypeScript file
           const tsOps = Array.filter(operations, isTypeScriptOp);
 
           if (isTypeScriptFile(path) && tsOps.length > 0) {
@@ -73,10 +57,6 @@ export class CompositionEngine extends Context.Service<CompositionEngine>()(
     Layer.provide(TypeScriptComposer.layer),
   );
 }
-
-// =============================================================================
-// Helpers
-// =============================================================================
 
 const isJsonFile = (path: string): boolean => path.endsWith(".json");
 

--- a/packages/scaffold/src/service/apply/JsonComposer.ts
+++ b/packages/scaffold/src/service/apply/JsonComposer.ts
@@ -1,22 +1,9 @@
-import type {
-  CompositionOperation,
-  JsonPkgDepsOp,
-  JsonPkgExportsOp,
-  JsonPkgScriptsOp,
-} from "@repo/domain/Plan";
+import type { CompositionOperation } from "@repo/domain/Plan";
 import { Context, Effect, Layer, Match, Schema } from "effect";
-
-// =============================================================================
-// Schemas
-// =============================================================================
 
 const PackageJsonFromString = Schema.fromJsonString(
   Schema.Record(Schema.String, Schema.Unknown),
 );
-
-// =============================================================================
-// Service Definition
-// =============================================================================
 
 export class JsonComposer extends Context.Service<JsonComposer>()(
   "JsonComposer",
@@ -34,39 +21,8 @@ export class JsonComposer extends Context.Service<JsonComposer>()(
           const mutablePkg = { ...pkg } as Record<string, unknown>;
 
           yield* Effect.forEach(operations, (op) =>
-            Effect.gen(function* () {
-              Match.typeTags<typeof CompositionOperation.cases.json.Type>()({
-                "json-pkg-exports": (o) => {
-                  const exports = (mutablePkg["exports"] ?? {}) as Record<
-                    string,
-                    string
-                  >;
-                  for (const entry of o.entries) {
-                    exports[entry.name] = entry.value;
-                  }
-                  mutablePkg["exports"] = exports;
-                },
-                "json-pkg-deps": (o) => {
-                  const section = (mutablePkg[o.section] ?? {}) as Record<
-                    string,
-                    string
-                  >;
-                  for (const entry of o.entries) {
-                    section[entry.name] = entry.value;
-                  }
-                  mutablePkg[o.section] = section;
-                },
-                "json-pkg-scripts": (o) => {
-                  const scripts = (mutablePkg["scripts"] ?? {}) as Record<
-                    string,
-                    string
-                  >;
-                  for (const entry of o.entries) {
-                    scripts[entry.name] = entry.value;
-                  }
-                  mutablePkg["scripts"] = scripts;
-                },
-              })(op);
+            Effect.sync(() => {
+              applyJsonOperation(mutablePkg, op);
             }),
           );
 
@@ -79,3 +35,27 @@ export class JsonComposer extends Context.Service<JsonComposer>()(
 ) {
   static readonly layer = Layer.effect(JsonComposer)(JsonComposer.make);
 }
+
+const applyJsonOperation = (
+  pkg: Record<string, unknown>,
+  op: typeof CompositionOperation.cases.json.Type,
+): void =>
+  Match.typeTags<typeof CompositionOperation.cases.json.Type>()({
+    "json-pkg-exports": (o) =>
+      assignPackageJsonEntries(pkg, "exports", o.entries),
+    "json-pkg-deps": (o) => assignPackageJsonEntries(pkg, o.section, o.entries),
+    "json-pkg-scripts": (o) =>
+      assignPackageJsonEntries(pkg, "scripts", o.entries),
+  })(op);
+
+const assignPackageJsonEntries = (
+  pkg: Record<string, unknown>,
+  sectionName: string,
+  entries: ReadonlyArray<{ readonly name: string; readonly value: string }>,
+): void => {
+  const section = (pkg[sectionName] ?? {}) as Record<string, string>;
+  for (const entry of entries) {
+    section[entry.name] = entry.value;
+  }
+  pkg[sectionName] = section;
+};

--- a/packages/scaffold/src/service/apply/TypeScriptComposer.ts
+++ b/packages/scaffold/src/service/apply/TypeScriptComposer.ts
@@ -16,17 +16,18 @@ import {
   Option,
   pipe,
 } from "effect";
-import type { CallExpression, ImportDeclaration, SourceFile } from "ts-morph";
+import type {
+  CallExpression,
+  ImportDeclaration,
+  Node,
+  SourceFile,
+} from "ts-morph";
 import { Project, SyntaxKind } from "ts-morph";
 
 class TargetNotFoundError extends Data.TaggedError("TargetNotFoundError")<{
   targetVariable: string;
   functionName: string;
 }> {}
-
-// =============================================================================
-// Service Definition
-// =============================================================================
 
 export class TypeScriptComposer extends Context.Service<TypeScriptComposer>()(
   "TypeScriptComposer",
@@ -79,10 +80,6 @@ export class TypeScriptComposer extends Context.Service<TypeScriptComposer>()(
   );
 }
 
-// =============================================================================
-// Implementation Helpers
-// =============================================================================
-
 const applyTsAddImport = (
   sourceFile: SourceFile,
   op: typeof TsAddImportOp.Type,
@@ -120,13 +117,11 @@ const applyTsAddReexport = (
   sourceFile: SourceFile,
   op: typeof TsAddReexportOp.Type,
 ): void => {
-  // Check if re-export already exists
   const existingExport = sourceFile.getExportDeclaration(
     (decl) => decl.getModuleSpecifierValue() === op.moduleSpecifier,
   );
 
   if (existingExport) {
-    // If namedExports specified, add them to existing export
     if (op.namedExports) {
       const existingNamedExports = existingExport.getNamedExports();
       for (const namedExport of op.namedExports) {
@@ -141,7 +136,6 @@ const applyTsAddReexport = (
     return;
   }
 
-  // Add new export declaration
   if (op.namedExports && op.namedExports.length > 0) {
     sourceFile.addExportDeclaration({
       moduleSpecifier: op.moduleSpecifier,
@@ -149,7 +143,6 @@ const applyTsAddReexport = (
       isTypeOnly: op.typeOnly ?? false,
     });
   } else {
-    // Star export: export * from "..."
     sourceFile.addExportDeclaration({
       moduleSpecifier: op.moduleSpecifier,
       isTypeOnly: op.typeOnly ?? false,
@@ -166,7 +159,6 @@ const applyTsAddReexport = (
 const appendToCallOrArray = (call: CallExpression, argument: string): void => {
   const args = call.getArguments();
 
-  // If the only argument is an array literal, add inside it
   if (
     args.length === 1 &&
     args[0] !== undefined &&
@@ -182,96 +174,82 @@ const appendToCallOrArray = (call: CallExpression, argument: string): void => {
     return;
   }
 
-  // Otherwise add as a regular function argument
   const alreadyExists = args.some((arg) => arg.getText() === argument);
   if (!alreadyExists) {
     call.addArgument(argument);
   }
 };
 
+const getTargetInitializer = (sourceFile: SourceFile, targetVariable: string) =>
+  pipe(
+    Option.fromNullishOr(sourceFile.getVariableDeclaration(targetVariable)),
+    Option.flatMap((declaration) =>
+      Option.fromNullishOr(declaration.getInitializer()),
+    ),
+  );
+
+const isMatchingFunctionCall = (
+  call: CallExpression,
+  functionName: string,
+): boolean => {
+  const expression = call.getExpression();
+
+  if (expression.isKind(SyntaxKind.PropertyAccessExpression)) {
+    return expression.getText() === functionName;
+  }
+
+  if (expression.isKind(SyntaxKind.Identifier)) {
+    const name = expression.getText();
+    return name === functionName || functionName.endsWith(`.${name}`);
+  }
+
+  return false;
+};
+
+const findCallExpression = (
+  initializer: Node,
+  functionName: string,
+): CallExpression | undefined => {
+  if (
+    initializer.isKind(SyntaxKind.CallExpression) &&
+    isMatchingFunctionCall(initializer, functionName)
+  ) {
+    return initializer;
+  }
+
+  return initializer
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .find((call) => isMatchingFunctionCall(call, functionName));
+};
+
+const toOuterCurriedCall = (call: CallExpression): CallExpression => {
+  const parent = call.getParent();
+  if (
+    parent?.isKind(SyntaxKind.CallExpression) &&
+    parent.getExpression() === call
+  ) {
+    // NOTE: Curried calls carry the composition argument on the outer call.
+    return parent;
+  }
+  return call;
+};
+
 const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
   sourceFile: SourceFile,
   op: typeof TsAppendCallArgOp.Type,
 ) {
-  // Find variable declaration with the target name
-  const variableDeclaration = sourceFile.getVariableDeclaration(
-    op.targetVariable,
-  );
-
-  if (!variableDeclaration) {
+  const initializer = getTargetInitializer(sourceFile, op.targetVariable);
+  if (Option.isNone(initializer)) {
     return yield* new TargetNotFoundError({
       targetVariable: op.targetVariable,
       functionName: op.functionName,
     });
   }
 
-  const initializer = variableDeclaration.getInitializer();
-  if (!initializer) {
-    return yield* new TargetNotFoundError({
-      targetVariable: op.targetVariable,
-      functionName: op.functionName,
-    });
-  }
-
-  // Helper to check if a call expression matches the function name
-  const isMatchingCall = (call: CallExpression): boolean => {
-    const expression = call.getExpression();
-
-    // Check for property access (e.g., Layer.mergeAll)
-    if (expression.isKind(SyntaxKind.PropertyAccessExpression)) {
-      const fullText = expression.getText();
-      if (fullText === op.functionName) {
-        return true;
-      }
-    }
-
-    // Check for identifier (e.g., mergeAll)
-    if (expression.isKind(SyntaxKind.Identifier)) {
-      const name = expression.getText();
-      // Match if function name is just the identifier or ends with it
-      if (name === op.functionName || op.functionName.endsWith(`.${name}`)) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  // First check if initializer itself is the call expression
-  if (initializer.isKind(SyntaxKind.CallExpression)) {
-    if (isMatchingCall(initializer)) {
-      // Check if this is a curried call: the matching call might be the callee
-      // of an outer call expression (e.g., Subscription.aggregate<M, Msg>()())
-      const parent = initializer.getParent();
-      if (parent && parent.isKind(SyntaxKind.CallExpression)) {
-        appendToCallOrArray(parent, op.argument);
-      } else {
-        appendToCallOrArray(initializer, op.argument);
-      }
-      return;
-    }
-  }
-
-  // Search descendants for the call
-  const callExpressions = initializer.getDescendantsOfKind(
-    SyntaxKind.CallExpression,
-  );
-
-  for (const call of callExpressions) {
-    if (isMatchingCall(call)) {
-      // Check if the matching call is the callee of a parent call (curried pattern)
-      const parent = call.getParent();
-      if (parent && parent.isKind(SyntaxKind.CallExpression)) {
-        const parentCall = parent as CallExpression;
-        // Verify the parent's expression is our matching call
-        if (parentCall.getExpression() === call) {
-          appendToCallOrArray(parentCall, op.argument);
-          return;
-        }
-      }
-      appendToCallOrArray(call, op.argument);
-      return;
-    }
+  const call = findCallExpression(initializer.value, op.functionName);
+  if (call) {
+    appendToCallOrArray(toOuterCurriedCall(call), op.argument);
+    return;
   }
 
   return yield* new TargetNotFoundError({
@@ -280,54 +258,20 @@ const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
   });
 });
 
-// =============================================================================
-// Object Field Injection
-// =============================================================================
-
 const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
   sourceFile: SourceFile,
   op: typeof TsObjectFieldOp.Type,
 ) {
-  // Find variable declaration with the target name
-  const variableDeclaration = sourceFile.getVariableDeclaration(
-    op.targetVariable,
-  );
-
-  if (!variableDeclaration) {
+  const initializer = getTargetInitializer(sourceFile, op.targetVariable);
+  if (Option.isNone(initializer)) {
     return yield* new TargetNotFoundError({
       targetVariable: op.targetVariable,
       functionName: op.functionName,
     });
   }
-
-  const initializer = variableDeclaration.getInitializer();
-  if (!initializer) {
-    return yield* new TargetNotFoundError({
-      targetVariable: op.targetVariable,
-      functionName: op.functionName,
-    });
-  }
-
-  // Helper to check if a call expression matches the function name
-  const isMatchingCall = (call: CallExpression): boolean => {
-    const expression = call.getExpression();
-
-    if (expression.isKind(SyntaxKind.PropertyAccessExpression)) {
-      if (expression.getText() === op.functionName) return true;
-    }
-
-    if (expression.isKind(SyntaxKind.Identifier)) {
-      const name = expression.getText();
-      if (name === op.functionName || op.functionName.endsWith(`.${name}`))
-        return true;
-    }
-
-    return false;
-  };
 
   const addFieldToCall = (call: CallExpression): boolean => {
     const args = call.getArguments();
-    // Find the first object literal argument
     const objectArg = args.find((arg) =>
       arg.isKind(SyntaxKind.ObjectLiteralExpression),
     );
@@ -338,11 +282,9 @@ const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
       SyntaxKind.ObjectLiteralExpression,
     );
 
-    // Check if field already exists
     const existingProp = objectLiteral.getProperty(op.field);
     if (existingProp) return true;
 
-    // Add the new property
     objectLiteral.addPropertyAssignment({
       name: op.field,
       initializer: op.value,
@@ -350,18 +292,9 @@ const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
     return true;
   };
 
-  // First check if initializer itself is the call expression
-  if (initializer.isKind(SyntaxKind.CallExpression)) {
-    if (isMatchingCall(initializer) && addFieldToCall(initializer)) return;
-  }
-
-  // Search descendants for the call
-  const callExpressions = initializer.getDescendantsOfKind(
-    SyntaxKind.CallExpression,
-  );
-
-  for (const call of callExpressions) {
-    if (isMatchingCall(call) && addFieldToCall(call)) return;
+  const call = findCallExpression(initializer.value, op.functionName);
+  if (call && addFieldToCall(call)) {
+    return;
   }
 
   return yield* new TargetNotFoundError({
@@ -369,10 +302,6 @@ const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
     functionName: op.functionName,
   });
 });
-
-// =============================================================================
-// JSX Slot Injection
-// =============================================================================
 
 const applyTsJsxSlot = (
   sourceFile: SourceFile,
@@ -384,7 +313,6 @@ const applyTsJsxSlot = (
 
   if (index === -1) return;
 
-  // Insert content after the slot marker (on the next line)
   const insertPos = index + slotMarker.length;
   const newText = `${text.slice(0, insertPos)}\n        ${op.content}${text.slice(insertPos)}`;
   sourceFile.replaceWithText(newText);

--- a/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
@@ -293,7 +293,7 @@ describe("BlueprintService", () => {
               ],
             });
 
-            // Server requires server-http-api which requires domain-api-contracts on packages/domain
+            // NOTE: This fixture checks the transitive module requirement chain.
             expect(
               blueprint.nodes
                 .filter((node) => node._tag === "target")

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -245,8 +245,7 @@ const resolveSelection = Effect.fn("BlueprintService.resolveSelection")(
                   ? target
                   : dep.target;
 
-              // Requiring a module implicitly requires the target to exist,
-              // so we create both a required-target edge and a required-module edge
+              // NOTE: Required modules emit both target and module edges so graph consumers can see the full closure.
               const requiredTarget = yield* ensureTarget(dependencyTarget);
 
               yield* appendEdge(stateRef, {

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -302,7 +302,7 @@ const resolveSelection = Effect.fn("BlueprintService.resolveSelection")(
 const appendEdge = (
   stateRef: Ref.Ref<ResolutionState>,
   edge: (typeof Blueprint.fields.edges.Type)[0],
-): Effect.Effect<void> =>
+) =>
   Ref.update(stateRef, (s) =>
     HashMap.has(s.edges, edge.id)
       ? s

--- a/packages/scaffold/src/service/finalize/FinalizeService.test.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.test.ts
@@ -34,9 +34,7 @@ const nodeConfig = new StackConfig({
   runtime: { _tag: "node", packageManager: "pnpm" },
 });
 
-const makeConfig = (
-  config: typeof StackConfig.Type = bunConfig,
-): FinalizeConfig => ({
+const makeConfig = (config: typeof StackConfig.Type = bunConfig) => ({
   config,
   repoRoot: "/repo",
 });

--- a/packages/scaffold/src/service/finalize/FinalizeService.test.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.test.ts
@@ -14,10 +14,6 @@ import { Effect, Layer, Result, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import { type FinalizeConfig, FinalizeService } from "./FinalizeService";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const serverIdentity = new TargetIdentity({
   kind: TargetKind.make("server"),
   name: "api",
@@ -77,7 +73,6 @@ const targetWithModule = (
     ],
   });
 
-// Stub catalog that returns definitions with configurable scripts
 const makeCatalogLayer = (
   targets: Record<string, Partial<typeof TargetDefinition.Type>> = {},
   modules: Record<string, Partial<typeof ModuleDefinition.Type>> = {},
@@ -124,11 +119,11 @@ const makeCatalogLayer = (
     }),
   } as never);
 
-// Stub spawner that records commands and can simulate failures
 const makeSpawnerLayer = (
   executed: string[],
   failures: Set<string> = new Set(),
 ) =>
+  // NOTE: The fake spawner records the exact shell command and can fail selected commands.
   Layer.succeed(ChildProcessSpawner, {
     spawn: (command: { command: string; args: ReadonlyArray<string> }) => {
       const cmd = [command.command, ...command.args].join(" ");
@@ -166,7 +161,6 @@ const makeFinalizeLayer = (
     Layer.provide(makeSpawnerLayer(executed, opts.failures)),
   );
 
-/** Helper: drives all script executions and builds a FinalizeReport */
 const runToReport = (
   svc: typeof FinalizeService.Service,
   blueprint: typeof Blueprint.Type,
@@ -188,10 +182,6 @@ const runToReport = (
     );
     return new FinalizeReport({ results });
   });
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe("FinalizeService", () => {
   describe("preview", () => {
@@ -371,7 +361,7 @@ describe("FinalizeService", () => {
           makeConfig(config),
         );
 
-        // Both install and lint should execute even if install fails
+        // NOTE: Finalize reports failures after attempting every configured script.
         expect(report.results).toHaveLength(2);
         expect(report.results[0]?._tag).toBe("Failure");
         expect(report.results[1]?._tag).toBe("Success");

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -1,6 +1,6 @@
 import { CatalogService } from "@repo/catalog";
 import { type Blueprint, BlueprintNode } from "@repo/domain/Blueprint";
-import type { ScriptDefinition } from "@repo/domain/Catalog";
+import { type TargetIdentity, TargetKey } from "@repo/domain/Catalog";
 import { type ScriptResult } from "@repo/domain/Finalize";
 import {
   ContributionTokenContext,
@@ -50,14 +50,9 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
           BlueprintNode.guards.target,
         );
 
-        // Collect finalize scripts from targets
         const targetScripts = yield* Effect.forEach(targetNodes, (node) =>
           Effect.map(catalog.getTarget(node.identity.kind), ({ scripts }) => {
-            const context = new ContributionTokenContext({
-              targetKey: node.id,
-              identity: node.identity,
-              config: config.config,
-            });
+            const context = createTokenContext(config, node.id, node.identity);
             return Arr.map(scripts ?? [], (s) => ({
               label: s.label,
               command: context.resolve(s.command),
@@ -68,7 +63,6 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
           }),
         ).pipe(Effect.map(Arr.flatten));
 
-        // Collect finalize scripts from modules (blueprint preserves dependency order)
         const moduleScripts = yield* Effect.forEach(moduleNodes, (moduleNode) =>
           Effect.gen(function* () {
             const targetNode = Arr.findFirst(
@@ -78,11 +72,11 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
             if (Option.isNone(targetNode)) return [];
 
             const definition = yield* catalog.getModule(moduleNode.moduleId);
-            const context = new ContributionTokenContext({
-              targetKey: moduleNode.targetId,
-              identity: targetNode.value.identity,
-              config: config.config,
-            });
+            const context = createTokenContext(
+              config,
+              moduleNode.targetId,
+              targetNode.value.identity,
+            );
             return Arr.map(definition.scripts ?? [], (s) => ({
               label: s.label,
               command: context.resolve(s.command),
@@ -152,42 +146,37 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
             BlueprintNode.guards.target,
           );
 
-          const steps: string[] = [];
+          const targetSteps = yield* Effect.forEach(targetNodes, (node) =>
+            Effect.map(catalog.getTarget(node.identity.kind), (definition) =>
+              resolveNextSteps(
+                definition.nextSteps,
+                createTokenContext(config, node.id, node.identity),
+              ),
+            ),
+          ).pipe(Effect.map(Arr.flatten));
 
-          // Collect target-level next steps
-          for (const node of targetNodes) {
-            const definition = yield* catalog.getTarget(node.identity.kind);
-            const context = new ContributionTokenContext({
-              targetKey: node.id,
-              identity: node.identity,
-              config: config.config,
-            });
-            for (const step of definition.nextSteps ?? []) {
-              steps.push(context.resolve(step));
-            }
-          }
+          const moduleSteps = yield* Effect.forEach(moduleNodes, (moduleNode) =>
+            Effect.gen(function* () {
+              const targetNode = Arr.findFirst(
+                targetNodes,
+                (t) => t.id === moduleNode.targetId,
+              );
+              if (Option.isNone(targetNode)) return [];
 
-          // Collect module-level next steps (dependency order from blueprint)
-          for (const moduleNode of moduleNodes) {
-            const targetNode = Arr.findFirst(
-              targetNodes,
-              (t) => t.id === moduleNode.targetId,
-            );
-            if (Option.isNone(targetNode)) continue;
+              const definition = yield* catalog.getModule(moduleNode.moduleId);
+              return resolveNextSteps(
+                definition.nextSteps,
+                createTokenContext(
+                  config,
+                  moduleNode.targetId,
+                  targetNode.value.identity,
+                ),
+              );
+            }),
+          ).pipe(Effect.map(Arr.flatten));
 
-            const definition = yield* catalog.getModule(moduleNode.moduleId);
-            const context = new ContributionTokenContext({
-              targetKey: moduleNode.targetId,
-              identity: targetNode.value.identity,
-              config: config.config,
-            });
-            for (const step of definition.nextSteps ?? []) {
-              steps.push(context.resolve(step));
-            }
-          }
-
-          // Deduplicate by exact string match, preserving order
-          return [...new Set(steps)];
+          // NOTE: Exact next-step text is the stable identity; preserve the first occurrence.
+          return [...new Set([...targetSteps, ...moduleSteps])];
         },
       );
 
@@ -199,6 +188,22 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
     FinalizeService.make,
   ).pipe(Layer.provide(CatalogService.layer));
 }
+
+const createTokenContext = (
+  config: FinalizeConfig,
+  targetKey: typeof TargetKey.Type,
+  identity: TargetIdentity,
+) =>
+  new ContributionTokenContext({
+    targetKey,
+    identity,
+    config: config.config,
+  });
+
+const resolveNextSteps = (
+  steps: ReadonlyArray<string> | undefined,
+  context: ContributionTokenContext,
+) => Arr.map(steps ?? [], (step) => context.resolve(step));
 
 /**
  * Orders scripts so that finalize-phase module/target scripts run first,

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -1,6 +1,5 @@
 import { CatalogService } from "@repo/catalog";
 import { type Blueprint, BlueprintNode } from "@repo/domain/Blueprint";
-import { type TargetIdentity, TargetKey } from "@repo/domain/Catalog";
 import { type ScriptResult } from "@repo/domain/Finalize";
 import {
   ContributionTokenContext,
@@ -52,7 +51,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
 
         const targetScripts = yield* Effect.forEach(targetNodes, (node) =>
           Effect.map(catalog.getTarget(node.identity.kind), ({ scripts }) => {
-            const context = createTokenContext(config, node.id, node.identity);
+            const context = createTokenContext(config, node);
             return Arr.map(scripts ?? [], (s) => ({
               label: s.label,
               command: context.resolve(s.command),
@@ -72,11 +71,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
             if (Option.isNone(targetNode)) return [];
 
             const definition = yield* catalog.getModule(moduleNode.moduleId);
-            const context = createTokenContext(
-              config,
-              moduleNode.targetId,
-              targetNode.value.identity,
-            );
+            const context = createTokenContext(config, targetNode.value);
             return Arr.map(definition.scripts ?? [], (s) => ({
               label: s.label,
               command: context.resolve(s.command),
@@ -150,7 +145,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
             Effect.map(catalog.getTarget(node.identity.kind), (definition) =>
               resolveNextSteps(
                 definition.nextSteps,
-                createTokenContext(config, node.id, node.identity),
+                createTokenContext(config, node),
               ),
             ),
           ).pipe(Effect.map(Arr.flatten));
@@ -166,11 +161,7 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
               const definition = yield* catalog.getModule(moduleNode.moduleId);
               return resolveNextSteps(
                 definition.nextSteps,
-                createTokenContext(
-                  config,
-                  moduleNode.targetId,
-                  targetNode.value.identity,
-                ),
+                createTokenContext(config, targetNode.value),
               );
             }),
           ).pipe(Effect.map(Arr.flatten));
@@ -191,12 +182,11 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
 
 const createTokenContext = (
   config: FinalizeConfig,
-  targetKey: typeof TargetKey.Type,
-  identity: TargetIdentity,
+  target: typeof BlueprintNode.cases.target.Type,
 ) =>
   new ContributionTokenContext({
-    targetKey,
-    identity,
+    targetKey: target.id,
+    identity: target.identity,
     config: config.config,
   });
 

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -203,7 +203,7 @@ const resolveNextSteps = (
 const orderScripts = (
   resolvedScripts: ResolvedScript[],
   configScripts: ResolvedScript[],
-): ResolvedScript[] => {
+) => {
   const finalize = resolvedScripts.filter((s) => s.phase === "finalize");
   const postFinalize = resolvedScripts.filter(
     (s) => s.phase === "post-finalize",

--- a/packages/scaffold/src/service/plan/PlanAssessor.ts
+++ b/packages/scaffold/src/service/plan/PlanAssessor.ts
@@ -153,15 +153,11 @@ function toPlannedFileOutcome({
   );
 }
 
-/**
- * Convert planning path structural data into composition operations
- */
 function toCompositionOperations(
   planningPath: PlanningIntentPath,
 ): Array<typeof CompositionOperation.Type> {
   const operations: Array<typeof CompositionOperation.Type> = [];
 
-  // Package.json exports -> json-pkg-exports
   if (planningPath.exports.length > 0) {
     operations.push({
       _tag: "json-pkg-exports",
@@ -170,7 +166,6 @@ function toCompositionOperations(
     });
   }
 
-  // Package.json dependencies -> json-pkg-deps (grouped by section)
   const depsBySection = Arr.groupBy(
     planningPath.dependencies,
     (d) => d.section,
@@ -184,7 +179,6 @@ function toCompositionOperations(
     });
   }
 
-  // Package.json scripts -> json-pkg-scripts
   if (planningPath.scripts.length > 0) {
     operations.push({
       _tag: "json-pkg-scripts",
@@ -193,7 +187,6 @@ function toCompositionOperations(
     });
   }
 
-  // Barrel exports -> ts-add-reexport
   for (const { exportPath } of planningPath.barrelExports) {
     operations.push({
       _tag: "ts-add-reexport",
@@ -202,9 +195,7 @@ function toCompositionOperations(
     });
   }
 
-  // Compositions -> ts-add-import + ts-append-call-arg
   for (const composition of planningPath.compositions) {
-    // Add import for the composed argument
     operations.push({
       _tag: "ts-add-import",
       fileType: "typescript",
@@ -214,7 +205,6 @@ function toCompositionOperations(
       namespaceImport: composition.import.namespaceImport,
     });
 
-    // Append argument to the function call
     operations.push({
       _tag: "ts-append-call-arg",
       fileType: "typescript",
@@ -224,7 +214,6 @@ function toCompositionOperations(
     });
   }
 
-  // Object fields -> ts-add-import (optional) + ts-object-field
   for (const objectField of planningPath.objectFields) {
     if (objectField.import) {
       operations.push({
@@ -247,7 +236,6 @@ function toCompositionOperations(
     });
   }
 
-  // JSX slots -> ts-add-import (optional) + ts-jsx-slot
   for (const jsxSlot of planningPath.jsxSlots) {
     if (jsxSlot.import) {
       operations.push({
@@ -296,17 +284,16 @@ function assessPlanningPath({
     hasTsconfig,
     hasCompositions,
   }).pipe(
-    // Combined cases first (authoritative + something else)
+    // NOTE: Authoritative content paired with merge operations is planned before pure merge families.
     Match.when({ hasContents: true, hasBarrelExports: true }, () =>
-      planAuthoritativeBarrelMerge(planningPath, snapshotPath),
+      assessBarrelMerge(planningPath, snapshotPath),
     ),
     Match.when({ hasContents: true, hasCompositions: true }, () =>
-      planAuthoritativeCompositionMerge(planningPath, snapshotPath),
+      assessCompositionMerge(planningPath, snapshotPath),
     ),
     Match.when({ hasContents: true, hasPackageJsonFields: true }, () =>
-      planAuthoritativePackageJsonMerge(planningPath, snapshotPath),
+      assessPackageJsonMerge(planningPath, snapshotPath),
     ),
-    // Pure single-family cases
     Match.when({ hasContents: true }, () =>
       assessAuthoritativeContents(planningPath, snapshotPath),
     ),
@@ -337,8 +324,6 @@ export function collectAncestorPaths(path: string): ReadonlyArray<string> {
     Arr.join(Arr.take(parts, index + 1), "/"),
   );
 }
-
-// --- Internal helpers ---
 
 type SnapshotPath = typeof RepoSnapshot.fields.paths.value.Type | undefined;
 
@@ -401,12 +386,7 @@ const planPackageJsonMerge = (
   planningPath: PlanningIntentPath,
   snapshotPath: SnapshotPath,
 ) => {
-  const {
-    path,
-    exports: requiredExports,
-    dependencies: requiredDependencies,
-    scripts: requiredScripts,
-  } = planningPath;
+  const { path } = planningPath;
   const existingContents = getExistingFileContents(path, snapshotPath);
 
   if (existingContents === undefined) {
@@ -422,46 +402,10 @@ const planPackageJsonMerge = (
     });
   }
 
-  const dependenciesBySection = Arr.groupBy(
-    requiredDependencies,
-    (plannedDependency) => plannedDependency.section,
-  );
-  const exportAssessment = assessFlatStringRecordEntries({
-    existingValue: packageJson["exports"],
-    requiredEntries: requiredExports,
-    keyOf: (plannedExport) => plannedExport.name,
-    valueOf: (plannedExport) => plannedExport.value,
-    toConflict: (plannedExport) =>
-      planConflict.exports(path, plannedExport.name),
+  const { conflicts, hasAdditions } = assessPackageJsonEntries({
+    packageJson,
+    planningPath,
   });
-  const dependencyAssessments = Record.collect(
-    dependenciesBySection,
-    (section, sectionDependencies) =>
-      assessFlatStringRecordEntries({
-        existingValue: packageJson[section],
-        requiredEntries: sectionDependencies,
-        keyOf: (plannedDependency) => plannedDependency.name,
-        valueOf: (plannedDependency) => plannedDependency.value,
-        toConflict: (plannedDependency) =>
-          planConflict.dependencies(path, plannedDependency),
-      }),
-  );
-  const scriptAssessment = assessFlatStringRecordEntries({
-    existingValue: packageJson["scripts"],
-    requiredEntries: requiredScripts,
-    keyOf: (script) => script.name,
-    valueOf: (script) => script.value,
-    toConflict: (script) => planConflict.scripts(path, script.name),
-  });
-  const conflicts = [
-    ...exportAssessment.conflicts,
-    ...Arr.flatMap(dependencyAssessments, (assessment) => assessment.conflicts),
-    ...scriptAssessment.conflicts,
-  ];
-  const hasAdditions =
-    exportAssessment.hasAdditions ||
-    Arr.some(dependencyAssessments, (assessment) => assessment.hasAdditions) ||
-    scriptAssessment.hasAdditions;
 
   if (conflicts.length > 0) {
     return createPathAssessment({
@@ -524,7 +468,6 @@ const planCompositionMerge = (
     snapshotPath,
   );
 
-  // Compositions require an existing file with composition points
   if (existingContents === undefined) {
     return createPathAssessment({
       classification: "conflict",
@@ -538,7 +481,7 @@ const planCompositionMerge = (
     });
   }
 
-  // File exists - mark as modify, actual target validation happens at apply time
+  // NOTE: Apply validates the concrete TypeScript composition target with ts-morph.
   return createPathAssessment({ classification: "modify" });
 };
 
@@ -546,7 +489,7 @@ const planCompositionMerge = (
  * Plan authoritative barrel merge: seed content + barrel exports.
  * Creates file with authoritative content, then appends barrel exports.
  */
-const planAuthoritativeBarrelMerge = (
+const assessBarrelMerge = (
   planningPath: PlanningIntentPath,
   snapshotPath: SnapshotPath,
 ): PathAssessment => {
@@ -556,15 +499,12 @@ const planAuthoritativeBarrelMerge = (
   );
   const requiredContents = planningPath.contents!;
 
-  // File doesn't exist - create with authoritative content + barrel exports
   if (existingContents === undefined) {
     return createPathAssessment({ classification: "create" });
   }
 
-  // File exists - check if authoritative content matches and parse for barrel exports
   const existingExports = parseSimpleBarrelExports(existingContents);
 
-  // If we can parse the existing barrel exports, check for new additions
   if (existingExports !== undefined) {
     const existingExportsSet = new Set(existingExports);
     const hasBarrelAdditions = Arr.some(
@@ -572,7 +512,6 @@ const planAuthoritativeBarrelMerge = (
       (plannedReExport) => !existingExportsSet.has(plannedReExport.exportPath),
     );
 
-    // Check if the authoritative export is present
     const authoritativeExportMatch = requiredContents.match(
       simpleBarrelExportPattern,
     );
@@ -588,7 +527,6 @@ const planAuthoritativeBarrelMerge = (
     return createPathAssessment({ classification: "modify" });
   }
 
-  // Can't parse as barrel - conflict on barrel exports
   const conflicts = Arr.map(planningPath.barrelExports, (plannedReExport) =>
     planConflict.barrelExport(planningPath.path, plannedReExport.exportPath),
   );
@@ -603,7 +541,7 @@ const planAuthoritativeBarrelMerge = (
  * Plan authoritative composition merge: seed content + compositions.
  * Creates file with authoritative content, then applies composition operations.
  */
-const planAuthoritativeCompositionMerge = (
+const assessCompositionMerge = (
   planningPath: PlanningIntentPath,
   snapshotPath: SnapshotPath,
 ): PathAssessment => {
@@ -611,20 +549,11 @@ const planAuthoritativeCompositionMerge = (
     planningPath.path,
     snapshotPath,
   );
-  const requiredContents = planningPath.contents!;
 
-  // File doesn't exist - create with authoritative content + compositions
   if (existingContents === undefined) {
     return createPathAssessment({ classification: "create" });
   }
 
-  // File exists - always mark as modify since we need to apply compositions
-  // The authoritative content check could differ, but compositions still need applying
-  if (existingContents !== requiredContents) {
-    return createPathAssessment({ classification: "modify" });
-  }
-
-  // Contents match but we have compositions to apply
   return createPathAssessment({ classification: "modify" });
 };
 
@@ -633,26 +562,19 @@ const planAuthoritativeCompositionMerge = (
  * Creates file with authoritative content, then applies package.json field operations.
  * Detects conflicts when existing package.json has conflicting entries.
  */
-const planAuthoritativePackageJsonMerge = (
+const assessPackageJsonMerge = (
   planningPath: PlanningIntentPath,
   snapshotPath: SnapshotPath,
 ): PathAssessment => {
-  const {
-    path,
-    exports: requiredExports,
-    dependencies: requiredDependencies,
-    scripts: requiredScripts,
-  } = planningPath;
+  const { path } = planningPath;
   const existingContents = getExistingFileContents(path, snapshotPath);
 
-  // File doesn't exist - create with authoritative content + package.json fields
   if (existingContents === undefined) {
     return createPathAssessment({ classification: "create" });
   }
 
   const packageJson = parseJsonRecord(existingContents);
 
-  // Can't parse as JSON - conflict on all planned entries
   if (packageJson === undefined) {
     return createPathAssessment({
       classification: "conflict",
@@ -660,47 +582,10 @@ const planAuthoritativePackageJsonMerge = (
     });
   }
 
-  // Assess each package.json field for conflicts
-  const dependenciesBySection = Arr.groupBy(
-    requiredDependencies,
-    (plannedDependency) => plannedDependency.section,
-  );
-  const exportAssessment = assessFlatStringRecordEntries({
-    existingValue: packageJson["exports"],
-    requiredEntries: requiredExports,
-    keyOf: (plannedExport) => plannedExport.name,
-    valueOf: (plannedExport) => plannedExport.value,
-    toConflict: (plannedExport) =>
-      planConflict.exports(path, plannedExport.name),
+  const { conflicts, hasAdditions } = assessPackageJsonEntries({
+    packageJson,
+    planningPath,
   });
-  const dependencyAssessments = Record.collect(
-    dependenciesBySection,
-    (section, sectionDependencies) =>
-      assessFlatStringRecordEntries({
-        existingValue: packageJson[section],
-        requiredEntries: sectionDependencies,
-        keyOf: (plannedDependency) => plannedDependency.name,
-        valueOf: (plannedDependency) => plannedDependency.value,
-        toConflict: (plannedDependency) =>
-          planConflict.dependencies(path, plannedDependency),
-      }),
-  );
-  const scriptAssessment = assessFlatStringRecordEntries({
-    existingValue: packageJson["scripts"],
-    requiredEntries: requiredScripts,
-    keyOf: (script) => script.name,
-    valueOf: (script) => script.value,
-    toConflict: (script) => planConflict.scripts(path, script.name),
-  });
-  const conflicts = [
-    ...exportAssessment.conflicts,
-    ...Arr.flatMap(dependencyAssessments, (assessment) => assessment.conflicts),
-    ...scriptAssessment.conflicts,
-  ];
-  const hasFieldAdditions =
-    exportAssessment.hasAdditions ||
-    Arr.some(dependencyAssessments, (assessment) => assessment.hasAdditions) ||
-    scriptAssessment.hasAdditions;
 
   if (conflicts.length > 0) {
     return createPathAssessment({
@@ -709,13 +594,10 @@ const planAuthoritativePackageJsonMerge = (
     });
   }
 
-  // Check if authoritative content differs from existing
   const requiredContents = planningPath.contents!;
   const authoritativeContentMatches = existingContents === requiredContents;
 
-  // If authoritative content matches and no field additions, unchanged
-  // Otherwise, we need to modify (either content differs or fields need adding)
-  if (authoritativeContentMatches && !hasFieldAdditions) {
+  if (authoritativeContentMatches && !hasAdditions) {
     return createPathAssessment({ classification: "unchanged" });
   }
 
@@ -775,6 +657,65 @@ const collectInvalidPackageJsonConflicts = (
     ...Arr.map(requiredDependencies, (d) => planConflict.dependencies(path, d)),
     ...Arr.map(requiredScripts, (s) => planConflict.scripts(path, s.name)),
   ];
+};
+
+const assessPackageJsonEntries = ({
+  packageJson,
+  planningPath,
+}: {
+  packageJson: Record<string, unknown>;
+  planningPath: PlanningIntentPath;
+}): FlatStringRecordAssessment<typeof PlanConflict.Type> => {
+  const { path } = planningPath;
+  const dependenciesBySection = Arr.groupBy(
+    planningPath.dependencies,
+    (plannedDependency) => plannedDependency.section,
+  );
+  const exportAssessment = assessFlatStringRecordEntries({
+    existingValue: packageJson["exports"],
+    requiredEntries: planningPath.exports,
+    keyOf: (plannedExport) => plannedExport.name,
+    valueOf: (plannedExport) => plannedExport.value,
+    toConflict: (plannedExport) =>
+      planConflict.exports(path, plannedExport.name),
+  });
+  const dependencyAssessments = Record.collect(
+    dependenciesBySection,
+    (section, sectionDependencies) =>
+      assessFlatStringRecordEntries({
+        existingValue: packageJson[section],
+        requiredEntries: sectionDependencies,
+        keyOf: (plannedDependency) => plannedDependency.name,
+        valueOf: (plannedDependency) => plannedDependency.value,
+        toConflict: (plannedDependency) =>
+          planConflict.dependencies(path, plannedDependency),
+      }),
+  );
+  const scriptAssessment = assessFlatStringRecordEntries({
+    existingValue: packageJson["scripts"],
+    requiredEntries: planningPath.scripts,
+    keyOf: (script) => script.name,
+    valueOf: (script) => script.value,
+    toConflict: (script) => planConflict.scripts(path, script.name),
+  });
+
+  return {
+    conflicts: [
+      ...exportAssessment.conflicts,
+      ...Arr.flatMap(
+        dependencyAssessments,
+        (assessment) => assessment.conflicts,
+      ),
+      ...scriptAssessment.conflicts,
+    ],
+    hasAdditions:
+      exportAssessment.hasAdditions ||
+      Arr.some(
+        dependencyAssessments,
+        (assessment) => assessment.hasAdditions,
+      ) ||
+      scriptAssessment.hasAdditions,
+  };
 };
 
 const assessFlatStringRecordEntries = <Entry, Conflict>({

--- a/packages/scaffold/src/service/plan/PlanRenderer.ts
+++ b/packages/scaffold/src/service/plan/PlanRenderer.ts
@@ -5,10 +5,6 @@ import {
 } from "@repo/domain/Plan";
 import { Array, Effect, Match, pipe } from "effect";
 
-// =============================================================================
-// Types
-// =============================================================================
-
 /**
  * A file outcome fully resolved for LLM consumption.
  *
@@ -47,10 +43,6 @@ export interface LlmPlanOutput {
     readonly command: string;
   }>;
 }
-
-// =============================================================================
-// Operation → Instruction Rendering
-// =============================================================================
 
 const renderOperation = (
   path: string,
@@ -101,10 +93,6 @@ const renderOperation = (
     Match.exhaustive,
   );
 
-// =============================================================================
-// Conflict Rendering
-// =============================================================================
-
 const renderConflict = (
   conflict: typeof PlanConflict.Type,
 ): { path: string; kind: string; description: string } =>
@@ -146,10 +134,6 @@ const renderConflict = (
     })),
     Match.exhaustive,
   );
-
-// =============================================================================
-// Plan Renderer
-// =============================================================================
 
 /**
  * Render a Plan into LLM-consumable output.

--- a/packages/scaffold/src/service/plan/PlanService.test.ts
+++ b/packages/scaffold/src/service/plan/PlanService.test.ts
@@ -251,8 +251,7 @@ describe("PlanService", () => {
   });
 
   describe("when planning compositions", () => {
-    // Simple blueprint that just has server-chat-rpc module without the full AI dependency chain
-    // This tests that composition contributions produce the correct operations
+    // NOTE: This fixture isolates server-chat-rpc so composition operations are the only behavior under test.
     const makeChatServerOnlyBlueprint = () =>
       new Blueprint({
         nodes: [
@@ -296,7 +295,6 @@ const HttpRpcRouter = Layer.empty;
             load: ({ paths }) =>
               Effect.succeed({
                 paths: paths.map((path) => {
-                  // Server index exists (for composition target)
                   if (path === "apps/server-api/src/index.ts") {
                     return {
                       _tag: "file" as const,
@@ -309,7 +307,6 @@ const HttpRpcRouter = Layer.empty;
               }),
           });
 
-          // The server index should have composition operations
           const serverOutcome = getOutcome(
             plan,
             "apps/server-api/src/index.ts",
@@ -317,7 +314,6 @@ const HttpRpcRouter = Layer.empty;
           expect(serverOutcome._tag).toBe("composed");
           assert(serverOutcome._tag === "composed");
 
-          // Should have ts-add-import operations for the ChatRpcLive layer
           const importOps = serverOutcome.operations.filter(
             (op) => op._tag === "ts-add-import",
           );
@@ -331,7 +327,6 @@ const HttpRpcRouter = Layer.empty;
             ]),
           );
 
-          // Should have ts-append-call-arg operations for Layer.mergeAll
           const appendOps = serverOutcome.operations.filter(
             (op) => op._tag === "ts-append-call-arg",
           );
@@ -352,8 +347,6 @@ const HttpRpcRouter = Layer.empty;
       "should report conflict when composition target file is missing and not created by target",
       () =>
         Effect.gen(function* () {
-          // Use a blueprint where the target does NOT produce the index.ts file
-          // and the composition targets a missing file
           const presenceIdentity = new TargetIdentity({
             kind: TargetKind.make("package"),
             name: "presence",
@@ -442,12 +435,10 @@ const HttpRpcRouter = Layer.empty;
               }),
           });
 
-          // Server target creates index.ts, so composition should work with it
           const serverOutcome = getOutcome(
             plan,
             "apps/server-api/src/index.ts",
           );
-          // When file is created by target AND has compositions, it should be composed
           expect(serverOutcome._tag).toBe("composed");
         }),
     );
@@ -648,11 +639,9 @@ const HttpRpcRouter = Layer.empty;
 
           const indexOutcome = getOutcome(plan, "packages/ai/src/index.ts");
 
-          // Should be composed with both authoritative content and barrel export operation
           expect(indexOutcome._tag).toBe("composed");
           expect(indexOutcome.classification).toBe("create");
 
-          // Should have ts-add-reexport for the barrel export from package-ai-toolkit-datetime
           expect(indexOutcome).toMatchObject({
             operations: expect.arrayContaining([
               expect.objectContaining({

--- a/packages/scaffold/src/service/plan/PlanService.ts
+++ b/packages/scaffold/src/service/plan/PlanService.ts
@@ -158,8 +158,6 @@ const compilePlanningPaths = (
   );
 };
 
-// --- Planning intent types and derivation ---
-
 export const PlanningIntentEntry = Schema.TaggedUnion({
   authoritative: {
     path: Schema.String,

--- a/packages/scaffold/src/service/plan/PlanService.ts
+++ b/packages/scaffold/src/service/plan/PlanService.ts
@@ -133,7 +133,7 @@ export class PlanService extends Context.Service<PlanService>()("PlanService", {
 
 const compilePlanningPaths = (
   normalizedContributions: typeof NormalizedContributions.Type,
-): Effect.Effect<ReadonlyArray<PlanningIntentPath>, PlanFailure> => {
+) => {
   const entriesByPath = Arr.groupBy(
     Arr.flatMap(
       [
@@ -316,7 +316,7 @@ const derivePlanningIntentPath = ({
 }: {
   path: string;
   entries: ReadonlyArray<typeof PlanningIntentEntry.Type>;
-}): Effect.Effect<PlanningIntentPath, PlanFailure> =>
+}) =>
   Effect.gen(function* () {
     const family = yield* derivePlanningIntentFamily({ entries, path });
     const authoritativeEntries = entries.filter(
@@ -601,10 +601,7 @@ const derivePlanningIntentFamily = ({
 }: {
   entries: ReadonlyArray<typeof PlanningIntentEntry.Type>;
   path: string;
-}): Effect.Effect<
-  PlanningIntentFamily | CompositePlanningIntentFamily,
-  PlanFailure
-> => {
+}) => {
   const families = new Set(Arr.map(entries, toPlanningIntentFamily));
 
   if (families.size === 1) {
@@ -651,7 +648,7 @@ const requireSingleValue = <Value>({
 }: {
   values: ReadonlyArray<Value>;
   errorMessage: string;
-}): Effect.Effect<Value, PlanFailure> => {
+}) => {
   const firstValue = values[0];
 
   if (
@@ -681,7 +678,7 @@ const collectUniqueEntries = <Entry, Result>({
   valueOf: (entry: Entry) => string;
   toResult: (entry: Entry) => Result;
   errorMessage: string;
-}): Effect.Effect<ReadonlyArray<Result>, PlanFailure> =>
+}) =>
   Effect.all(
     Record.collect(Arr.groupBy(entries, keyOf), (_, groupedEntries) =>
       requireSingleValue({

--- a/packages/tui/src/components/Confirm.ts
+++ b/packages/tui/src/components/Confirm.ts
@@ -67,7 +67,7 @@ export const Confirm = (options: ConfirmOptions): Prompt.Prompt<boolean> => {
     : [];
   const hasChildren = childrenRenderedLines.length > 0;
 
-  const viewportHeight = (terminalRows: number): number =>
+  const viewportHeight = (terminalRows: number) =>
     Math.max(MIN_VIEWPORT_ROWS, terminalRows - CHROME_ROWS);
 
   const renderSubmitted = (cursor: number) =>

--- a/packages/tui/src/components/TextArea.ts
+++ b/packages/tui/src/components/TextArea.ts
@@ -23,15 +23,14 @@ interface TextAreaState {
   readonly error: Option.Option<string>;
 }
 
-const splitLines = (value: string): Array<string> => {
+const splitLines = (value: string) => {
   const lines = value.split("\n");
   return lines.length === 0 ? [""] : lines;
 };
 
-const joinLines = (lines: ReadonlyArray<string>): string => lines.join("\n");
+const joinLines = (lines: ReadonlyArray<string>) => lines.join("\n");
 
-const clampCol = (col: number, line: string): number =>
-  Math.min(col, line.length);
+const clampCol = (col: number, line: string) => Math.min(col, line.length);
 
 const TextAreaKeys = {
   NewLine: new KeyBinding({

--- a/packages/tui/src/components/atom/Hint.ts
+++ b/packages/tui/src/components/atom/Hint.ts
@@ -7,7 +7,6 @@
  * @module
  */
 import { Ansi, Box } from "effect-boxes";
-import type { AnsiStyle } from "effect-boxes/Ansi";
 import type { KeyBinding, KeyMap } from "../../lib/KeyBinding.js";
 
 // ─── Kbd ─────────────────────────────────────────────────────────────────────
@@ -15,7 +14,7 @@ import type { KeyBinding, KeyMap } from "../../lib/KeyBinding.js";
 /**
  * Render a single key binding as `**key** action` (bold key, normal action).
  */
-export const Kbd = (binding: KeyBinding): Box.Box<AnsiStyle> =>
+export const Kbd = (binding: KeyBinding) =>
   Box.hcat(
     [
       Box.text(binding.label).pipe(Box.annotate(Ansi.bold)),
@@ -37,7 +36,7 @@ export const Kbd = (binding: KeyBinding): Box.Box<AnsiStyle> =>
  * // => "↑ up • ↓ down • enter select"  (dimmed, indented)
  * ```
  */
-export const Hint = (keymap: KeyMap): Box.Box<AnsiStyle> =>
+export const Hint = (keymap: KeyMap) =>
   Box.punctuateH(
     Object.values(keymap)
       .filter((b) => b.enabled ?? true)

--- a/packages/tui/src/components/atom/Table.ts
+++ b/packages/tui/src/components/atom/Table.ts
@@ -8,7 +8,7 @@ export const Table = (
     readonly headerAlign?: typeof Box.left;
   }>,
   rows: Box.Box<Ansi.AnsiStyle>[][],
-): Box.Box<Ansi.AnsiStyle> => {
+) => {
   const sep = Box.text(" │ ");
 
   const headerRow = Box.punctuateH(

--- a/packages/tui/test/services/MockTerminal.ts
+++ b/packages/tui/test/services/MockTerminal.ts
@@ -125,7 +125,7 @@ export const inputText = (
 // Utilities
 // =============================================================================
 
-const shouldQuit = (input: Terminal.UserInput): boolean =>
+const shouldQuit = (input: Terminal.UserInput) =>
   input.key.ctrl && (input.key.name === "c" || input.key.name === "d");
 
 const toUserInput = (


### PR DESCRIPTION
## Goal/Scope

Consolidate function arguments during the durable-context refactor

## Description
- Remove noisy/overly explicit return types for cleaner APIs
- Tidy up CLI, catalog, and scaffold comments into a “durable context” format for consistent documentation

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #169 
- <kbd>&nbsp;2&nbsp;</kbd> #168 
- <kbd>&nbsp;1&nbsp;</kbd> #165 👈 
<!-- GitButler Footer Boundary Bottom -->

