### PR TITLE
feat: extract DevTool out into its own module for each target

### DIFF
--- a/.changeset/dark-crabs-doubt.md
+++ b/.changeset/dark-crabs-doubt.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+Extract DevTools into its own module for each target

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -44,7 +44,7 @@ export const cliTsconfigContents = `{
  * Additional subcommands are added by modules.
  */
 export const cliIndexContents = `import { BunRuntime, BunServices } from "@effect/platform-bun";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { Command } from "effect/unstable/cli";
 
 const root = Command.make("{{packageName}}");
@@ -52,11 +52,38 @@ const root = Command.make("{{packageName}}");
 // NOTE: Modules inject additional subcommands through Command.withSubcommands.
 const AllCommands = Command.withSubcommands([]);
 
+// NOTE: Modules append additional runtime layers through Layer.mergeAll.
+const RuntimeLayers = Layer.mergeAll(BunServices.layer);
+
 root.pipe(
   AllCommands,
   Command.run({ version: "0.0.0" }),
-  Effect.provide(BunServices.layer),
+  Effect.provide(RuntimeLayers),
   BunRuntime.runMain,
+);
+`;
+
+export const cliDevToolsContents = `import { Config, Effect, Layer } from "effect";
+import { DevTools } from "effect/unstable/devtools";
+
+const DevToolsConfig = Config.all({
+  enableDevTools: Config.boolean("DEVTOOLS").pipe(Config.withDefault(false)),
+  devToolsUrl: Config.string("DEVTOOLS_URL").pipe(
+    Config.withDefault("ws://localhost:34437"),
+  ),
+});
+
+export const DevToolsLive = Layer.unwrap(
+  Effect.gen(function* () {
+    const config = yield* DevToolsConfig;
+
+    if (!config.enableDevTools) {
+      return Layer.empty;
+    }
+
+    yield* Effect.logDebug("Enabling DevTools Layer");
+    return DevTools.layer(config.devToolsUrl);
+  }),
 );
 `;
 

--- a/packages/catalog/src/registry/content/client-api.ts
+++ b/packages/catalog/src/registry/content/client-api.ts
@@ -1,18 +1,10 @@
 export const clientHelloAtomContents = `import { Api } from "@repo/domain/Api";
-import { Effect, Layer } from "effect";
-import { DevTools } from "effect/unstable/devtools";
+import { Effect } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { HttpApiClient } from "effect/unstable/httpapi";
-import { Atom } from "effect/unstable/reactivity";
+import { runtime } from "../atom";
 
 const SERVER_URL = import.meta.env.VITE_SERVER_URL || "http://localhost:9000";
-const ENABLE_DEVTOOLS = import.meta.env.VITE_ENABLE_DEVTOOLS === "true";
-
-const ApiLayer = Layer.mergeAll(
-  ENABLE_DEVTOOLS ? DevTools.layer() : Layer.empty,
-);
-
-const runtime = Atom.runtime(ApiLayer);
 
 export const helloAtom = runtime.fn(() =>
   Effect.gen(function* () {

--- a/packages/catalog/src/registry/content/client-chat.ts
+++ b/packages/catalog/src/registry/content/client-chat.ts
@@ -31,20 +31,19 @@ export class ChatRpcClient extends Context.Service<ChatRpcClient>()("ChatRpcClie
 // Client chat atom (uses ChatRpcClient instead of RpcClient)
 export const clientChatAtomContents = `import { ChatStreamPart, type ChatId, type ChatMessage, type ChatResponse, type ToolCall } from "@repo/domain/Chat";
 import { Effect, Stream } from "effect";
-import { Atom, type Atom as AtomType } from "effect/unstable/reactivity";
+import type { Atom as AtomType } from "effect/unstable/reactivity";
+import { runtime } from "../atom";
 import { ChatRpcClient } from "../chat-rpc-client";
-
-const chatRuntime = Atom.runtime(ChatRpcClient.layer);
 
 export const chatStartAtom: AtomType.AtomResultFn<
   void,
   { readonly chatId: ChatId },
   unknown
-> = chatRuntime.fn(() =>
+> = runtime.fn(() =>
   Effect.gen(function* () {
     const rpc = yield* ChatRpcClient;
     return yield* rpc.client.chat_start();
-  }),
+  }).pipe(Effect.provide(ChatRpcClient.layer)),
 );
 
 export const accumulateChatResponse = (
@@ -185,12 +184,12 @@ export const chatAtom: AtomType.AtomResultFn<
   },
   ChatResponse,
   unknown
-> = chatRuntime.fn(({ chatId, messages }) => {
+> = runtime.fn(({ chatId, messages }) => {
   return Stream.unwrap(
     Effect.gen(function* () {
       const rpc = yield* ChatRpcClient;
       return rpc.client.chat_ask({ chatId, messages });
-    }),
+    }).pipe(Effect.provide(ChatRpcClient.layer)),
   ).pipe(
     Stream.tapError((error: unknown) =>
       Effect.logError("[chatAtom] Stream error occurred:", error),

--- a/packages/catalog/src/registry/content/client-foldkit.ts
+++ b/packages/catalog/src/registry/content/client-foldkit.ts
@@ -137,7 +137,7 @@ export const foldkitStylesContents = `@import "tailwindcss";
 
 export const foldkitEntryContents = `import { Runtime } from "foldkit";
 
-import { init, Message, Model, subscriptions, update, view } from "./main";
+import { init, Model, subscriptions, update, view } from "./main";
 
 const program = Runtime.makeProgram({
   Model,
@@ -146,12 +146,16 @@ const program = Runtime.makeProgram({
   view,
   subscriptions,
   container: document.getElementById("root"),
-  devTools: {
-    Message,
-  },
 });
 
 Runtime.run(program);
+`;
+
+export const foldkitDevToolsContents = `import { Message } from "./main";
+
+export const devTools = {
+  Message,
+};
 `;
 
 export const foldkitMainContents = `import { Effect, Match as M, Schema as S } from "effect";

--- a/packages/catalog/src/registry/content/client-rpc.ts
+++ b/packages/catalog/src/registry/content/client-rpc.ts
@@ -29,19 +29,9 @@ export class RpcClient extends Context.Service<RpcClient>()("RpcClient", {
 `;
 
 export const clientTickAtomContents = `import type { TickEvent } from "@repo/domain/Rpc";
-import { Effect, Layer, Stream } from "effect";
-import { DevTools } from "effect/unstable/devtools";
-import { Atom } from "effect/unstable/reactivity";
+import { Effect, Stream } from "effect";
+import { runtime } from "../atom";
 import { RpcClient } from "../rpc-client";
-
-const ENABLE_DEVTOOLS = import.meta.env.VITE_ENABLE_DEVTOOLS === "true";
-
-const RpcLayer = Layer.mergeAll(
-  RpcClient.layer,
-  ENABLE_DEVTOOLS ? DevTools.layer() : Layer.empty,
-);
-
-const runtime = Atom.runtime(RpcLayer);
 
 export const tickAtom = runtime.fn(
   ({ abort = false }: { readonly abort?: boolean }) =>
@@ -50,7 +40,10 @@ export const tickAtom = runtime.fn(
         yield* Effect.logDebug("Starting Tick Atom Stream");
         const rpc = yield* RpcClient;
         return rpc.client.tick({ ticks: 10 });
-      }).pipe((self) => (abort ? Effect.interrupt : self)),
+      }).pipe(
+        Effect.provide(RpcClient.layer),
+        (self) => (abort ? Effect.interrupt : self),
+      ),
     ).pipe(
       Stream.catchTags({
         RpcClientError: (e) => Stream.die(e),

--- a/packages/catalog/src/registry/content/client.ts
+++ b/packages/catalog/src/registry/content/client.ts
@@ -315,14 +315,23 @@ export const clientIndexCssContents = `@import "tailwindcss";
 `;
 
 export const clientAtomContents = `import { Layer } from "effect";
-import { DevTools } from "effect/unstable/devtools";
 import { Atom } from "effect/unstable/reactivity";
 
-const ENABLE_DEVTOOLS = import.meta.env.VITE_ENABLE_DEVTOOLS === "true";
+// NOTE: Modules append additional runtime layers through Layer.mergeAll.
+const RuntimeLayer = Layer.mergeAll(Layer.empty);
 
-export const runtime = Atom.runtime(
-  ENABLE_DEVTOOLS ? DevTools.layer() : Layer.empty,
-);
+export const runtime = Atom.runtime(RuntimeLayer);
+`;
+
+export const clientDevToolsContents = `import { Layer } from "effect";
+import { DevTools } from "effect/unstable/devtools";
+
+export const DevToolsLive =
+  import.meta.env.VITE_ENABLE_DEVTOOLS === "true"
+    ? DevTools.layer(
+        import.meta.env.VITE_DEVTOOLS_URL || "ws://localhost:34437",
+      )
+    : Layer.empty;
 `;
 
 export const clientThemeToggleContents = `import { useLayoutEffect, useState } from "react";
@@ -378,6 +387,7 @@ interface ImportMetaEnv {
   readonly VITE_SERVER_URL: string;
   readonly VITE_WS_URL: string;
   readonly VITE_ENABLE_DEVTOOLS: string;
+  readonly VITE_DEVTOOLS_URL?: string;
 }
 
 interface ImportMeta {

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -37,27 +37,24 @@ export const serverTsconfigContents = `{
  * This is a minimal server template that includes:
  * - Basic HTTP server with CORS
  * - HTTP API router with Health and Hello endpoints
- * - DevTools support (optional)
  *
  * Additional capabilities (RPC, WebSocket) are added by modules.
  */
 export const serverIndexContents = `import { BunHttpServer, BunRuntime } from "@effect/platform-bun";
 import { Api } from "@repo/domain/Api";
 import { Config, Effect, Layer } from "effect";
-import { DevTools } from "effect/unstable/devtools";
 import { HttpRouter, HttpServer } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { HealthGroupLive } from "./Api/Health";
 import { HelloGroupLive } from "./Api/Hello";
 
-const ServerConfig = Config.all({
+export const ServerConfig = Config.all({
   port: Config.number("PORT").pipe(Config.withDefault(9000)),
   hostname: Config.string("HOST").pipe(Config.withDefault("0.0.0.0")),
   idleTimeout: Config.number("IDLE_TIMEOUT").pipe(Config.withDefault(120)),
   allowedOrigins: Config.string("ALLOWED_ORIGINS").pipe(
     Config.withDefault("http://localhost:3000"),
   ),
-  enableDevTools: Config.boolean("DEVTOOLS").pipe(Config.withDefault(false)),
 });
 
 // HTTP API Router
@@ -71,14 +68,8 @@ const AllRouters = Layer.mergeAll(ApiRouter).pipe(
   Layer.provide(RouterDependencies),
 );
 
-const DevToolsLive = Effect.gen(function* () {
-  const config = yield* ServerConfig;
-  if (!config.enableDevTools) {
-    return Layer.empty;
-  }
-  yield* Effect.logDebug("Enabling DevTools Layer");
-  return DevTools.layer();
-}).pipe(Layer.unwrap);
+// NOTE: Modules append additional server layers through Layer.mergeAll.
+const ServerLayers = Layer.mergeAll(BunHttpServer.layerConfig(ServerConfig));
 
 const HttpLive = Effect.gen(function* () {
   const config = yield* ServerConfig;
@@ -101,10 +92,33 @@ const HttpLive = Effect.gen(function* () {
 
   return HttpRouter.serve(CorsRouters).pipe(
     HttpServer.withLogAddress,
-    Layer.provideMerge(DevToolsLive),
-    Layer.provideMerge(BunHttpServer.layerConfig(ServerConfig)),
+    Layer.provideMerge(ServerLayers),
   );
 }).pipe(Layer.unwrap, Layer.launch);
 
 BunRuntime.runMain(HttpLive);
+`;
+
+export const serverDevToolsContents = `import { Config, Effect, Layer } from "effect";
+import { DevTools } from "effect/unstable/devtools";
+
+const DevToolsConfig = Config.all({
+  enableDevTools: Config.boolean("DEVTOOLS").pipe(Config.withDefault(false)),
+  devToolsUrl: Config.string("DEVTOOLS_URL").pipe(
+    Config.withDefault("ws://localhost:34437"),
+  ),
+});
+
+export const DevToolsLive = Layer.unwrap(
+  Effect.gen(function* () {
+    const config = yield* DevToolsConfig;
+
+    if (!config.enableDevTools) {
+      return Layer.empty;
+    }
+
+    yield* Effect.logDebug("Enabling DevTools Layer");
+    return DevTools.layer(config.devToolsUrl);
+  }),
+);
 `;

--- a/packages/catalog/src/registry/modules/cli.ts
+++ b/packages/catalog/src/registry/modules/cli.ts
@@ -7,6 +7,7 @@ import {
 import {
   cliAskCommandContents,
   cliChatDriverContents,
+  cliDevToolsContents,
   cliHelloCommandContents,
   cliTerminalChatCommandContents,
   cliTerminalChatContents,
@@ -160,6 +161,31 @@ export const cliModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         import: {
           moduleSpecifier: "./commands/chat",
           namedImports: ["chat"],
+        },
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("cli-devtools"),
+    title: "Effect DevTools CLI",
+    description: "Optional Effect DevTools tracer layer for CLI apps",
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("cli") }],
+    dependencies: [],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/observability/DevTools.ts",
+        contents: cliDevToolsContents,
+      },
+      {
+        _tag: "ts-call-arg",
+        path: "{{targetPath}}/src/index.ts",
+        targetVariable: "RuntimeLayers",
+        functionName: "Layer.mergeAll",
+        argument: "DevToolsLive",
+        import: {
+          moduleSpecifier: "./observability/DevTools",
+          namedImports: ["DevToolsLive"],
         },
       },
     ],

--- a/packages/catalog/src/registry/modules/client-foldkit.ts
+++ b/packages/catalog/src/registry/modules/client-foldkit.ts
@@ -4,6 +4,7 @@ import {
   TargetIdentity,
   TargetKind,
 } from "@repo/domain/Catalog";
+import { foldkitDevToolsContents } from "../content/client-foldkit";
 import { foldkitRestFeatureContents } from "../content/client-foldkit-api";
 import {
   foldkitChatClientContents,
@@ -37,6 +38,32 @@ const updateCaseValue = (namespace: string, modelField: string) =>
 
 export const clientFoldkitModules: ReadonlyArray<typeof ModuleDefinition.Type> =
   [
+    {
+      id: ModuleId.make("client-foldkit-devtools"),
+      title: "Foldkit DevTools",
+      description: "Optional Foldkit runtime devtools for message inspection",
+      supportedOn: [{ _tag: "kind", kind: foldkitKind }],
+      dependencies: [],
+      contributions: [
+        {
+          _tag: "file",
+          path: "{{targetPath}}/src/devtools.ts",
+          contents: foldkitDevToolsContents,
+        },
+        {
+          _tag: "ts-object-field",
+          path: "{{targetPath}}/src/entry.ts",
+          targetVariable: "program",
+          functionName: "Runtime.makeProgram",
+          field: "devTools",
+          value: "devTools",
+          import: {
+            moduleSpecifier: "./devtools",
+            namedImports: ["devTools"],
+          },
+        },
+      ],
+    },
     {
       id: ModuleId.make("client-foldkit-http-api"),
       title: "HTTP API Client (Foldkit)",

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -4,6 +4,7 @@ import {
   TargetIdentity,
   TargetKind,
 } from "@repo/domain/Catalog";
+import { clientDevToolsContents } from "../content/client";
 import {
   clientHelloAtomContents,
   clientRestCardContents,
@@ -281,6 +282,31 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       {
         label: "Install shadcn card component",
         command: "bunx shadcn@latest add card --yes --overwrite",
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("client-react-devtools"),
+    title: "Effect DevTools React Client",
+    description: "Optional Effect DevTools tracer layer for React atom runtime",
+    supportedOn: [{ _tag: "kind", kind: clientReactKind }],
+    dependencies: [],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/lib/devtools.ts",
+        contents: clientDevToolsContents,
+      },
+      {
+        _tag: "ts-call-arg",
+        path: "{{targetPath}}/src/lib/atom.ts",
+        targetVariable: "RuntimeLayer",
+        functionName: "Layer.mergeAll",
+        argument: "DevToolsLive",
+        import: {
+          moduleSpecifier: "./devtools",
+          namedImports: ["DevToolsLive"],
+        },
       },
     ],
   },

--- a/packages/catalog/src/registry/modules/server.ts
+++ b/packages/catalog/src/registry/modules/server.ts
@@ -13,6 +13,7 @@ import {
   serverChatSessionsContents,
 } from "../content/chat";
 import { serverTickContents } from "../content/rpc";
+import { serverDevToolsContents } from "../content/server";
 import { serverPresenceContents } from "../content/websocket";
 
 const serverKind = TargetKind.make("server");
@@ -262,6 +263,31 @@ export const serverModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         import: {
           moduleSpecifier: "./Rpc/Presence",
           namedImports: ["PresenceRpcLive"],
+        },
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("server-devtools"),
+    title: "Effect DevTools Server",
+    description: "Optional Effect DevTools tracer layer for server apps",
+    supportedOn: [{ _tag: "kind", kind: serverKind }],
+    dependencies: [],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/observability/DevTools.ts",
+        contents: serverDevToolsContents,
+      },
+      {
+        _tag: "ts-call-arg",
+        path: "{{targetPath}}/src/index.ts",
+        targetVariable: "ServerLayers",
+        functionName: "Layer.mergeAll",
+        argument: "DevToolsLive",
+        import: {
+          moduleSpecifier: "./observability/DevTools",
+          namedImports: ["DevToolsLive"],
         },
       },
     ],


### PR DESCRIPTION
## Goals/Scope

Extract `DevTool` into its own dedicated module per target.

## Description

- Refactor: split `DevTool` implementation into separate per-target modules.
- Improve maintainability by isolating target-specific logic/configuration.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #169 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #168 
- <kbd>&nbsp;1&nbsp;</kbd> #165 
<!-- GitButler Footer Boundary Bottom -->

