### PR TITLE
refactor: consolidate service layer patterns

### DIFF
--- a/packages/scaffold/scratchpad.ts
+++ b/packages/scaffold/scratchpad.ts
@@ -2,46 +2,16 @@ import { BunServices } from "@effect/platform-bun";
 import { CatalogService } from "@repo/catalog";
 import { Apply as ApplyIntent } from "@repo/domain/Apply";
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
-import type { RepoSnapshot } from "@repo/domain/Plan";
 import { StackConfig } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
-import { Console, Effect, FileSystem, Layer, Random } from "effect";
+import { Console, Effect, FileSystem, Random } from "effect";
 import { Box } from "effect-boxes";
 import {
   ApplyService,
   BlueprintService,
-  ContributionResolver,
   PlanService,
   ScaffoldFormatter,
 } from "./src";
-import { PlanAssessor } from "./src/service/plan/PlanAssessor";
-import { RepoSnapshotService } from "./src/service/plan/RepoSnapshotService";
-
-// ---------------------------------------------------------------------------
-// Mock RepoSnapshotService — returns every requested path as "missing"
-// to simulate scaffolding into a fresh, empty repository.
-// ---------------------------------------------------------------------------
-const EmptyRepoSnapshotLayer = Layer.succeed(RepoSnapshotService, {
-  load: Effect.fn("MockRepoSnapshotService.load")(function* ({
-    paths,
-  }: {
-    readonly paths: ReadonlyArray<string>;
-    readonly repoRoot: string;
-  }) {
-    return {
-      paths: paths.map((path) => ({ _tag: "missing", path })),
-    } satisfies typeof RepoSnapshot.Type;
-  }),
-} as never);
-
-// ---------------------------------------------------------------------------
-// PlanService layer wired with the mock snapshot
-// ---------------------------------------------------------------------------
-const PlanServiceLayer = Layer.effect(PlanService)(PlanService.make).pipe(
-  Layer.provide(ContributionResolver.layer),
-  Layer.provide(EmptyRepoSnapshotLayer),
-  Layer.provide(PlanAssessor.layer),
-);
 
 // ---------------------------------------------------------------------------
 // Test selections
@@ -172,7 +142,7 @@ void Effect.runPromise(
   main.pipe(
     Effect.provide(ApplyService.layer),
     Effect.provide(BlueprintService.layer),
-    Effect.provide(PlanServiceLayer),
+    Effect.provide(PlanService.layer),
     Effect.provide(ScaffoldFormatter.layer),
     Effect.provide(BunServices.layer),
     Effect.provide(CatalogService.layer),

--- a/packages/scaffold/src/service/apply/ApplyService.test.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.test.ts
@@ -1,7 +1,11 @@
 /** @effect-diagnostics globalErrorInEffectFailure:skip-file */
 import assert from "node:assert/strict";
 import { describe, expect, it } from "@effect/vitest";
-import { type ApplyDecision, Apply as ApplyIntent } from "@repo/domain/Apply";
+import {
+  type ApplyDecision,
+  ApplyFailure,
+  Apply as ApplyIntent,
+} from "@repo/domain/Apply";
 import {
   CompositionOperation,
   Plan,
@@ -19,8 +23,16 @@ import {
   PlatformError,
 } from "effect";
 import { ApplyService } from "./ApplyService";
-import { CompositionEngine } from "./CompositionEngine";
-import { type ApplyWriteRequest, WriteEngine } from "./WriteEngine";
+import {
+  CompositionEngine,
+  type CompositionEngineShape,
+} from "./CompositionEngine";
+import {
+  type ApplyWriteOutcome,
+  type ApplyWriteRequest,
+  WriteEngine,
+  type WriteEngineShape,
+} from "./WriteEngine";
 
 const testRepoRoot = "/repo";
 
@@ -124,15 +136,10 @@ const makeApplyServiceLayer = ({
   write: (args: {
     readonly repoRoot: string;
     readonly write: ApplyWriteRequest;
-  }) => Effect.Effect<
-    {
-      readonly path: string;
-      readonly status: "created" | "modified" | "unchanged";
-    },
-    unknown,
-    never
-  >;
-  compose?: (input: CompositionInput) => Effect.Effect<string>;
+  }) => Effect.Effect<ApplyWriteOutcome, ApplyFailure, never>;
+  compose?: (
+    input: CompositionInput,
+  ) => Effect.Effect<string, ApplyFailure, never>;
   entries?: Record<string, MockPathEntry>;
 }) =>
   Layer.effect(ApplyService)(ApplyService.make).pipe(
@@ -140,7 +147,7 @@ const makeApplyServiceLayer = ({
       Layer.mergeAll(
         Layer.succeed(WriteEngine, {
           write: Effect.fn("MockWriteEngine.write")(write),
-        } as never),
+        } satisfies WriteEngineShape),
         Layer.succeed(CompositionEngine, {
           compose: Effect.fn("MockCompositionEngine.compose")(
             (
@@ -152,7 +159,7 @@ const makeApplyServiceLayer = ({
                 ? compose({ path, contents, operations })
                 : Effect.succeed(contents),
           ),
-        } as never),
+        } satisfies CompositionEngineShape),
         makeFileSystemLayer(entries),
         Path.layer,
       ),
@@ -348,7 +355,7 @@ describe("ApplyService", () => {
     );
 
     it.effect(
-      "should default conflicted authoritative outcomes to override when decision is absent",
+      "should override conflicted authoritative outcomes when decision is override",
       () =>
         Effect.gen(function* () {
           const writeCalls: Array<ApplyWriteRequest> = [];
@@ -361,6 +368,12 @@ describe("ApplyService", () => {
                   classification: "conflict",
                   contents: "export const Api = {};\n",
                 }),
+              ],
+              decisions: [
+                {
+                  path: "packages/domain/src/Api.ts",
+                  value: "override",
+                },
               ],
             }),
             layer: makeApplyServiceLayer({
@@ -387,6 +400,150 @@ describe("ApplyService", () => {
             modified: ["packages/domain/src/Api.ts"],
             skipped: [],
             failed: [],
+          });
+        }),
+    );
+
+    it.effect(
+      "should fail before repo access when a conflicted path is missing a decision",
+      () =>
+        Effect.gen(function* () {
+          const writeCalls: Array<ApplyWriteRequest> = [];
+          const composeCalls: Array<CompositionInput> = [];
+
+          const exit = yield* Effect.exit(
+            runApply({
+              apply: makeApply({
+                outcomes: [
+                  completeOutcome({
+                    path: "packages/domain/src/Api.ts",
+                    classification: "conflict",
+                    contents: "export const Api = {};\n",
+                  }),
+                ],
+              }),
+              layer: makeApplyServiceLayer({
+                write: ({ write }) => {
+                  writeCalls.push(write);
+                  return Effect.succeed({
+                    path: write.path,
+                    status: "modified" as const,
+                  });
+                },
+                compose: (input) => {
+                  composeCalls.push(input);
+                  return Effect.succeed("unused");
+                },
+              }),
+            }),
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          assert(Exit.isFailure(exit));
+          expect(writeCalls).toHaveLength(0);
+          expect(composeCalls).toHaveLength(0);
+          expect(Cause.squash(exit.cause)).toMatchObject({
+            _tag: "ApplyFailure",
+            reason: "invalidApplyIntent",
+            message:
+              "Missing apply decision for conflicted path packages/domain/src/Api.ts.",
+          });
+        }),
+    );
+
+    it.effect(
+      "should fail before repo access when a decision targets a non-conflicted path",
+      () =>
+        Effect.gen(function* () {
+          const writeCalls: Array<ApplyWriteRequest> = [];
+
+          const exit = yield* Effect.exit(
+            runApply({
+              apply: makeApply({
+                outcomes: [
+                  completeOutcome({
+                    path: "packages/domain/src/Api.ts",
+                    classification: "create",
+                    contents: "export const Api = {};\n",
+                  }),
+                ],
+                decisions: [
+                  {
+                    path: "packages/domain/src/Api.ts",
+                    value: "override",
+                  },
+                ],
+              }),
+              layer: makeApplyServiceLayer({
+                write: ({ write }) => {
+                  writeCalls.push(write);
+                  return Effect.succeed({
+                    path: write.path,
+                    status: "created" as const,
+                  });
+                },
+              }),
+            }),
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          assert(Exit.isFailure(exit));
+          expect(writeCalls).toHaveLength(0);
+          expect(Cause.squash(exit.cause)).toMatchObject({
+            _tag: "ApplyFailure",
+            reason: "invalidApplyIntent",
+            message:
+              "Unexpected apply decision for non-conflicted path packages/domain/src/Api.ts.",
+          });
+        }),
+    );
+
+    it.effect(
+      "should fail before repo access when decisions contain duplicate paths",
+      () =>
+        Effect.gen(function* () {
+          const writeCalls: Array<ApplyWriteRequest> = [];
+
+          const exit = yield* Effect.exit(
+            runApply({
+              apply: makeApply({
+                outcomes: [
+                  completeOutcome({
+                    path: "packages/domain/src/Api.ts",
+                    classification: "conflict",
+                    contents: "export const Api = {};\n",
+                  }),
+                ],
+                decisions: [
+                  {
+                    path: "packages/domain/src/Api.ts",
+                    value: "override",
+                  },
+                  {
+                    path: "packages/domain/src/Api.ts",
+                    value: "skip",
+                  },
+                ],
+              }),
+              layer: makeApplyServiceLayer({
+                write: ({ write }) => {
+                  writeCalls.push(write);
+                  return Effect.succeed({
+                    path: write.path,
+                    status: "modified" as const,
+                  });
+                },
+              }),
+            }),
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          assert(Exit.isFailure(exit));
+          expect(writeCalls).toHaveLength(0);
+          expect(Cause.squash(exit.cause)).toMatchObject({
+            _tag: "ApplyFailure",
+            reason: "invalidApplyIntent",
+            message: "Duplicate apply decision for packages/domain/src/Api.ts.",
           });
         }),
     );
@@ -623,6 +780,138 @@ describe("ApplyService", () => {
         }),
     );
 
+    it.effect("should fail when composition fails and then avoid writes", () =>
+      Effect.gen(function* () {
+        const writeCalls: Array<ApplyWriteRequest> = [];
+
+        const layer = Layer.effect(ApplyService)(ApplyService.make).pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.succeed(WriteEngine, {
+                write: Effect.fn("MockWriteEngine.write")(({ write }) => {
+                  writeCalls.push(write);
+                  return Effect.succeed({
+                    path: write.path,
+                    status: "created" as const,
+                  });
+                }),
+              } satisfies WriteEngineShape),
+              CompositionEngine.layer,
+              makeFileSystemLayer({
+                "/repo/packages/domain/src/index.ts": {
+                  _tag: "missing",
+                },
+              }),
+              Path.layer,
+            ),
+          ),
+        );
+
+        const exit = yield* Effect.exit(
+          runApply({
+            apply: makeApply({
+              outcomes: [
+                partialOutcome({
+                  path: "packages/domain/src/index.ts",
+                  classification: "create",
+                  operations: [
+                    {
+                      _tag: "ts-append-call-arg",
+                      fileType: "typescript",
+                      targetVariable: "program",
+                      functionName: "Command.withSubcommands",
+                      argument: "apiCommand",
+                    },
+                  ],
+                }),
+              ],
+            }),
+            layer,
+          }),
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        assert(Exit.isFailure(exit));
+        expect(writeCalls).toHaveLength(0);
+        expect(Cause.squash(exit.cause)).toMatchObject({
+          _tag: "ApplyFailure",
+          reason: "repoRootInvalid",
+          message:
+            "Could not find Command.withSubcommands on program during TypeScript composition.",
+        });
+      }),
+    );
+
+    it.effect(
+      "should fail when package.json composition finds a non-object section and then avoid writes",
+      () =>
+        Effect.gen(function* () {
+          const writeCalls: Array<ApplyWriteRequest> = [];
+
+          const layer = Layer.effect(ApplyService)(ApplyService.make).pipe(
+            Layer.provide(
+              Layer.mergeAll(
+                Layer.succeed(WriteEngine, {
+                  write: Effect.fn("MockWriteEngine.write")(({ write }) => {
+                    writeCalls.push(write);
+                    return Effect.succeed({
+                      path: write.path,
+                      status: "modified" as const,
+                    });
+                  }),
+                } satisfies WriteEngineShape),
+                CompositionEngine.layer,
+                makeFileSystemLayer({
+                  "/repo/package.json": {
+                    _tag: "file",
+                    contents: JSON.stringify({
+                      scripts: "vite dev",
+                    }),
+                  },
+                }),
+                Path.layer,
+              ),
+            ),
+          );
+
+          const exit = yield* Effect.exit(
+            runApply({
+              apply: makeApply({
+                outcomes: [
+                  partialOutcome({
+                    path: "package.json",
+                    classification: "modify",
+                    operations: [
+                      {
+                        _tag: "json-pkg-scripts",
+                        fileType: "json",
+                        entries: [
+                          {
+                            name: "dev",
+                            value: "vite dev",
+                          },
+                        ],
+                      },
+                    ],
+                  }),
+                ],
+              }),
+              layer,
+            }),
+          );
+
+          expect(Exit.isFailure(exit)).toBe(true);
+          assert(Exit.isFailure(exit));
+          expect(writeCalls).toHaveLength(0);
+          expect(Cause.squash(exit.cause)).toMatchObject({
+            _tag: "ApplyFailure",
+            reason: "repoRootInvalid",
+            message:
+              'Expected package.json field "scripts" to be an object during apply.',
+          });
+        }),
+    );
+
     it.effect("should map unchanged write outcomes into skipped paths", () =>
       Effect.gen(function* () {
         const result = yield* runApply({
@@ -680,7 +969,12 @@ describe("ApplyService", () => {
                 writeCalls.push(write);
 
                 if (write.path === "packages/domain/src/Api.ts") {
-                  return Effect.fail(new Error("disk full"));
+                  return Effect.fail(
+                    new ApplyFailure({
+                      reason: "executionFailure",
+                      message: "disk full",
+                    }),
+                  );
                 }
 
                 return Effect.succeed({
@@ -779,7 +1073,10 @@ describe("ApplyService", () => {
                     });
                   default:
                     return Effect.fail(
-                      new Error(`Unexpected write path ${write.path}`),
+                      new ApplyFailure({
+                        reason: "executionFailure",
+                        message: `Unexpected write path ${write.path}`,
+                      }),
                     );
                 }
               },

--- a/packages/scaffold/src/service/apply/ApplyService.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.ts
@@ -55,74 +55,131 @@ const PreparedApplyAction = Schema.TaggedUnion({
   },
 });
 
-export class ApplyService extends Context.Service<ApplyService>()(
-  "ApplyService",
-  {
-    make: Effect.gen(function* () {
-      const writeEngine = yield* WriteEngine;
-      const compositionEngine = yield* CompositionEngine;
-      const fileSystem = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
+type ActionProjection = {
+  readonly skippedPaths: Set<string>;
+  readonly writeRequests: Array<ApplyWriteRequest>;
+};
 
-      const materializeFrom = Effect.fn("ApplyService.materializeFrom")(
-        function* (apply: typeof Apply.Type) {
-          const decisionsByPath = new Map(
-            apply.decisions.map(
-              (decision) => [decision.path, decision.value] as const,
+type WriteAttempt =
+  | {
+      readonly path: string;
+      readonly status: "created" | "modified" | "unchanged";
+    }
+  | {
+      readonly path: string;
+      readonly status: "failure";
+      readonly reason: string;
+    };
+
+export interface ApplyServiceShape {
+  readonly apply: (input: {
+    readonly apply: typeof Apply.Type;
+    readonly repoRoot: string;
+  }) => Effect.Effect<ApplyResult, ApplyFailure, never>;
+  readonly preview: (input: {
+    readonly apply: typeof Apply.Type;
+    readonly repoRoot: string;
+  }) => Effect.Effect<ApplyResult, ApplyFailure, never>;
+}
+
+export class ApplyService extends Context.Service<
+  ApplyService,
+  ApplyServiceShape
+>()("ApplyService", {
+  make: Effect.gen(function* () {
+    const writeEngine = yield* WriteEngine;
+    const compositionEngine = yield* CompositionEngine;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const validateApplyIntent = Effect.fn("ApplyService.validateApplyIntent")(
+      function* (apply: typeof Apply.Type) {
+        const conflictPaths = new Set(
+          Arr.map(
+            Arr.filter(
+              apply.plan.outcomes,
+              (outcome) => outcome.classification === "conflict",
             ),
-          );
-          return Arr.map(
-            apply.plan.outcomes,
-            (outcome): typeof MaterializedPlannedOutcomeAction.Type =>
-              Match.value(outcome).pipe(
-                Match.withReturnType<
-                  typeof MaterializedPlannedOutcomeAction.Type
-                >(),
-                Match.when({ classification: "unchanged" }, (o) =>
-                  MaterializedPlannedOutcomeAction.cases.skip.make({
-                    path: o.path,
-                    reason: o.classification,
-                  }),
-                ),
-                Match.whenOr(
-                  { classification: "create" },
-                  { classification: "modify" },
-                  (o) =>
-                    Match.valueTags(o, {
-                      complete: (n) =>
-                        MaterializedPlannedOutcomeAction.cases[
-                          "write-authoritative"
-                        ].make({
-                          path: n.path,
-                          contents: n.contents,
-                          writeMode: n.classification,
-                        }),
-                      composed: (n) =>
-                        MaterializedPlannedOutcomeAction.cases[
-                          "write-composed"
-                        ].make({
-                          path: n.path,
-                          seedContents: n.seedContents,
-                          operations: n.operations,
-                          writeMode: n.classification,
-                        }),
-                    }),
-                ),
-                Match.when({ classification: "conflict" }, (o) => {
-                  if (decisionsByPath.get(outcome.path) === "skip") {
-                    return MaterializedPlannedOutcomeAction.cases.skip.make({
-                      path: o.path,
-                      reason: "decision",
-                    });
-                  }
-                  return Match.valueTags(o, {
+            (outcome) => outcome.path,
+          ),
+        );
+
+        const seenDecisionPaths = new Set<string>();
+        const duplicateDecision = Arr.findFirst(apply.decisions, (decision) => {
+          if (seenDecisionPaths.has(decision.path)) {
+            return true;
+          }
+          seenDecisionPaths.add(decision.path);
+          return false;
+        });
+        if (Option.isSome(duplicateDecision)) {
+          return yield* new ApplyFailure({
+            reason: "invalidApplyIntent",
+            message: `Duplicate apply decision for ${duplicateDecision.value.path}.`,
+          });
+        }
+
+        const extraDecision = Arr.findFirst(
+          apply.decisions,
+          (decision) => !conflictPaths.has(decision.path),
+        );
+        if (Option.isSome(extraDecision)) {
+          return yield* new ApplyFailure({
+            reason: "invalidApplyIntent",
+            message: `Unexpected apply decision for non-conflicted path ${extraDecision.value.path}.`,
+          });
+        }
+
+        const decisionPaths = new Set(
+          Arr.map(apply.decisions, (decision) => decision.path),
+        );
+        const missingDecisionPath = Arr.findFirst(
+          [...conflictPaths],
+          (conflictPath) => !decisionPaths.has(conflictPath),
+        );
+        if (Option.isSome(missingDecisionPath)) {
+          return yield* new ApplyFailure({
+            reason: "invalidApplyIntent",
+            message: `Missing apply decision for conflicted path ${missingDecisionPath.value}.`,
+          });
+        }
+      },
+    );
+
+    const materializeFrom = Effect.fn("ApplyService.materializeFrom")(
+      function* (apply: typeof Apply.Type) {
+        yield* validateApplyIntent(apply);
+
+        const decisionsByPath = new Map(
+          apply.decisions.map(
+            (decision) => [decision.path, decision.value] as const,
+          ),
+        );
+        return Arr.map(
+          apply.plan.outcomes,
+          (outcome): typeof MaterializedPlannedOutcomeAction.Type =>
+            Match.value(outcome).pipe(
+              Match.withReturnType<
+                typeof MaterializedPlannedOutcomeAction.Type
+              >(),
+              Match.when({ classification: "unchanged" }, (o) =>
+                MaterializedPlannedOutcomeAction.cases.skip.make({
+                  path: o.path,
+                  reason: o.classification,
+                }),
+              ),
+              Match.whenOr(
+                { classification: "create" },
+                { classification: "modify" },
+                (o) =>
+                  Match.valueTags(o, {
                     complete: (n) =>
                       MaterializedPlannedOutcomeAction.cases[
                         "write-authoritative"
                       ].make({
                         path: n.path,
                         contents: n.contents,
-                        writeMode: "override",
+                        writeMode: n.classification,
                       }),
                     composed: (n) =>
                       MaterializedPlannedOutcomeAction.cases[
@@ -131,269 +188,314 @@ export class ApplyService extends Context.Service<ApplyService>()(
                         path: n.path,
                         seedContents: n.seedContents,
                         operations: n.operations,
-                        writeMode: "override",
+                        writeMode: n.classification,
                       }),
+                  }),
+              ),
+              Match.when({ classification: "conflict" }, (o) => {
+                if (decisionsByPath.get(outcome.path) === "skip") {
+                  return MaterializedPlannedOutcomeAction.cases.skip.make({
+                    path: o.path,
+                    reason: "decision",
                   });
-                }),
-                Match.exhaustive,
-              ),
-          );
-        },
-      );
-
-      const loadFileContents = Effect.fn("ApplyService.loadFileContents")(
-        function* (filePath: string) {
-          const pathStat = yield* fileSystem
-            .stat(filePath)
-            .pipe(
-              Effect.catch((error) =>
-                error.reason._tag === "NotFound"
-                  ? Effect.succeed(null)
-                  : Effect.fail(error),
-              ),
-            );
-
-          if (pathStat === null) {
-            return Option.none<string>();
-          }
-
-          if (pathStat.type === "Directory") {
-            throw new ApplyFailure({
-              reason: "repoRootInvalid",
-              message: `Expected ${filePath} to be a file during apply.`,
-            });
-          }
-
-          const contents = yield* fileSystem.readFileString(filePath).pipe(
-            Effect.mapError(
-              (error) =>
-                new ApplyFailure({
-                  reason: "repoRootInvalid",
-                  message: `Could not read ${filePath} during apply: ${error.message}`,
-                }),
-            ),
-          );
-
-          return Option.some(contents);
-        },
-      );
-
-      const loadComposedBaseContents = Effect.fn(
-        "ApplyService.loadComposedBaseContents",
-      )(function* ({
-        action,
-        repoRoot,
-      }: {
-        action: WriteComposedAction;
-        repoRoot: string;
-      }) {
-        const fullPath = path.join(repoRoot, action.path);
-        const existingContents =
-          action.writeMode === "modify"
-            ? yield* loadFileContents(fullPath)
-            : Option.none<string>();
-
-        if (Option.isSome(existingContents)) {
-          return existingContents.value;
-        }
-
-        if (action.seedContents !== undefined) {
-          return action.seedContents;
-        }
-
-        const fallbackContents = yield* loadFileContents(fullPath);
-        return Option.getOrElse(fallbackContents, () =>
-          action.path.endsWith(".json") ? "{}" : "",
-        );
-      });
-
-      const prepare = Effect.fn("ApplyService.prepare")(function* ({
-        action,
-        repoRoot,
-      }: {
-        action: typeof MaterializedPlannedOutcomeAction.Type;
-        repoRoot: string;
-      }) {
-        switch (action._tag) {
-          case "skip":
-            return PreparedApplyAction.cases.skip.make({
-              path: action.path,
-            });
-          case "write-authoritative":
-            return PreparedApplyAction.cases.write.make({
-              request: {
-                path: action.path,
-                contents: action.contents,
-                writeMode: action.writeMode,
-              },
-            });
-          case "write-composed": {
-            // NOTE: Modify composes from disk first so repeat applies preserve unrelated fields.
-            const baseContents = yield* loadComposedBaseContents({
-              action,
-              repoRoot,
-            });
-            const composedContents = yield* compositionEngine.compose(
-              action.path,
-              baseContents,
-              action.operations,
-            );
-
-            return PreparedApplyAction.cases.write.make({
-              request: {
-                path: action.path,
-                contents: composedContents,
-                writeMode: action.writeMode,
-              },
-            });
-          }
-        }
-      });
-
-      const projection = Effect.fn("ApplyService.projection")(function* ({
-        actions,
-        repoRoot,
-      }: {
-        actions: ReadonlyArray<typeof MaterializedPlannedOutcomeAction.Type>;
-        repoRoot: string;
-      }) {
-        const preparedActions = yield* Effect.all(
-          Arr.map(actions, (action) =>
-            prepare({
-              action,
-              repoRoot,
-            }),
-          ),
-          {
-            concurrency: 1,
-          },
-        );
-
-        return Arr.reduce<
-          typeof PreparedApplyAction.Type,
-          {
-            skippedPaths: Set<string>;
-            writeRequests: Array<ApplyWriteRequest>;
-          }
-        >(
-          preparedActions,
-          {
-            skippedPaths: new Set<string>(),
-            writeRequests: [],
-          },
-          (proj, preparedAction) => {
-            switch (preparedAction._tag) {
-              case "skip":
-                proj.skippedPaths.add(preparedAction.path);
-                return proj;
-              case "write":
-                proj.writeRequests.push(preparedAction.request);
-                return proj;
-            }
-          },
-        );
-      });
-
-      const apply = Effect.fn("ApplyService.apply")(function* ({
-        apply: applyIntent,
-        repoRoot,
-      }: {
-        apply: typeof Apply.Type;
-        repoRoot: string;
-      }) {
-        const actions = yield* materializeFrom(applyIntent);
-
-        const actionProjection = yield* projection({ actions, repoRoot });
-
-        const writeAttempts = yield* Effect.all(
-          Arr.map(actionProjection.writeRequests, (writeRequest) =>
-            writeEngine.write({ repoRoot, write: writeRequest }).pipe(
-              Effect.catch((error) =>
-                Effect.succeed({
-                  path: writeRequest.path,
-                  status: "failure" as const,
-                  reason: error.message,
-                }),
-              ),
-            ),
-          ),
-          {
-            concurrency: 1,
-          },
-        );
-        const writeProjection = Arr.reduce<
-          (typeof writeAttempts)[number],
-          {
-            created: Array<string>;
-            modified: Array<string>;
-            skippedPaths: Set<string>;
-            failed: Array<typeof ApplyFailedPath.Type>;
-          }
-        >(
-          writeAttempts,
-          {
-            created: [],
-            modified: [],
-            skippedPaths: actionProjection.skippedPaths,
-            failed: [],
-          },
-          (proj, writeAttempt) => {
-            switch (writeAttempt.status) {
-              case "created":
-                proj.created.push(writeAttempt.path);
-                return proj;
-              case "modified":
-                proj.modified.push(writeAttempt.path);
-                return proj;
-              case "unchanged":
-                proj.skippedPaths.add(writeAttempt.path);
-                return proj;
-              case "failure":
-                proj.failed.push({
-                  path: writeAttempt.path,
-                  reason: writeAttempt.reason,
+                }
+                return Match.valueTags(o, {
+                  complete: (n) =>
+                    MaterializedPlannedOutcomeAction.cases[
+                      "write-authoritative"
+                    ].make({
+                      path: n.path,
+                      contents: n.contents,
+                      writeMode: "override",
+                    }),
+                  composed: (n) =>
+                    MaterializedPlannedOutcomeAction.cases[
+                      "write-composed"
+                    ].make({
+                      path: n.path,
+                      seedContents: n.seedContents,
+                      operations: n.operations,
+                      writeMode: "override",
+                    }),
                 });
-                return proj;
-            }
-          },
+              }),
+              Match.exhaustive,
+            ),
+        );
+      },
+    );
+
+    const loadFileContents = Effect.fn("ApplyService.loadFileContents")(
+      function* (filePath: string) {
+        const pathStat = yield* fileSystem.stat(filePath).pipe(
+          Effect.catch((error) =>
+            error.reason._tag === "NotFound"
+              ? Effect.succeed(null)
+              : Effect.fail(
+                  new ApplyFailure({
+                    reason: "repoRootInvalid",
+                    message: `Could not inspect ${filePath} during apply: ${error.message}`,
+                  }),
+                ),
+          ),
         );
 
-        return new ApplyResult({
-          created: writeProjection.created,
-          modified: writeProjection.modified,
-          skipped: [...writeProjection.skippedPaths],
-          failed: writeProjection.failed,
-        }).toSorted();
-      });
+        if (pathStat === null) {
+          return Option.none<string>();
+        }
 
-      const preview = Effect.fn("ApplyService.preview")(function* ({
-        apply: applyIntent,
-        repoRoot,
-      }: {
-        apply: typeof Apply.Type;
-        repoRoot: string;
-      }) {
-        const actions = yield* materializeFrom(applyIntent);
-        const actionProjection = yield* projection({ actions, repoRoot });
+        if (pathStat.type === "Directory") {
+          return yield* new ApplyFailure({
+            reason: "repoRootInvalid",
+            message: `Expected ${filePath} to be a file during apply.`,
+          });
+        }
 
-        return new ApplyResult({
-          created: actionProjection.writeRequests
-            .filter((r) => r.writeMode === "create")
-            .map((r) => r.path),
-          modified: actionProjection.writeRequests
-            .filter(
-              (r) => r.writeMode === "modify" || r.writeMode === "override",
-            )
-            .map((r) => r.path),
-          skipped: [...actionProjection.skippedPaths],
+        const contents = yield* fileSystem.readFileString(filePath).pipe(
+          Effect.mapError(
+            (error) =>
+              new ApplyFailure({
+                reason: "repoRootInvalid",
+                message: `Could not read ${filePath} during apply: ${error.message}`,
+              }),
+          ),
+        );
+
+        return Option.some(contents);
+      },
+    );
+
+    const loadComposedBaseContents = Effect.fn(
+      "ApplyService.loadComposedBaseContents",
+    )(function* ({
+      action,
+      repoRoot,
+    }: {
+      action: WriteComposedAction;
+      repoRoot: string;
+    }) {
+      const fullPath = path.join(repoRoot, action.path);
+      const existingContents =
+        action.writeMode === "modify"
+          ? yield* loadFileContents(fullPath)
+          : Option.none<string>();
+
+      if (Option.isSome(existingContents)) {
+        return existingContents.value;
+      }
+
+      if (action.seedContents !== undefined) {
+        return action.seedContents;
+      }
+
+      const fallbackContents = yield* loadFileContents(fullPath);
+      return Option.getOrElse(fallbackContents, () =>
+        action.path.endsWith(".json") ? "{}" : "",
+      );
+    });
+
+    const prepare = Effect.fn("ApplyService.prepare")(function* ({
+      action,
+      repoRoot,
+    }: {
+      action: typeof MaterializedPlannedOutcomeAction.Type;
+      repoRoot: string;
+    }) {
+      switch (action._tag) {
+        case "skip":
+          return PreparedApplyAction.cases.skip.make({
+            path: action.path,
+          });
+        case "write-authoritative":
+          return PreparedApplyAction.cases.write.make({
+            request: {
+              path: action.path,
+              contents: action.contents,
+              writeMode: action.writeMode,
+            },
+          });
+        case "write-composed": {
+          // NOTE: Modify composes from disk first so repeat applies preserve unrelated fields.
+          const baseContents = yield* loadComposedBaseContents({
+            action,
+            repoRoot,
+          });
+          const composedContents = yield* compositionEngine.compose(
+            action.path,
+            baseContents,
+            action.operations,
+          );
+
+          return PreparedApplyAction.cases.write.make({
+            request: {
+              path: action.path,
+              contents: composedContents,
+              writeMode: action.writeMode,
+            },
+          });
+        }
+      }
+    });
+
+    const prepareWrites = Effect.fn("ApplyService.prepareWrites")(function* ({
+      actions,
+      repoRoot,
+    }: {
+      actions: ReadonlyArray<typeof MaterializedPlannedOutcomeAction.Type>;
+      repoRoot: string;
+    }) {
+      const preparedActions = yield* Effect.all(
+        Arr.map(actions, (action) =>
+          prepare({
+            action,
+            repoRoot,
+          }),
+        ),
+        {
+          concurrency: 1,
+        },
+      );
+
+      return Arr.reduce<typeof PreparedApplyAction.Type, ActionProjection>(
+        preparedActions,
+        {
+          skippedPaths: new Set<string>(),
+          writeRequests: [],
+        },
+        (projectionBuilder, preparedAction) => {
+          switch (preparedAction._tag) {
+            case "skip":
+              projectionBuilder.skippedPaths.add(preparedAction.path);
+              return projectionBuilder;
+            case "write":
+              projectionBuilder.writeRequests.push(preparedAction.request);
+              return projectionBuilder;
+          }
+        },
+      );
+    });
+
+    const executeWrites = Effect.fn("ApplyService.executeWrites")(function* ({
+      repoRoot,
+      writeRequests,
+    }: {
+      repoRoot: string;
+      writeRequests: ReadonlyArray<ApplyWriteRequest>;
+    }) {
+      return yield* Effect.all(
+        Arr.map(writeRequests, (writeRequest) =>
+          writeEngine.write({ repoRoot, write: writeRequest }).pipe(
+            Effect.catch((error) =>
+              Effect.succeed({
+                path: writeRequest.path,
+                status: "failure" as const,
+                reason: error.message,
+              }),
+            ),
+          ),
+        ),
+        {
+          concurrency: 1,
+        },
+      );
+    });
+
+    const toApplyResult = ({
+      skippedPaths,
+      writeAttempts,
+    }: {
+      skippedPaths: ReadonlySet<string>;
+      writeAttempts: ReadonlyArray<WriteAttempt>;
+    }) => {
+      const resultBuilder = Arr.reduce<
+        WriteAttempt,
+        {
+          created: Array<string>;
+          modified: Array<string>;
+          skippedPaths: Set<string>;
+          failed: Array<typeof ApplyFailedPath.Type>;
+        }
+      >(
+        writeAttempts,
+        {
+          created: [],
+          modified: [],
+          skippedPaths: new Set(skippedPaths),
           failed: [],
-        }).toSorted();
+        },
+        (builder, writeAttempt) => {
+          switch (writeAttempt.status) {
+            case "created":
+              builder.created.push(writeAttempt.path);
+              return builder;
+            case "modified":
+              builder.modified.push(writeAttempt.path);
+              return builder;
+            case "unchanged":
+              builder.skippedPaths.add(writeAttempt.path);
+              return builder;
+            case "failure":
+              builder.failed.push({
+                path: writeAttempt.path,
+                reason: writeAttempt.reason,
+              });
+              return builder;
+          }
+        },
+      );
+
+      return new ApplyResult({
+        created: resultBuilder.created,
+        modified: resultBuilder.modified,
+        skipped: [...resultBuilder.skippedPaths],
+        failed: resultBuilder.failed,
+      }).toSorted();
+    };
+
+    const apply = Effect.fn("ApplyService.apply")(function* ({
+      apply: applyIntent,
+      repoRoot,
+    }: {
+      apply: typeof Apply.Type;
+      repoRoot: string;
+    }) {
+      const actions = yield* materializeFrom(applyIntent);
+
+      const actionProjection = yield* prepareWrites({ actions, repoRoot });
+
+      const writeAttempts = yield* executeWrites({
+        repoRoot,
+        writeRequests: actionProjection.writeRequests,
       });
 
-      return { apply, preview } as const;
-    }),
-  },
-) {
+      return toApplyResult({
+        skippedPaths: actionProjection.skippedPaths,
+        writeAttempts,
+      });
+    });
+
+    const preview = Effect.fn("ApplyService.preview")(function* ({
+      apply: applyIntent,
+      repoRoot,
+    }: {
+      apply: typeof Apply.Type;
+      repoRoot: string;
+    }) {
+      const actions = yield* materializeFrom(applyIntent);
+      const actionProjection = yield* prepareWrites({ actions, repoRoot });
+
+      return toApplyResult({
+        skippedPaths: actionProjection.skippedPaths,
+        writeAttempts: Arr.map(actionProjection.writeRequests, (request) => ({
+          path: request.path,
+          status: request.writeMode === "create" ? "created" : "modified",
+        })),
+      });
+    });
+
+    return { apply, preview } satisfies ApplyServiceShape;
+  }),
+}) {
   static readonly layer = Layer.effect(ApplyService)(ApplyService.make).pipe(
     Layer.provide(WriteEngine.layer),
     Layer.provide(CompositionEngine.layer),

--- a/packages/scaffold/src/service/apply/CompositionEngine.ts
+++ b/packages/scaffold/src/service/apply/CompositionEngine.ts
@@ -1,3 +1,4 @@
+import { ApplyFailure } from "@repo/domain/Apply";
 import { CompositionOperation } from "@repo/domain/Plan";
 import { Array, Context, Effect, Layer } from "effect";
 import { JsonComposer } from "./JsonComposer";
@@ -13,48 +14,52 @@ const isTypeScriptOp = (
 ): op is typeof CompositionOperation.cases.typescript.Type =>
   op.fileType === "typescript";
 
-export class CompositionEngine extends Context.Service<CompositionEngine>()(
-  "CompositionEngine",
-  {
-    make: Effect.gen(function* () {
-      const jsonComposer = yield* JsonComposer;
-      const typeScriptComposer = yield* TypeScriptComposer;
+export interface CompositionEngineShape {
+  readonly compose: (
+    path: string,
+    contents: string,
+    operations: ReadonlyArray<typeof CompositionOperation.Type>,
+  ) => Effect.Effect<string, ApplyFailure, never>;
+}
 
-      return {
-        compose: Effect.fn(function* (
-          path: string,
-          contents: string,
-          operations: ReadonlyArray<typeof CompositionOperation.Type>,
-        ) {
-          if (operations.length === 0) {
-            return contents;
-          }
+export class CompositionEngine extends Context.Service<
+  CompositionEngine,
+  CompositionEngineShape
+>()("CompositionEngine", {
+  make: Effect.gen(function* () {
+    const jsonComposer = yield* JsonComposer;
+    const typeScriptComposer = yield* TypeScriptComposer;
 
-          let result = contents;
+    return {
+      compose: Effect.fn(function* (
+        path: string,
+        contents: string,
+        operations: ReadonlyArray<typeof CompositionOperation.Type>,
+      ) {
+        if (operations.length === 0) {
+          return contents;
+        }
 
-          const jsonOps = Array.filter(operations, isJsonOp);
+        const jsonOps = Array.filter(operations, isJsonOp);
+        const jsonComposed =
+          isJsonFile(path) && jsonOps.length > 0
+            ? yield* jsonComposer.compose(contents, jsonOps)
+            : contents;
 
-          if (isJsonFile(path) && jsonOps.length > 0) {
-            result = yield* jsonComposer.compose(result, jsonOps);
-          }
-
-          const tsOps = Array.filter(operations, isTypeScriptOp);
-
-          if (isTypeScriptFile(path) && tsOps.length > 0) {
-            result = yield* typeScriptComposer.compose(result, tsOps);
-          }
-
-          return result;
-        }),
-      };
-    }),
-  },
-) {
+        const tsOps = Array.filter(operations, isTypeScriptOp);
+        return isTypeScriptFile(path) && tsOps.length > 0
+          ? yield* typeScriptComposer.compose(jsonComposed, tsOps)
+          : jsonComposed;
+      }),
+    } satisfies CompositionEngineShape;
+  }),
+}) {
   static readonly layer = Layer.effect(CompositionEngine)(
     CompositionEngine.make,
   ).pipe(
     Layer.provide(JsonComposer.layer),
     Layer.provide(TypeScriptComposer.layer),
+    Layer.satisfiesServicesType<never>(),
   );
 }
 

--- a/packages/scaffold/src/service/apply/JsonComposer.ts
+++ b/packages/scaffold/src/service/apply/JsonComposer.ts
@@ -1,45 +1,71 @@
+import { ApplyFailure } from "@repo/domain/Apply";
 import type { CompositionOperation } from "@repo/domain/Plan";
-import { Context, Effect, Layer, Match, Schema } from "effect";
+import { Array as Arr, Context, Effect, Layer, Match, Schema } from "effect";
 
 const PackageJsonFromString = Schema.fromJsonString(
   Schema.Record(Schema.String, Schema.Unknown),
 );
 
-export class JsonComposer extends Context.Service<JsonComposer>()(
-  "JsonComposer",
-  {
-    make: Effect.succeed({
-      compose: (
-        contents: string,
-        operations: ReadonlyArray<typeof CompositionOperation.cases.json.Type>,
-      ) =>
-        Effect.gen(function* () {
-          const pkg = yield* Schema.decodeUnknownEffect(PackageJsonFromString)(
-            contents,
-          );
+export interface JsonComposerShape {
+  readonly compose: (
+    contents: string,
+    operations: ReadonlyArray<typeof CompositionOperation.cases.json.Type>,
+  ) => Effect.Effect<string, ApplyFailure, never>;
+}
 
-          const mutablePkg = { ...pkg } as Record<string, unknown>;
+export class JsonComposer extends Context.Service<
+  JsonComposer,
+  JsonComposerShape
+>()("JsonComposer", {
+  make: Effect.succeed({
+    compose: (
+      contents: string,
+      operations: ReadonlyArray<typeof CompositionOperation.cases.json.Type>,
+    ) =>
+      Effect.gen(function* () {
+        const pkg = yield* Schema.decodeUnknownEffect(PackageJsonFromString)(
+          contents,
+        ).pipe(
+          Effect.mapError(
+            (error) =>
+              new ApplyFailure({
+                reason: "repoRootInvalid",
+                message: `Could not parse package.json during apply: ${error.message}`,
+              }),
+          ),
+        );
 
-          yield* Effect.forEach(operations, (op) =>
-            Effect.sync(() => {
-              applyJsonOperation(mutablePkg, op);
-            }),
-          );
+        const mutablePkg = { ...pkg } as Record<string, unknown>;
 
-          return yield* Schema.encodeUnknownEffect(PackageJsonFromString)(
-            mutablePkg,
-          );
-        }),
-    }),
-  },
-) {
-  static readonly layer = Layer.effect(JsonComposer)(JsonComposer.make);
+        yield* Effect.forEach(
+          operations,
+          (op) => applyJsonOperation(mutablePkg, op),
+          { discard: true },
+        );
+
+        return yield* Schema.encodeUnknownEffect(PackageJsonFromString)(
+          mutablePkg,
+        ).pipe(
+          Effect.mapError(
+            (error) =>
+              new ApplyFailure({
+                reason: "repoRootInvalid",
+                message: `Could not encode package.json during apply: ${error.message}`,
+              }),
+          ),
+        );
+      }),
+  } satisfies JsonComposerShape),
+}) {
+  static readonly layer = Layer.effect(JsonComposer)(JsonComposer.make).pipe(
+    Layer.satisfiesServicesType<never>(),
+  );
 }
 
 const applyJsonOperation = (
   pkg: Record<string, unknown>,
   op: typeof CompositionOperation.cases.json.Type,
-): void =>
+): Effect.Effect<void, ApplyFailure, never> =>
   Match.typeTags<typeof CompositionOperation.cases.json.Type>()({
     "json-pkg-exports": (o) =>
       assignPackageJsonEntries(pkg, "exports", o.entries),
@@ -52,10 +78,25 @@ const assignPackageJsonEntries = (
   pkg: Record<string, unknown>,
   sectionName: string,
   entries: ReadonlyArray<{ readonly name: string; readonly value: string }>,
-): void => {
-  const section = (pkg[sectionName] ?? {}) as Record<string, string>;
-  for (const entry of entries) {
-    section[entry.name] = entry.value;
-  }
-  pkg[sectionName] = section;
-};
+): Effect.Effect<void, ApplyFailure, never> =>
+  Effect.gen(function* () {
+    const existingSection = pkg[sectionName];
+    if (existingSection !== undefined && !isPlainObject(existingSection)) {
+      return yield* new ApplyFailure({
+        reason: "repoRootInvalid",
+        message: `Expected package.json field "${sectionName}" to be an object during apply.`,
+      });
+    }
+
+    pkg[sectionName] = Arr.reduce(
+      entries,
+      existingSection === undefined ? {} : { ...existingSection },
+      (section, entry) => ({
+        ...section,
+        [entry.name]: entry.value,
+      }),
+    );
+  });
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/scaffold/src/service/apply/TypeScriptComposer.ts
+++ b/packages/scaffold/src/service/apply/TypeScriptComposer.ts
@@ -1,3 +1,4 @@
+import { ApplyFailure } from "@repo/domain/Apply";
 import type {
   CompositionOperation,
   TsAddImportOp,
@@ -9,7 +10,6 @@ import type {
 import {
   Array as Arr,
   Context,
-  Data,
   Effect,
   Layer,
   Match,
@@ -24,60 +24,64 @@ import type {
 } from "ts-morph";
 import { Project, SyntaxKind } from "ts-morph";
 
-class TargetNotFoundError extends Data.TaggedError("TargetNotFoundError")<{
-  targetVariable: string;
-  functionName: string;
-}> {}
+export interface TypeScriptComposerShape {
+  readonly compose: (
+    contents: string,
+    operations: ReadonlyArray<
+      typeof CompositionOperation.cases.typescript.Type
+    >,
+  ) => Effect.Effect<string, ApplyFailure, never>;
+}
 
-export class TypeScriptComposer extends Context.Service<TypeScriptComposer>()(
-  "TypeScriptComposer",
-  {
-    make: Effect.succeed({
-      compose: Effect.fn(function* (
-        contents: string,
-        operations: ReadonlyArray<
-          typeof CompositionOperation.cases.typescript.Type
-        >,
-      ) {
-        const project = new Project({
-          useInMemoryFileSystem: true,
-          skipAddingFilesFromTsConfig: true,
-        });
+export class TypeScriptComposer extends Context.Service<
+  TypeScriptComposer,
+  TypeScriptComposerShape
+>()("TypeScriptComposer", {
+  make: Effect.succeed({
+    compose: Effect.fn(function* (
+      contents: string,
+      operations: ReadonlyArray<
+        typeof CompositionOperation.cases.typescript.Type
+      >,
+    ) {
+      const project = new Project({
+        useInMemoryFileSystem: true,
+        skipAddingFilesFromTsConfig: true,
+      });
 
-        const sourceFile = project.createSourceFile("temp.ts", contents);
+      const sourceFile = project.createSourceFile("temp.ts", contents);
 
-        yield* Effect.forEach(
-          operations,
-          (op) =>
-            Match.value(op).pipe(
-              Match.tag("ts-add-import", (importOp) =>
-                Effect.sync(() => applyTsAddImport(sourceFile, importOp)),
-              ),
-              Match.tag("ts-add-reexport", (reexportOp) =>
-                Effect.sync(() => applyTsAddReexport(sourceFile, reexportOp)),
-              ),
-              Match.tag("ts-append-call-arg", (appendOp) =>
-                applyTsAppendCallArg(sourceFile, appendOp),
-              ),
-              Match.tag("ts-object-field", (fieldOp) =>
-                applyTsObjectField(sourceFile, fieldOp),
-              ),
-              Match.tag("ts-jsx-slot", (slotOp) =>
-                Effect.sync(() => applyTsJsxSlot(sourceFile, slotOp)),
-              ),
-              Match.exhaustive,
+      yield* Effect.forEach(
+        operations,
+        (op) =>
+          Match.value(op).pipe(
+            Match.tag("ts-add-import", (importOp) =>
+              Effect.sync(() => applyTsAddImport(sourceFile, importOp)),
             ),
-          { discard: true },
-        );
+            Match.tag("ts-add-reexport", (reexportOp) =>
+              Effect.sync(() => applyTsAddReexport(sourceFile, reexportOp)),
+            ),
+            Match.tag("ts-append-call-arg", (appendOp) =>
+              applyTsAppendCallArg(sourceFile, appendOp),
+            ),
+            Match.tag("ts-object-field", (fieldOp) =>
+              applyTsObjectField(sourceFile, fieldOp),
+            ),
+            Match.tag("ts-jsx-slot", (slotOp) =>
+              Effect.sync(() => applyTsJsxSlot(sourceFile, slotOp)),
+            ),
+            Match.exhaustive,
+          ),
+        { discard: true },
+      );
 
-        return sourceFile.getFullText();
-      }),
+      return sourceFile.getFullText();
     }),
-  },
-) {
+  } satisfies TypeScriptComposerShape),
+}) {
   static readonly layer = Layer.effect(TypeScriptComposer)(
     TypeScriptComposer.make,
-  );
+  ).pipe(Layer.satisfiesServicesType<never>());
 }
 
 const applyTsAddImport = (
@@ -124,14 +128,14 @@ const applyTsAddReexport = (
   if (existingExport) {
     if (op.namedExports) {
       const existingNamedExports = existingExport.getNamedExports();
-      for (const namedExport of op.namedExports) {
-        const alreadyExists = existingNamedExports.some(
-          (ne) => ne.getName() === namedExport,
-        );
-        if (!alreadyExists) {
-          existingExport.addNamedExport(namedExport);
-        }
-      }
+      Arr.forEach(
+        Arr.filter(
+          op.namedExports,
+          (namedExport) =>
+            !existingNamedExports.some((ne) => ne.getName() === namedExport),
+        ),
+        (namedExport) => existingExport.addNamedExport(namedExport),
+      );
     }
     return;
   }
@@ -240,10 +244,7 @@ const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
 ) {
   const initializer = getTargetInitializer(sourceFile, op.targetVariable);
   if (Option.isNone(initializer)) {
-    return yield* new TargetNotFoundError({
-      targetVariable: op.targetVariable,
-      functionName: op.functionName,
-    });
+    return yield* missingTarget(op.targetVariable, op.functionName);
   }
 
   const call = findCallExpression(initializer.value, op.functionName);
@@ -252,10 +253,7 @@ const applyTsAppendCallArg = Effect.fn("applyTsAppendCallArg")(function* (
     return;
   }
 
-  return yield* new TargetNotFoundError({
-    targetVariable: op.targetVariable,
-    functionName: op.functionName,
-  });
+  return yield* missingTarget(op.targetVariable, op.functionName);
 });
 
 const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
@@ -264,10 +262,7 @@ const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
 ) {
   const initializer = getTargetInitializer(sourceFile, op.targetVariable);
   if (Option.isNone(initializer)) {
-    return yield* new TargetNotFoundError({
-      targetVariable: op.targetVariable,
-      functionName: op.functionName,
-    });
+    return yield* missingTarget(op.targetVariable, op.functionName);
   }
 
   const addFieldToCall = (call: CallExpression): boolean => {
@@ -297,11 +292,16 @@ const applyTsObjectField = Effect.fn("applyTsObjectField")(function* (
     return;
   }
 
-  return yield* new TargetNotFoundError({
-    targetVariable: op.targetVariable,
-    functionName: op.functionName,
-  });
+  return yield* missingTarget(op.targetVariable, op.functionName);
 });
+
+const missingTarget = (targetVariable: string, functionName: string) =>
+  Effect.fail(
+    new ApplyFailure({
+      reason: "repoRootInvalid",
+      message: `Could not find ${functionName} on ${targetVariable} during TypeScript composition.`,
+    }),
+  );
 
 const applyTsJsxSlot = (
   sourceFile: SourceFile,

--- a/packages/scaffold/src/service/apply/WriteEngine.ts
+++ b/packages/scaffold/src/service/apply/WriteEngine.ts
@@ -7,12 +7,27 @@ export type ApplyWriteRequest = {
   readonly writeMode: "create" | "modify" | "override";
 };
 
-type ApplyWriteOutcome = {
+export type ApplyWriteOutcome = {
   readonly path: string;
   readonly status: "created" | "modified" | "unchanged";
 };
 
-export class WriteEngine extends Context.Service<WriteEngine>()("WriteEngine", {
+type InspectedPath =
+  | { readonly _tag: "missing" }
+  | { readonly _tag: "directory" }
+  | { readonly _tag: "file"; readonly contents: string };
+
+export interface WriteEngineShape {
+  readonly write: (input: {
+    readonly repoRoot: string;
+    readonly write: ApplyWriteRequest;
+  }) => Effect.Effect<ApplyWriteOutcome, ApplyFailure, never>;
+}
+
+export class WriteEngine extends Context.Service<
+  WriteEngine,
+  WriteEngineShape
+>()("WriteEngine", {
   make: Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -58,15 +73,18 @@ export class WriteEngine extends Context.Service<WriteEngine>()("WriteEngine", {
     };
 
     const inspect = Effect.fn("WriteEngine.inspect")(function* (path: string) {
-      const pathStat = yield* fileSystem
-        .stat(path)
-        .pipe(
-          Effect.catch((error) =>
-            error.reason._tag === "NotFound"
-              ? Effect.succeed(null)
-              : Effect.fail(error),
-          ),
-        );
+      const pathStat = yield* fileSystem.stat(path).pipe(
+        Effect.catch((error) =>
+          error.reason._tag === "NotFound"
+            ? Effect.succeed(null)
+            : Effect.fail(
+                new ApplyFailure({
+                  reason: "repoRootInvalid",
+                  message: `Could not inspect ${path} during apply: ${error.message}`,
+                }),
+              ),
+        ),
+      );
 
       if (pathStat === null) {
         return {
@@ -80,13 +98,49 @@ export class WriteEngine extends Context.Service<WriteEngine>()("WriteEngine", {
         };
       }
 
-      const contents = yield* fileSystem.readFileString(path);
+      const contents = yield* fileSystem.readFileString(path).pipe(
+        Effect.mapError(
+          (error) =>
+            new ApplyFailure({
+              reason: "repoRootInvalid",
+              message: `Could not read ${path} during apply: ${error.message}`,
+            }),
+        ),
+      );
 
       return {
         _tag: "file" as const,
         contents,
-      };
+      } satisfies InspectedPath;
     });
+
+    const validateWriteMode = Effect.fn("WriteEngine.validateWriteMode")(
+      function* (write: ApplyWriteRequest, existingPath: InspectedPath) {
+        return yield* Match.value(write.writeMode).pipe(
+          Match.when("create", () =>
+            existingPath._tag === "missing"
+              ? Effect.void
+              : Effect.fail(
+                  new ApplyFailure({
+                    reason: "repoRootInvalid",
+                    message: `Expected ${write.path} to be missing for create apply mode.`,
+                  }),
+                ),
+          ),
+          Match.whenOr("modify", "override", () =>
+            existingPath._tag === "file"
+              ? Effect.void
+              : Effect.fail(
+                  new ApplyFailure({
+                    reason: "repoRootInvalid",
+                    message: `Expected ${write.path} to be an existing file for ${write.writeMode} apply mode.`,
+                  }),
+                ),
+          ),
+          Match.exhaustive,
+        );
+      },
+    );
 
     const write = Effect.fn("WriteEngine.write")(function* ({
       repoRoot,
@@ -99,25 +153,7 @@ export class WriteEngine extends Context.Service<WriteEngine>()("WriteEngine", {
 
       const existingPath = yield* inspect(absolutePath);
 
-      Match.value(write.writeMode).pipe(
-        Match.when("create", () => {
-          if (existingPath._tag !== "missing") {
-            throw new ApplyFailure({
-              reason: "repoRootInvalid",
-              message: `Expected ${write.path} to be missing for create apply mode.`,
-            });
-          }
-        }),
-        Match.whenOr("modify", "override", () => {
-          if (existingPath._tag !== "file") {
-            throw new ApplyFailure({
-              reason: "repoRootInvalid",
-              message: `Expected ${write.path} to be an existing file for ${write.writeMode} apply mode.`,
-            });
-          }
-        }),
-        Match.exhaustive,
-      );
+      yield* validateWriteMode(write, existingPath);
 
       if (
         existingPath._tag === "file" &&
@@ -129,9 +165,19 @@ export class WriteEngine extends Context.Service<WriteEngine>()("WriteEngine", {
         } satisfies ApplyWriteOutcome;
       }
 
-      yield* fileSystem.makeDirectory(path.dirname(absolutePath), {
-        recursive: true,
-      });
+      yield* fileSystem
+        .makeDirectory(path.dirname(absolutePath), {
+          recursive: true,
+        })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new ApplyFailure({
+                reason: "executionFailure",
+                message: `Could not create directory ${path.dirname(absolutePath)} during apply: ${error.message}`,
+              }),
+          ),
+        );
 
       yield* atomicWrite({
         path: absolutePath,
@@ -144,7 +190,7 @@ export class WriteEngine extends Context.Service<WriteEngine>()("WriteEngine", {
       } satisfies ApplyWriteOutcome;
     });
 
-    return { write } as const;
+    return { write } satisfies WriteEngineShape;
   }),
 }) {
   static readonly layer = Layer.effect(WriteEngine)(WriteEngine.make);

--- a/packages/scaffold/src/service/plan/PlanService.test.ts
+++ b/packages/scaffold/src/service/plan/PlanService.test.ts
@@ -12,6 +12,7 @@ import { StackConfig } from "@repo/domain/Scaffold";
 import { Cause, Effect, Exit, Layer } from "effect";
 import { ContributionResolver } from "./ContributionResolver";
 import { PlanAssessor } from "./PlanAssessor";
+import { PlanningIntentCompiler } from "./PlanningIntentCompiler";
 import { PlanService } from "./PlanService";
 import { RepoSnapshotService } from "./RepoSnapshotService";
 
@@ -171,6 +172,7 @@ const makePlanServiceLayer = (
 ) =>
   Layer.effect(PlanService)(PlanService.make).pipe(
     Layer.provide(ContributionResolver.layer),
+    Layer.provide(PlanningIntentCompiler.layer),
     Layer.provide(makeRepoSnapshotServiceLayer(load)),
     Layer.provide(PlanAssessor.layer),
   );

--- a/packages/scaffold/src/service/plan/PlanService.ts
+++ b/packages/scaffold/src/service/plan/PlanService.ts
@@ -1,33 +1,37 @@
 import { CatalogService } from "@repo/catalog";
 import type { Blueprint } from "@repo/domain/Blueprint";
-import { Contribution } from "@repo/domain/Catalog";
+import type { CatalogNotFound } from "@repo/domain/Catalog";
 import { Plan, PlanFailure, type RepoSnapshot } from "@repo/domain/Plan";
-import type {
-  NormalizedContributions,
-  StackConfig,
-} from "@repo/domain/Scaffold";
-import {
-  Array as Arr,
-  Context,
-  Effect,
-  Layer,
-  Match,
-  Option,
-  pipe,
-  Record,
-  Schema,
-} from "effect";
+import type { StackConfig } from "@repo/domain/Scaffold";
+import { Array as Arr, Context, Effect, Layer, Option, pipe } from "effect";
 import { ContributionResolver } from "./ContributionResolver";
 import {
   collectAncestorPaths,
   PlanAssessor,
   type PlanningIntentPath,
 } from "./PlanAssessor";
+import { PlanningIntentCompiler } from "./PlanningIntentCompiler";
 import { RepoSnapshotService } from "./RepoSnapshotService";
 
-export class PlanService extends Context.Service<PlanService>()("PlanService", {
+export type PlanServiceBuildInput = {
+  readonly blueprint: typeof Blueprint.Type;
+  readonly repoRoot: string;
+  readonly config: typeof StackConfig.Type;
+};
+
+export interface PlanServiceShape {
+  readonly build: (
+    input: PlanServiceBuildInput,
+  ) => Effect.Effect<typeof Plan.Type, PlanFailure | CatalogNotFound, never>;
+}
+
+export class PlanService extends Context.Service<
+  PlanService,
+  PlanServiceShape
+>()("PlanService", {
   make: Effect.gen(function* () {
     const contribute = yield* ContributionResolver;
+    const compiler = yield* PlanningIntentCompiler;
     const snapshot = yield* RepoSnapshotService;
     const assessor = yield* PlanAssessor;
 
@@ -35,18 +39,12 @@ export class PlanService extends Context.Service<PlanService>()("PlanService", {
       blueprint,
       repoRoot,
       config,
-    }: {
-      blueprint: typeof Blueprint.Type;
-      repoRoot: string;
-      config: typeof StackConfig.Type;
-    }) {
+    }: PlanServiceBuildInput) {
       const normalizedContributions = yield* contribute.resolve(
         blueprint,
         config,
       );
-      const planningPaths = yield* compilePlanningPaths(
-        normalizedContributions,
-      );
+      const planningPaths = yield* compiler.compile(normalizedContributions);
 
       const repoSnapshot = yield* snapshot.load({
         paths: Arr.fromIterable(
@@ -60,7 +58,7 @@ export class PlanService extends Context.Service<PlanService>()("PlanService", {
         repoRoot,
       });
 
-      return projectPlan({ planningPaths, repoSnapshot });
+      return yield* projectPlan({ planningPaths, repoSnapshot });
     });
 
     const projectPlan = ({
@@ -69,621 +67,72 @@ export class PlanService extends Context.Service<PlanService>()("PlanService", {
     }: {
       planningPaths: ReadonlyArray<PlanningIntentPath>;
       repoSnapshot: typeof RepoSnapshot.Type;
-    }) => {
-      const snapshotPaths = new Map(
-        Arr.map(
-          repoSnapshot.paths,
-          (snapshotPath) => [snapshotPath.path, snapshotPath] as const,
-        ),
-      );
-
-      const assertAncestorDirectories = (path: string) =>
-        pipe(
-          Arr.findFirst(
-            collectAncestorPaths(path),
-            (ancestorPath) => snapshotPaths.get(ancestorPath)?._tag === "file",
+    }) =>
+      Effect.gen(function* () {
+        const snapshotPaths = new Map(
+          Arr.map(
+            repoSnapshot.paths,
+            (snapshotPath) => [snapshotPath.path, snapshotPath] as const,
           ),
-          Option.match({
-            onNone: () => {},
-            onSome: (blockedAncestorPath) => {
-              throw new PlanFailure({
-                reason: "repoRootNotEmpty",
-                message: `Expected ${blockedAncestorPath} to be a directory during planning.`,
-              });
-            },
-          }),
         );
 
-      const assessedPaths = Arr.map(planningPaths, (planningPath) => {
-        assertAncestorDirectories(planningPath.path);
+        const assertAncestorDirectories = (path: string) =>
+          pipe(
+            Arr.findFirst(
+              collectAncestorPaths(path),
+              (ancestorPath) =>
+                snapshotPaths.get(ancestorPath)?._tag === "file",
+            ),
+            Option.match({
+              onNone: () => Effect.void,
+              onSome: (blockedAncestorPath) =>
+                Effect.fail(
+                  new PlanFailure({
+                    reason: "repoRootNotEmpty",
+                    message: `Expected ${blockedAncestorPath} to be a directory during planning.`,
+                  }),
+                ),
+            }),
+          );
 
-        return {
-          planningPath,
-          assessment: assessor.assessPlanningPath({
-            planningPath,
-            snapshotPath: snapshotPaths.get(planningPath.path),
-          }),
-        } as const;
+        const assessedPaths = yield* Effect.forEach(
+          planningPaths,
+          (planningPath) =>
+            Effect.gen(function* () {
+              yield* assertAncestorDirectories(planningPath.path);
+
+              return {
+                planningPath,
+                assessment: assessor.assessPlanningPath({
+                  planningPath,
+                  snapshotPath: snapshotPaths.get(planningPath.path),
+                }),
+              } as const;
+            }),
+        );
+
+        return new Plan({
+          outcomes: Arr.map(assessedPaths, ({ planningPath, assessment }) =>
+            assessor.toPlannedFileOutcome({
+              planningPath,
+              classification: assessment.classification,
+            }),
+          ),
+          conflicts: Arr.flatMap(
+            assessedPaths,
+            ({ assessment }) => assessment.conflicts,
+          ),
+        }).toSorted();
       });
 
-      return new Plan({
-        outcomes: Arr.map(assessedPaths, ({ planningPath, assessment }) =>
-          assessor.toPlannedFileOutcome({
-            planningPath,
-            classification: assessment.classification,
-          }),
-        ),
-        conflicts: Arr.flatMap(
-          assessedPaths,
-          ({ assessment }) => assessment.conflicts,
-        ),
-      }).toSorted();
-    };
-
-    return { build } as const;
+    return { build } satisfies PlanServiceShape;
   }),
 }) {
   static readonly layer = Layer.effect(PlanService)(PlanService.make).pipe(
     Layer.provide(ContributionResolver.layer),
+    Layer.provide(PlanningIntentCompiler.layer),
     Layer.provide(RepoSnapshotService.layer),
     Layer.provide(PlanAssessor.layer),
     Layer.provide(CatalogService.layer),
   );
 }
-
-const compilePlanningPaths = (
-  normalizedContributions: typeof NormalizedContributions.Type,
-) => {
-  const entriesByPath = Arr.groupBy(
-    Arr.flatMap(
-      [
-        ...Arr.map(
-          normalizedContributions.targets,
-          (entry) => entry.contributions,
-        ),
-        ...Arr.map(
-          normalizedContributions.modules,
-          (entry) => entry.contributions,
-        ),
-      ],
-      toPlanningIntentEntries,
-    ),
-    (entry) => entry.path,
-  );
-
-  return Effect.all(
-    Record.collect(entriesByPath, (path, entries) =>
-      derivePlanningIntentPath({ path, entries }),
-    ),
-  );
-};
-
-export const PlanningIntentEntry = Schema.TaggedUnion({
-  authoritative: {
-    path: Schema.String,
-    contents: Schema.String,
-    conflictOnModify: Schema.Boolean,
-  },
-  packageJsonEntry: {
-    path: Schema.String,
-    field: Schema.Literals([
-      "exports",
-      "dependencies",
-      "devDependencies",
-      "scripts",
-    ]),
-    name: Schema.String,
-    value: Schema.String,
-  },
-  barrelExport: {
-    path: Schema.String,
-    exportPath: Schema.String,
-  },
-  tsCallArg: {
-    path: Schema.String,
-    targetVariable: Schema.String,
-    functionName: Schema.String,
-    argument: Schema.String,
-    import: Schema.Struct({
-      moduleSpecifier: Schema.String,
-      namedImports: Schema.Union([
-        Schema.Array(Schema.String),
-        Schema.Undefined,
-      ]),
-      defaultImport: Schema.Union([Schema.String, Schema.Undefined]),
-      namespaceImport: Schema.Union([Schema.String, Schema.Undefined]),
-    }),
-  },
-  tsObjectField: {
-    path: Schema.String,
-    targetVariable: Schema.String,
-    functionName: Schema.String,
-    field: Schema.String,
-    value: Schema.String,
-    import: Schema.Union([
-      Schema.Struct({
-        moduleSpecifier: Schema.String,
-        namedImports: Schema.Union([
-          Schema.Array(Schema.String),
-          Schema.Undefined,
-        ]),
-        defaultImport: Schema.Union([Schema.String, Schema.Undefined]),
-        namespaceImport: Schema.Union([Schema.String, Schema.Undefined]),
-      }),
-      Schema.Undefined,
-    ]),
-  },
-  jsxSlot: {
-    path: Schema.String,
-    slotId: Schema.String,
-    content: Schema.String,
-    import: Schema.Union([
-      Schema.Struct({
-        moduleSpecifier: Schema.String,
-        namedImports: Schema.Union([
-          Schema.Array(Schema.String),
-          Schema.Undefined,
-        ]),
-        defaultImport: Schema.Union([Schema.String, Schema.Undefined]),
-        namespaceImport: Schema.Union([Schema.String, Schema.Undefined]),
-      }),
-      Schema.Undefined,
-    ]),
-  },
-});
-
-const toPlanningIntentEntries = (
-  contributions: ReadonlyArray<typeof Contribution.Type>,
-): ReadonlyArray<typeof PlanningIntentEntry.Type> =>
-  Arr.flatMap(
-    contributions,
-    Contribution.match({
-      file: (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
-        PlanningIntentEntry.cases.authoritative.make({
-          path: c.path,
-          contents: c.contents,
-          conflictOnModify: c.conflictOnModify ?? false,
-        }),
-      ],
-      "pkg-json-entry": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
-        PlanningIntentEntry.cases.packageJsonEntry.make({
-          path: c.path,
-          field: c.field,
-          name: c.name,
-          value: c.value,
-        }),
-      ],
-      "barrel-export": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
-        PlanningIntentEntry.cases.barrelExport.make({
-          path: c.barrelPath,
-          exportPath: c.exportPath,
-        }),
-      ],
-      "ts-call-arg": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
-        PlanningIntentEntry.cases.tsCallArg.make({
-          path: c.path,
-          targetVariable: c.targetVariable,
-          functionName: c.functionName,
-          argument: c.argument,
-          import: {
-            moduleSpecifier: c.import.moduleSpecifier,
-            namedImports: c.import.namedImports,
-            defaultImport: c.import.defaultImport,
-            namespaceImport: c.import.namespaceImport,
-          },
-        }),
-      ],
-      "ts-object-field": (
-        c,
-      ): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
-        PlanningIntentEntry.cases.tsObjectField.make({
-          path: c.path,
-          targetVariable: c.targetVariable,
-          functionName: c.functionName,
-          field: c.field,
-          value: c.value,
-          import: c.import
-            ? {
-                moduleSpecifier: c.import.moduleSpecifier,
-                namedImports: c.import.namedImports,
-                defaultImport: c.import.defaultImport,
-                namespaceImport: c.import.namespaceImport,
-              }
-            : undefined,
-        }),
-      ],
-      "jsx-slot": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
-        PlanningIntentEntry.cases.jsxSlot.make({
-          path: c.path,
-          slotId: c.slotId,
-          content: c.content,
-          import: c.import
-            ? {
-                moduleSpecifier: c.import.moduleSpecifier,
-                namedImports: c.import.namedImports,
-                defaultImport: c.import.defaultImport,
-                namespaceImport: c.import.namespaceImport,
-              }
-            : undefined,
-        }),
-      ],
-    }),
-  );
-
-const derivePlanningIntentPath = ({
-  path,
-  entries,
-}: {
-  path: string;
-  entries: ReadonlyArray<typeof PlanningIntentEntry.Type>;
-}) =>
-  Effect.gen(function* () {
-    const family = yield* derivePlanningIntentFamily({ entries, path });
-    const authoritativeEntries = entries.filter(
-      PlanningIntentEntry.guards.authoritative,
-    );
-    const packageJsonEntries = entries.filter(
-      PlanningIntentEntry.guards.packageJsonEntry,
-    );
-    const barrelExportEntries = entries.filter(
-      PlanningIntentEntry.guards.barrelExport,
-    );
-    const tsCallArgEntries = entries.filter(
-      PlanningIntentEntry.guards.tsCallArg,
-    );
-    const tsObjectFieldEntries = entries.filter(
-      PlanningIntentEntry.guards.tsObjectField,
-    );
-    const jsxSlotEntries = entries.filter(PlanningIntentEntry.guards.jsxSlot);
-
-    const resolveContents = () =>
-      requireSingleValue({
-        values: Arr.map(authoritativeEntries, (entry) => entry.contents),
-        errorMessage: `Conflicting authoritative file outcomes for ${path}.`,
-      });
-
-    const resolveConflictOnModify = () =>
-      authoritativeEntries.length > 0 &&
-      authoritativeEntries.some((e) => e.conflictOnModify);
-
-    const resolvePackageJsonFields = () => {
-      type PackageJsonCase =
-        typeof PlanningIntentEntry.cases.packageJsonEntry.Type;
-
-      const exportEntries = packageJsonEntries.filter(
-        (e): e is PackageJsonCase & { field: "exports" } =>
-          e.field === "exports",
-      );
-      const depEntries = packageJsonEntries.filter(
-        (
-          e,
-        ): e is PackageJsonCase & {
-          field: "dependencies" | "devDependencies";
-        } => e.field === "dependencies" || e.field === "devDependencies",
-      );
-      const scriptEntries = packageJsonEntries.filter(
-        (e): e is PackageJsonCase & { field: "scripts" } =>
-          e.field === "scripts",
-      );
-
-      return Effect.all({
-        exports: collectUniqueEntries({
-          entries: exportEntries,
-          keyOf: (entry) => entry.name,
-          valueOf: (entry) => entry.value,
-          toResult: (entry) => ({ name: entry.name, value: entry.value }),
-          errorMessage: `Conflicting package.json export outcomes for ${path}.`,
-        }),
-        dependencies: collectUniqueEntries({
-          entries: depEntries,
-          keyOf: (entry) => `${entry.field}:${entry.name}`,
-          valueOf: (entry) => entry.value,
-          toResult: (entry) => ({
-            section: entry.field,
-            name: entry.name,
-            value: entry.value,
-          }),
-          errorMessage: `Conflicting package.json dependency outcomes for ${path}.`,
-        }),
-        scripts: collectUniqueEntries({
-          entries: scriptEntries,
-          keyOf: (entry) => entry.name,
-          valueOf: (entry) => entry.value,
-          toResult: (entry) => ({ name: entry.name, value: entry.value }),
-          errorMessage: `Conflicting package.json script outcomes for ${path}.`,
-        }),
-      });
-    };
-
-    const emptyPackageJsonFields = {
-      exports: [],
-      dependencies: [],
-      scripts: [],
-    };
-
-    return yield* Match.value(family).pipe(
-      Match.when("authoritative", () =>
-        Effect.gen(function* () {
-          const contents = yield* resolveContents();
-          const isConflictOnModify = resolveConflictOnModify();
-          return {
-            path,
-            contents: isConflictOnModify ? undefined : contents,
-            ...emptyPackageJsonFields,
-            barrelExports: [],
-            compositions: [],
-            objectFields: [],
-            jsxSlots: [],
-            tsconfig: isConflictOnModify ? { path, contents } : undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("packageJson", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: undefined,
-            ...(yield* resolvePackageJsonFields()),
-            barrelExports: [],
-            compositions: [],
-            objectFields: [],
-            jsxSlots: [],
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("barrel", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: undefined,
-            ...emptyPackageJsonFields,
-            barrelExports: yield* collectUniqueEntries({
-              entries: barrelExportEntries,
-              keyOf: (entry) => entry.exportPath,
-              valueOf: (entry) => entry.exportPath,
-              toResult: (entry) => ({ exportPath: entry.exportPath }),
-              errorMessage: `Conflicting barrel export outcomes for ${path}.`,
-            }),
-            compositions: [],
-            objectFields: [],
-            jsxSlots: [],
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("tsCallArg", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: undefined,
-            ...emptyPackageJsonFields,
-            barrelExports: [],
-            compositions: Arr.map(tsCallArgEntries, (entry) => ({
-              targetVariable: entry.targetVariable,
-              functionName: entry.functionName,
-              argument: entry.argument,
-              import: entry.import,
-            })),
-            objectFields: Arr.map(tsObjectFieldEntries, (entry) => ({
-              targetVariable: entry.targetVariable,
-              functionName: entry.functionName,
-              field: entry.field,
-              value: entry.value,
-              import: entry.import,
-            })),
-            jsxSlots: [],
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("jsxSlot", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: undefined,
-            ...emptyPackageJsonFields,
-            barrelExports: [],
-            compositions: [],
-            objectFields: [],
-            jsxSlots: Arr.map(jsxSlotEntries, (entry) => ({
-              slotId: entry.slotId,
-              content: entry.content,
-              import: entry.import,
-            })),
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("authoritativePackageJson", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: yield* resolveContents(),
-            ...(yield* resolvePackageJsonFields()),
-            barrelExports: [],
-            compositions: [],
-            objectFields: [],
-            jsxSlots: [],
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("authoritativeTsCallArg", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: yield* resolveContents(),
-            ...emptyPackageJsonFields,
-            barrelExports: [],
-            compositions: Arr.map(tsCallArgEntries, (entry) => ({
-              targetVariable: entry.targetVariable,
-              functionName: entry.functionName,
-              argument: entry.argument,
-              import: entry.import,
-            })),
-            objectFields: Arr.map(tsObjectFieldEntries, (entry) => ({
-              targetVariable: entry.targetVariable,
-              functionName: entry.functionName,
-              field: entry.field,
-              value: entry.value,
-              import: entry.import,
-            })),
-            jsxSlots: [],
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("authoritativeBarrel", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: yield* resolveContents(),
-            ...emptyPackageJsonFields,
-            barrelExports: yield* collectUniqueEntries({
-              entries: barrelExportEntries,
-              keyOf: (entry) => entry.exportPath,
-              valueOf: (entry) => entry.exportPath,
-              toResult: (entry) => ({ exportPath: entry.exportPath }),
-              errorMessage: `Conflicting barrel export outcomes for ${path}.`,
-            }),
-            compositions: [],
-            objectFields: [],
-            jsxSlots: [],
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.when("authoritativeJsxSlot", () =>
-        Effect.gen(function* () {
-          return {
-            path,
-            contents: yield* resolveContents(),
-            ...emptyPackageJsonFields,
-            barrelExports: [],
-            compositions: [],
-            objectFields: [],
-            jsxSlots: Arr.map(jsxSlotEntries, (entry) => ({
-              slotId: entry.slotId,
-              content: entry.content,
-              import: entry.import,
-            })),
-            tsconfig: undefined,
-          } satisfies PlanningIntentPath;
-        }),
-      ),
-      Match.exhaustive,
-    );
-  });
-
-type CompositePlanningIntentFamily =
-  | "authoritativePackageJson"
-  | "authoritativeTsCallArg"
-  | "authoritativeBarrel"
-  | "authoritativeJsxSlot";
-
-const COMPOSITE_FAMILIES: ReadonlyArray<{
-  pair: [PlanningIntentFamily, PlanningIntentFamily];
-  result: CompositePlanningIntentFamily;
-}> = [
-  {
-    pair: ["authoritative", "packageJson"],
-    result: "authoritativePackageJson",
-  },
-  { pair: ["authoritative", "tsCallArg"], result: "authoritativeTsCallArg" },
-  { pair: ["authoritative", "barrel"], result: "authoritativeBarrel" },
-  { pair: ["authoritative", "jsxSlot"], result: "authoritativeJsxSlot" },
-];
-
-const derivePlanningIntentFamily = ({
-  entries,
-  path,
-}: {
-  entries: ReadonlyArray<typeof PlanningIntentEntry.Type>;
-  path: string;
-}) => {
-  const families = new Set(Arr.map(entries, toPlanningIntentFamily));
-
-  if (families.size === 1) {
-    // biome-ignore lint/style/noNonNullAssertion: entries is non-empty when families.size === 1
-    return Effect.succeed(toPlanningIntentFamily(entries[0]!));
-  }
-
-  if (families.size === 2) {
-    const match = COMPOSITE_FAMILIES.find(
-      ({ pair }) => families.has(pair[0]) && families.has(pair[1]),
-    );
-    if (match) {
-      return Effect.succeed(match.result);
-    }
-  }
-
-  return Effect.fail(
-    new PlanFailure({
-      reason: "invalidPlanIntent",
-      message: `Conflicting planning intents for ${path}.`,
-    }),
-  );
-};
-
-type PlanningIntentFamily =
-  | "authoritative"
-  | "packageJson"
-  | "barrel"
-  | "tsCallArg"
-  | "jsxSlot";
-
-const toPlanningIntentFamily = PlanningIntentEntry.match({
-  authoritative: () => "authoritative" as const,
-  packageJsonEntry: () => "packageJson" as const,
-  barrelExport: () => "barrel" as const,
-  tsCallArg: () => "tsCallArg" as const,
-  tsObjectField: () => "tsCallArg" as const,
-  jsxSlot: () => "jsxSlot" as const,
-}) satisfies (entry: typeof PlanningIntentEntry.Type) => PlanningIntentFamily;
-
-const requireSingleValue = <Value>({
-  values,
-  errorMessage,
-}: {
-  values: ReadonlyArray<Value>;
-  errorMessage: string;
-}) => {
-  const firstValue = values[0];
-
-  if (
-    firstValue !== undefined &&
-    Arr.every(values, (value) => value === firstValue)
-  ) {
-    return Effect.succeed(firstValue);
-  }
-
-  return Effect.fail(
-    new PlanFailure({
-      reason: "invalidPlanIntent",
-      message: errorMessage,
-    }),
-  );
-};
-
-const collectUniqueEntries = <Entry, Result>({
-  entries,
-  keyOf,
-  valueOf,
-  toResult,
-  errorMessage,
-}: {
-  entries: ReadonlyArray<Entry>;
-  keyOf: (entry: Entry) => string;
-  valueOf: (entry: Entry) => string;
-  toResult: (entry: Entry) => Result;
-  errorMessage: string;
-}) =>
-  Effect.all(
-    Record.collect(Arr.groupBy(entries, keyOf), (_, groupedEntries) =>
-      requireSingleValue({
-        values: Arr.map(groupedEntries, valueOf),
-        errorMessage,
-      }).pipe(Effect.as(toResult(groupedEntries[0]!))),
-    ),
-  );

--- a/packages/scaffold/src/service/plan/PlanningIntentCompiler.ts
+++ b/packages/scaffold/src/service/plan/PlanningIntentCompiler.ts
@@ -1,0 +1,635 @@
+import { Contribution } from "@repo/domain/Catalog";
+import { PlanFailure } from "@repo/domain/Plan";
+import type { NormalizedContributions } from "@repo/domain/Scaffold";
+import {
+  Array as Arr,
+  Context,
+  Effect,
+  Layer,
+  Match,
+  Option,
+  pipe,
+  Record,
+  Schema,
+} from "effect";
+import type { PlanningIntentPath } from "./PlanAssessor";
+
+export interface PlanningIntentCompilerShape {
+  readonly compile: (
+    normalizedContributions: typeof NormalizedContributions.Type,
+  ) => Effect.Effect<ReadonlyArray<PlanningIntentPath>, PlanFailure, never>;
+}
+
+export class PlanningIntentCompiler extends Context.Service<
+  PlanningIntentCompiler,
+  PlanningIntentCompilerShape
+>()("PlanningIntentCompiler", {
+  make: Effect.succeed({
+    compile,
+  } satisfies PlanningIntentCompilerShape),
+}) {
+  static readonly layer = Layer.effect(
+    PlanningIntentCompiler,
+    PlanningIntentCompiler.make,
+  ).pipe(Layer.satisfiesServicesType<never>());
+}
+
+function compile(normalizedContributions: typeof NormalizedContributions.Type) {
+  const entriesByPath = Arr.groupBy(
+    Arr.flatMap(
+      [
+        ...Arr.map(
+          normalizedContributions.targets,
+          (entry) => entry.contributions,
+        ),
+        ...Arr.map(
+          normalizedContributions.modules,
+          (entry) => entry.contributions,
+        ),
+      ],
+      toPlanningIntentEntries,
+    ),
+    (entry) => entry.path,
+  );
+
+  return Effect.all(
+    Record.collect(entriesByPath, (path, entries) =>
+      derivePlanningIntentPath({ path, entries }),
+    ),
+  );
+}
+
+const PlanningIntentEntry = Schema.TaggedUnion({
+  authoritative: {
+    path: Schema.String,
+    contents: Schema.String,
+    conflictOnModify: Schema.Boolean,
+  },
+  packageJsonEntry: {
+    path: Schema.String,
+    field: Schema.Literals([
+      "exports",
+      "dependencies",
+      "devDependencies",
+      "scripts",
+    ]),
+    name: Schema.String,
+    value: Schema.String,
+  },
+  barrelExport: {
+    path: Schema.String,
+    exportPath: Schema.String,
+  },
+  tsCallArg: {
+    path: Schema.String,
+    targetVariable: Schema.String,
+    functionName: Schema.String,
+    argument: Schema.String,
+    import: Schema.Struct({
+      moduleSpecifier: Schema.String,
+      namedImports: Schema.Union([
+        Schema.Array(Schema.String),
+        Schema.Undefined,
+      ]),
+      defaultImport: Schema.Union([Schema.String, Schema.Undefined]),
+      namespaceImport: Schema.Union([Schema.String, Schema.Undefined]),
+    }),
+  },
+  tsObjectField: {
+    path: Schema.String,
+    targetVariable: Schema.String,
+    functionName: Schema.String,
+    field: Schema.String,
+    value: Schema.String,
+    import: Schema.Union([
+      Schema.Struct({
+        moduleSpecifier: Schema.String,
+        namedImports: Schema.Union([
+          Schema.Array(Schema.String),
+          Schema.Undefined,
+        ]),
+        defaultImport: Schema.Union([Schema.String, Schema.Undefined]),
+        namespaceImport: Schema.Union([Schema.String, Schema.Undefined]),
+      }),
+      Schema.Undefined,
+    ]),
+  },
+  jsxSlot: {
+    path: Schema.String,
+    slotId: Schema.String,
+    content: Schema.String,
+    import: Schema.Union([
+      Schema.Struct({
+        moduleSpecifier: Schema.String,
+        namedImports: Schema.Union([
+          Schema.Array(Schema.String),
+          Schema.Undefined,
+        ]),
+        defaultImport: Schema.Union([Schema.String, Schema.Undefined]),
+        namespaceImport: Schema.Union([Schema.String, Schema.Undefined]),
+      }),
+      Schema.Undefined,
+    ]),
+  },
+});
+
+const toPlanningIntentEntries = (
+  contributions: ReadonlyArray<typeof Contribution.Type>,
+): ReadonlyArray<typeof PlanningIntentEntry.Type> =>
+  Arr.flatMap(
+    contributions,
+    Contribution.match({
+      file: (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
+        PlanningIntentEntry.cases.authoritative.make({
+          path: c.path,
+          contents: c.contents,
+          conflictOnModify: c.conflictOnModify ?? false,
+        }),
+      ],
+      "pkg-json-entry": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
+        PlanningIntentEntry.cases.packageJsonEntry.make({
+          path: c.path,
+          field: c.field,
+          name: c.name,
+          value: c.value,
+        }),
+      ],
+      "barrel-export": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
+        PlanningIntentEntry.cases.barrelExport.make({
+          path: c.barrelPath,
+          exportPath: c.exportPath,
+        }),
+      ],
+      "ts-call-arg": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
+        PlanningIntentEntry.cases.tsCallArg.make({
+          path: c.path,
+          targetVariable: c.targetVariable,
+          functionName: c.functionName,
+          argument: c.argument,
+          import: {
+            moduleSpecifier: c.import.moduleSpecifier,
+            namedImports: c.import.namedImports,
+            defaultImport: c.import.defaultImport,
+            namespaceImport: c.import.namespaceImport,
+          },
+        }),
+      ],
+      "ts-object-field": (
+        c,
+      ): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
+        PlanningIntentEntry.cases.tsObjectField.make({
+          path: c.path,
+          targetVariable: c.targetVariable,
+          functionName: c.functionName,
+          field: c.field,
+          value: c.value,
+          import: c.import
+            ? {
+                moduleSpecifier: c.import.moduleSpecifier,
+                namedImports: c.import.namedImports,
+                defaultImport: c.import.defaultImport,
+                namespaceImport: c.import.namespaceImport,
+              }
+            : undefined,
+        }),
+      ],
+      "jsx-slot": (c): ReadonlyArray<typeof PlanningIntentEntry.Type> => [
+        PlanningIntentEntry.cases.jsxSlot.make({
+          path: c.path,
+          slotId: c.slotId,
+          content: c.content,
+          import: c.import
+            ? {
+                moduleSpecifier: c.import.moduleSpecifier,
+                namedImports: c.import.namedImports,
+                defaultImport: c.import.defaultImport,
+                namespaceImport: c.import.namespaceImport,
+              }
+            : undefined,
+        }),
+      ],
+    }),
+  );
+
+type PlanningIntentEntryGroups = {
+  readonly authoritative: ReadonlyArray<
+    typeof PlanningIntentEntry.cases.authoritative.Type
+  >;
+  readonly packageJson: ReadonlyArray<
+    typeof PlanningIntentEntry.cases.packageJsonEntry.Type
+  >;
+  readonly barrel: ReadonlyArray<
+    typeof PlanningIntentEntry.cases.barrelExport.Type
+  >;
+  readonly tsCallArg: ReadonlyArray<
+    typeof PlanningIntentEntry.cases.tsCallArg.Type
+  >;
+  readonly tsObjectField: ReadonlyArray<
+    typeof PlanningIntentEntry.cases.tsObjectField.Type
+  >;
+  readonly jsxSlot: ReadonlyArray<
+    typeof PlanningIntentEntry.cases.jsxSlot.Type
+  >;
+};
+
+const groupPlanningIntentEntries = (
+  entries: ReadonlyArray<typeof PlanningIntentEntry.Type>,
+): PlanningIntentEntryGroups => ({
+  authoritative: entries.filter(PlanningIntentEntry.guards.authoritative),
+  packageJson: entries.filter(PlanningIntentEntry.guards.packageJsonEntry),
+  barrel: entries.filter(PlanningIntentEntry.guards.barrelExport),
+  tsCallArg: entries.filter(PlanningIntentEntry.guards.tsCallArg),
+  tsObjectField: entries.filter(PlanningIntentEntry.guards.tsObjectField),
+  jsxSlot: entries.filter(PlanningIntentEntry.guards.jsxSlot),
+});
+
+const emptyPackageJsonFields = {
+  exports: [],
+  dependencies: [],
+  scripts: [],
+};
+
+const emptyCompositionFields = {
+  barrelExports: [],
+  compositions: [],
+  objectFields: [],
+  jsxSlots: [],
+};
+
+const makePlanningIntentPath = ({
+  path,
+  contents,
+  packageJsonFields = emptyPackageJsonFields,
+  barrelExports = [],
+  compositions = [],
+  objectFields = [],
+  jsxSlots = [],
+  tsconfig,
+}: {
+  readonly path: string;
+  readonly contents: string | undefined;
+  readonly packageJsonFields?: Pick<
+    PlanningIntentPath,
+    "exports" | "dependencies" | "scripts"
+  >;
+  readonly barrelExports?: PlanningIntentPath["barrelExports"];
+  readonly compositions?: PlanningIntentPath["compositions"];
+  readonly objectFields?: PlanningIntentPath["objectFields"];
+  readonly jsxSlots?: PlanningIntentPath["jsxSlots"];
+  readonly tsconfig: PlanningIntentPath["tsconfig"];
+}): PlanningIntentPath => ({
+  path,
+  contents,
+  ...packageJsonFields,
+  barrelExports,
+  compositions,
+  objectFields,
+  jsxSlots,
+  tsconfig,
+});
+
+const derivePlanningIntentPath = ({
+  path,
+  entries,
+}: {
+  path: string;
+  entries: ReadonlyArray<typeof PlanningIntentEntry.Type>;
+}) =>
+  Effect.gen(function* () {
+    const family = yield* derivePlanningIntentFamily({ entries, path });
+    const groups = groupPlanningIntentEntries(entries);
+
+    const resolveContents = () =>
+      requireSingleValue({
+        values: Arr.map(groups.authoritative, (entry) => entry.contents),
+        errorMessage: `Conflicting authoritative file outcomes for ${path}.`,
+      });
+
+    const resolveConflictOnModify = () =>
+      groups.authoritative.length > 0 &&
+      groups.authoritative.some((e) => e.conflictOnModify);
+
+    const resolvePackageJsonFields = () => {
+      type PackageJsonCase =
+        typeof PlanningIntentEntry.cases.packageJsonEntry.Type;
+
+      const exportEntries = groups.packageJson.filter(
+        (e): e is PackageJsonCase & { field: "exports" } =>
+          e.field === "exports",
+      );
+      const depEntries = groups.packageJson.filter(
+        (
+          e,
+        ): e is PackageJsonCase & {
+          field: "dependencies" | "devDependencies";
+        } => e.field === "dependencies" || e.field === "devDependencies",
+      );
+      const scriptEntries = groups.packageJson.filter(
+        (e): e is PackageJsonCase & { field: "scripts" } =>
+          e.field === "scripts",
+      );
+
+      return Effect.all({
+        exports: collectUniqueEntries({
+          entries: exportEntries,
+          keyOf: (entry) => entry.name,
+          valueOf: (entry) => entry.value,
+          toResult: (entry) => ({ name: entry.name, value: entry.value }),
+          errorMessage: `Conflicting package.json export outcomes for ${path}.`,
+        }),
+        dependencies: collectUniqueEntries({
+          entries: depEntries,
+          keyOf: (entry) => `${entry.field}:${entry.name}`,
+          valueOf: (entry) => entry.value,
+          toResult: (entry) => ({
+            section: entry.field,
+            name: entry.name,
+            value: entry.value,
+          }),
+          errorMessage: `Conflicting package.json dependency outcomes for ${path}.`,
+        }),
+        scripts: collectUniqueEntries({
+          entries: scriptEntries,
+          keyOf: (entry) => entry.name,
+          valueOf: (entry) => entry.value,
+          toResult: (entry) => ({ name: entry.name, value: entry.value }),
+          errorMessage: `Conflicting package.json script outcomes for ${path}.`,
+        }),
+      });
+    };
+
+    const collectBarrelExports = () =>
+      collectUniqueEntries({
+        entries: groups.barrel,
+        keyOf: (entry) => entry.exportPath,
+        valueOf: (entry) => entry.exportPath,
+        toResult: (entry) => ({ exportPath: entry.exportPath }),
+        errorMessage: `Conflicting barrel export outcomes for ${path}.`,
+      });
+
+    const toCompositions = () =>
+      Arr.map(groups.tsCallArg, (entry) => ({
+        targetVariable: entry.targetVariable,
+        functionName: entry.functionName,
+        argument: entry.argument,
+        import: entry.import,
+      }));
+
+    const toObjectFields = () =>
+      Arr.map(groups.tsObjectField, (entry) => ({
+        targetVariable: entry.targetVariable,
+        functionName: entry.functionName,
+        field: entry.field,
+        value: entry.value,
+        import: entry.import,
+      }));
+
+    const toJsxSlots = () =>
+      Arr.map(groups.jsxSlot, (entry) => ({
+        slotId: entry.slotId,
+        content: entry.content,
+        import: entry.import,
+      }));
+
+    return yield* Match.value(family).pipe(
+      Match.when("authoritative", () =>
+        Effect.gen(function* () {
+          const contents = yield* resolveContents();
+          const isConflictOnModify = resolveConflictOnModify();
+
+          return makePlanningIntentPath({
+            path,
+            contents: isConflictOnModify ? undefined : contents,
+            ...emptyCompositionFields,
+            tsconfig: isConflictOnModify ? { path, contents } : undefined,
+          });
+        }),
+      ),
+      Match.when("packageJson", () =>
+        Effect.gen(function* () {
+          return makePlanningIntentPath({
+            path,
+            contents: undefined,
+            packageJsonFields: yield* resolvePackageJsonFields(),
+            ...emptyCompositionFields,
+            tsconfig: undefined,
+          });
+        }),
+      ),
+      Match.when("barrel", () =>
+        Effect.gen(function* () {
+          return makePlanningIntentPath({
+            path,
+            contents: undefined,
+            barrelExports: yield* collectBarrelExports(),
+            tsconfig: undefined,
+          });
+        }),
+      ),
+      Match.when("tsCallArg", () =>
+        Effect.succeed(
+          makePlanningIntentPath({
+            path,
+            contents: undefined,
+            compositions: toCompositions(),
+            objectFields: toObjectFields(),
+            tsconfig: undefined,
+          }),
+        ),
+      ),
+      Match.when("jsxSlot", () =>
+        Effect.succeed(
+          makePlanningIntentPath({
+            path,
+            contents: undefined,
+            jsxSlots: toJsxSlots(),
+            tsconfig: undefined,
+          }),
+        ),
+      ),
+      Match.when("authoritativePackageJson", () =>
+        Effect.gen(function* () {
+          return makePlanningIntentPath({
+            path,
+            contents: yield* resolveContents(),
+            packageJsonFields: yield* resolvePackageJsonFields(),
+            ...emptyCompositionFields,
+            tsconfig: undefined,
+          });
+        }),
+      ),
+      Match.when("authoritativeTsCallArg", () =>
+        Effect.gen(function* () {
+          return makePlanningIntentPath({
+            path,
+            contents: yield* resolveContents(),
+            compositions: toCompositions(),
+            objectFields: toObjectFields(),
+            tsconfig: undefined,
+          });
+        }),
+      ),
+      Match.when("authoritativeBarrel", () =>
+        Effect.gen(function* () {
+          return makePlanningIntentPath({
+            path,
+            contents: yield* resolveContents(),
+            barrelExports: yield* collectBarrelExports(),
+            tsconfig: undefined,
+          });
+        }),
+      ),
+      Match.when("authoritativeJsxSlot", () =>
+        Effect.gen(function* () {
+          return makePlanningIntentPath({
+            path,
+            contents: yield* resolveContents(),
+            jsxSlots: toJsxSlots(),
+            tsconfig: undefined,
+          });
+        }),
+      ),
+      Match.exhaustive,
+    );
+  });
+
+type CompositePlanningIntentFamily =
+  | "authoritativePackageJson"
+  | "authoritativeTsCallArg"
+  | "authoritativeBarrel"
+  | "authoritativeJsxSlot";
+
+const COMPOSITE_FAMILIES: ReadonlyArray<{
+  pair: [PlanningIntentFamily, PlanningIntentFamily];
+  result: CompositePlanningIntentFamily;
+}> = [
+  {
+    pair: ["authoritative", "packageJson"],
+    result: "authoritativePackageJson",
+  },
+  { pair: ["authoritative", "tsCallArg"], result: "authoritativeTsCallArg" },
+  { pair: ["authoritative", "barrel"], result: "authoritativeBarrel" },
+  { pair: ["authoritative", "jsxSlot"], result: "authoritativeJsxSlot" },
+];
+
+const derivePlanningIntentFamily = ({
+  entries,
+  path,
+}: {
+  entries: ReadonlyArray<typeof PlanningIntentEntry.Type>;
+  path: string;
+}) => {
+  const families = new Set(Arr.map(entries, toPlanningIntentFamily));
+
+  if (families.size === 1) {
+    return pipe(
+      Arr.head(entries),
+      Option.match({
+        onNone: () =>
+          Effect.fail(
+            new PlanFailure({
+              reason: "invalidPlanIntent",
+              message: `No planning intents found for ${path}.`,
+            }),
+          ),
+        onSome: (entry) => Effect.succeed(toPlanningIntentFamily(entry)),
+      }),
+    );
+  }
+
+  if (families.size === 2) {
+    const match = COMPOSITE_FAMILIES.find(
+      ({ pair }) => families.has(pair[0]) && families.has(pair[1]),
+    );
+    if (match) {
+      return Effect.succeed(match.result);
+    }
+  }
+
+  return Effect.fail(
+    new PlanFailure({
+      reason: "invalidPlanIntent",
+      message: `Conflicting planning intents for ${path}.`,
+    }),
+  );
+};
+
+type PlanningIntentFamily =
+  | "authoritative"
+  | "packageJson"
+  | "barrel"
+  | "tsCallArg"
+  | "jsxSlot";
+
+const toPlanningIntentFamily = PlanningIntentEntry.match({
+  authoritative: () => "authoritative" as const,
+  packageJsonEntry: () => "packageJson" as const,
+  barrelExport: () => "barrel" as const,
+  tsCallArg: () => "tsCallArg" as const,
+  tsObjectField: () => "tsCallArg" as const,
+  jsxSlot: () => "jsxSlot" as const,
+}) satisfies (entry: typeof PlanningIntentEntry.Type) => PlanningIntentFamily;
+
+const requireSingleValue = <Value>({
+  values,
+  errorMessage,
+}: {
+  values: ReadonlyArray<Value>;
+  errorMessage: string;
+}) =>
+  pipe(
+    Arr.head(values),
+    Option.match({
+      onNone: () =>
+        Effect.fail(
+          new PlanFailure({
+            reason: "invalidPlanIntent",
+            message: errorMessage,
+          }),
+        ),
+      onSome: (firstValue) =>
+        Arr.every(values, (value) => value === firstValue)
+          ? Effect.succeed(firstValue)
+          : Effect.fail(
+              new PlanFailure({
+                reason: "invalidPlanIntent",
+                message: errorMessage,
+              }),
+            ),
+    }),
+  );
+
+const collectUniqueEntries = <Entry, Result>({
+  entries,
+  keyOf,
+  valueOf,
+  toResult,
+  errorMessage,
+}: {
+  entries: ReadonlyArray<Entry>;
+  keyOf: (entry: Entry) => string;
+  valueOf: (entry: Entry) => string;
+  toResult: (entry: Entry) => Result;
+  errorMessage: string;
+}) =>
+  Effect.all(
+    Record.collect(Arr.groupBy(entries, keyOf), (_, groupedEntries) =>
+      pipe(
+        Arr.head(groupedEntries),
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new PlanFailure({
+                reason: "invalidPlanIntent",
+                message: errorMessage,
+              }),
+            ),
+          onSome: (firstEntry) =>
+            requireSingleValue({
+              values: Arr.map(groupedEntries, valueOf),
+              errorMessage,
+            }).pipe(Effect.as(toResult(firstEntry))),
+        }),
+      ),
+    ),
+  );


### PR DESCRIPTION
## Goals/Scope

Use the new skills to help consolidate down the patters when using Service from effect

## Description

- Refactored the **Plan** service layer to improve structure and maintainability.
- Refactored the **Apply** service layer to improve structure and maintainability.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #169 
- <kbd>&nbsp;2&nbsp;</kbd> #168 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #165 
<!-- GitButler Footer Boundary Bottom -->

