### PR TITLE
refactor: use new shadcn message and marker componens for ChatBox

### DIFF
--- a/.changeset/rich-geckos-lay.md
+++ b/.changeset/rich-geckos-lay.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+fix RPC chat stream lifetime by providing the client layer across the full stream

--- a/.changeset/seven-webs-dress.md
+++ b/.changeset/seven-webs-dress.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+fix the Foldkit Vite plugin import to use the named `foldkit` export

--- a/.changeset/shaggy-tigers-tickle.md
+++ b/.changeset/shaggy-tigers-tickle.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+use the shadcn components for messages and markers for the ChatBox

--- a/packages/catalog/src/registry/content/chat.ts
+++ b/packages/catalog/src/registry/content/chat.ts
@@ -295,12 +295,10 @@ export class ChatRuntime extends Context.Service<ChatRuntime>()("ChatRuntime", {
     const generate = (messages: ReadonlyArray<ChatMessage>) =>
       Stream.unwrap(
         Effect.gen(function* () {
-          const queue = yield* chat
-            .chat(messages.map(toPromptMessage))
-            .pipe(Effect.provide(FastModelLive), Effect.orDie);
+          const queue = yield* chat.chat(messages.map(toPromptMessage));
           return Stream.fromQueue(queue);
         }),
-      );
+      ).pipe(Stream.provide(FastModelLive), Stream.orDie);
 
     return {
       start: sessions.start,

--- a/packages/catalog/src/registry/content/client-chat.ts
+++ b/packages/catalog/src/registry/content/client-chat.ts
@@ -29,7 +29,13 @@ export class ChatRpcClient extends Context.Service<ChatRpcClient>()("ChatRpcClie
 `;
 
 // Client chat atom (uses ChatRpcClient instead of RpcClient)
-export const clientChatAtomContents = `import { ChatStreamPart, type ChatId, type ChatMessage, type ChatResponse, type ToolCall } from "@repo/domain/Chat";
+export const clientChatAtomContents = `import {
+  type ChatId,
+  type ChatMessage,
+  type ChatResponse,
+  ChatStreamPart,
+  type ToolCall,
+} from "@repo/domain/Chat";
 import { Effect, Stream } from "effect";
 import type { Atom as AtomType } from "effect/unstable/reactivity";
 import { runtime } from "../atom";
@@ -90,7 +96,7 @@ export const accumulateChatResponse = (
         _tag: "streaming",
         segments: currentSegments,
         reasoning:
-          (state._tag === "streaming" ? state.reasoning ?? "" : "") +
+          (state._tag === "streaming" ? (state.reasoning ?? "") : "") +
           part.delta,
       };
     },
@@ -103,29 +109,31 @@ export const accumulateChatResponse = (
           ...currentSegments,
           {
             _tag: "tool-call",
-                  tool: {
-                    id: part.id,
-                    name: part.name,
-                    status: "running",
-                    ...(part.input === undefined ? {} : { input: part.input }),
-                  },
-                },
+            tool: {
+              id: part.id,
+              name: part.name,
+              status: "running",
+              ...(part.input === undefined ? {} : { input: part.input }),
+            },
+          },
         ],
         reasoning: state._tag === "streaming" ? state.reasoning : undefined,
       };
     },
 
-    "tool-success": (part) => updateToolResult(state, {
-      id: part.id,
-      status: "complete",
-      result: part.output,
-    }),
+    "tool-success": (part) =>
+      updateToolResult(state, {
+        id: part.id,
+        status: "complete",
+        result: part.output,
+      }),
 
-    "tool-failure": (part) => updateToolResult(state, {
-      id: part.id,
-      status: "failed",
-      result: part.error,
-    }),
+    "tool-failure": (part) =>
+      updateToolResult(state, {
+        id: part.id,
+        status: "failed",
+        result: part.error,
+      }),
 
     finish: (part) => {
       const segments = state._tag === "streaming" ? state.segments : [];
@@ -159,22 +167,22 @@ const updateToolResult = (
     result: string;
   },
 ): ChatResponse => {
-      if (state._tag !== "streaming") return state;
-      return {
-        ...state,
-        segments: state.segments.map((seg) =>
-          seg._tag === "tool-call" && seg.tool.id === update.id
-            ? {
-                ...seg,
-                tool: {
-                  ...seg.tool,
-                  status: update.status,
-                  result: update.result,
-                },
-              }
-            : seg,
-        ),
-      };
+  if (state._tag !== "streaming") return state;
+  return {
+    ...state,
+    segments: state.segments.map((seg) =>
+      seg._tag === "tool-call" && seg.tool.id === update.id
+        ? {
+            ...seg,
+            tool: {
+              ...seg.tool,
+              status: update.status,
+              result: update.result,
+            },
+          }
+        : seg,
+    ),
+  };
 };
 
 export const chatAtom: AtomType.AtomResultFn<
@@ -189,8 +197,9 @@ export const chatAtom: AtomType.AtomResultFn<
     Effect.gen(function* () {
       const rpc = yield* ChatRpcClient;
       return rpc.client.chat_ask({ chatId, messages });
-    }).pipe(Effect.provide(ChatRpcClient.layer)),
+    }),
   ).pipe(
+    Stream.provide(ChatRpcClient.layer),
     Stream.tapError((error: unknown) =>
       Effect.logError("[chatAtom] Stream error occurred:", error),
     ),
@@ -222,15 +231,37 @@ export const chatAtom: AtomType.AtomResultFn<
 
 export const clientChatBoxContents = `import { useAtom } from "@effect/atom-react";
 import type { ChatId, ChatResponse, MessageSegment } from "@repo/domain/Chat";
+import { Cause } from "effect";
 import { AsyncResult } from "effect/unstable/reactivity";
+import {
+  CircleAlertIcon,
+  CircleCheckIcon,
+  LoaderCircleIcon,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { chatAtom, chatStartAtom } from "@/lib/atoms/chat-atom";
-import { cn } from "@/lib/utils";
+import { Bubble, BubbleContent } from "@/components/ui/bubble";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Marker, MarkerContent, MarkerIcon } from "@/components/ui/marker";
+import {
+  Message,
+  MessageContent,
+  MessageFooter,
+  MessageGroup,
+} from "@/components/ui/message";
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from "@/components/ui/message-scroller";
+import { chatAtom, chatStartAtom } from "@/lib/atoms/chat-atom";
 
-type Message = {
+type ChatEntry = {
+  id: string;
   role: "user" | "assistant" | "system";
   message: string;
   segments?: readonly MessageSegment[];
@@ -244,13 +275,14 @@ type Message = {
   finishReason?: string | undefined;
 };
 
+const EMPTY_SEGMENTS: readonly MessageSegment[] = [];
+
 export function ChatBox() {
   const [result, runChat] = useAtom(chatAtom);
   const [startResult, startChat] = useAtom(chatStartAtom);
   const [chatId, setChatId] = useState<ChatId | null>(null);
   const [input, setInput] = useState("");
-  const [history, setHistory] = useState<Message[]>([]);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [history, setHistory] = useState<ChatEntry[]>([]);
   const lastSentMessagesRef = useRef<
     Array<{
       role: "user" | "assistant" | "system";
@@ -269,12 +301,18 @@ export function ChatBox() {
   );
 
   const currentSegments =
-    currentResult._tag === "initial" ? [] : currentResult.segments;
+    currentResult._tag === "initial" ? EMPTY_SEGMENTS : currentResult.segments;
 
   const isWaiting = AsyncResult.isWaiting(result);
   const isStarting = AsyncResult.isWaiting(startResult);
   const isFailure = AsyncResult.isFailure(result);
   const isStreaming = currentResult._tag === "streaming";
+  const asyncFailureMessage = isFailure ? Cause.pretty(result.cause) : null;
+
+  useEffect(() => {
+    if (!asyncFailureMessage) return;
+    console.error("[ChatBox] chat atom failed", asyncFailureMessage);
+  }, [asyncFailureMessage]);
 
   useEffect(() => {
     const started = AsyncResult.getOrElse(startResult, () => null);
@@ -325,7 +363,11 @@ export function ChatBox() {
 
   const handleSend = () => {
     if (!input.trim()) return;
-    const userMsg: Message = { role: "user", message: input };
+    const userMsg: ChatEntry = {
+      id: crypto.randomUUID(),
+      role: "user",
+      message: input,
+    };
     setHistory((prev) => [...prev, userMsg]);
     setInput("");
 
@@ -333,25 +375,18 @@ export function ChatBox() {
     sendMessages(messages);
   };
 
-  const streamingMessage = useMemo<Message | null>(() => {
-    if (currentResult._tag !== "streaming") return null;
-    if (currentSegments.length === 0) return null;
-    return {
-      role: "assistant",
-      message: "",
-      segments: currentSegments,
-    };
-  }, [currentResult._tag, currentSegments]);
-
-  const displayHistory = useMemo(() => {
-    if (!streamingMessage) return history;
-    return [...history, streamingMessage];
-  }, [history, streamingMessage]);
-
-  const scrollTrigger = useMemo(
-    () => \`\${displayHistory.length}-\${currentSegments.length}\`,
-    [displayHistory.length, currentSegments.length],
-  );
+  const displayHistory =
+    currentResult._tag === "streaming" && currentResult.segments.length > 0
+      ? [
+          ...history,
+          {
+            id: \`streaming-\${chatId ?? "pending"}\`,
+            role: "assistant" as const,
+            message: "",
+            segments: currentResult.segments,
+          },
+        ]
+      : history;
 
   const completionSnapshot = useMemo(() => {
     if (currentResult._tag !== "complete") return null;
@@ -371,6 +406,7 @@ export function ChatBox() {
     setHistory((prev) => [
       ...prev,
       {
+        id: crypto.randomUUID(),
         role: "assistant",
         message: "",
         segments: completionSnapshot.segments,
@@ -380,148 +416,135 @@ export function ChatBox() {
     ]);
   }, [completionSnapshot]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scrollTrigger is stable string
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    container.scrollTo({
-      top: container.scrollHeight,
-      behavior: isStreaming ? "auto" : "smooth",
-    });
-  }, [scrollTrigger]);
-
   return (
     <Card className="flex h-full w-full flex-col">
       <CardHeader>
         <CardTitle>Chat (RPC)</CardTitle>
-        <div className="flex gap-2 mt-1">
+        <div className="mt-1 flex flex-wrap gap-2">
           {chatId && (
-            <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-[0.65rem] text-muted-foreground">
-              {chatId}
-            </span>
+            <Marker className="w-fit rounded-none border border-border bg-muted px-2 py-0.5 font-mono text-[0.65rem]">
+              <MarkerContent>{chatId}</MarkerContent>
+            </Marker>
           )}
-          {isStarting && (
-            <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
-              Starting
-            </span>
-          )}
-          {isStreaming && (
-            <span className="inline-flex items-center rounded-full border border-border bg-secondary px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.2em] text-secondary-foreground">
-              Streaming
-            </span>
-          )}
+          {isStarting && <StatusMarker label="Starting" status="pending" />}
+          {isStreaming && <StatusMarker label="Streaming" status="active" />}
           {isWaiting && !isStreaming && (
-            <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
-              Loading
-            </span>
+            <StatusMarker label="Loading" status="pending" />
           )}
-          {isFailure && (
-            <span className="inline-flex items-center rounded-full bg-destructive px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.2em] text-destructive-foreground">
-              Error
-            </span>
-          )}
+          {isFailure && <StatusMarker label="Error" status="error" />}
         </div>
       </CardHeader>
 
-      <CardContent className="flex-1 min-h-0 flex flex-col gap-0 p-0">
-        <div className="flex-1 min-h-0 overflow-y-auto px-4" ref={scrollContainerRef}>
-        <div className="space-y-6 py-6">
-          {displayHistory.length === 0 && currentSegments.length === 0 && (
-            <div className="flex flex-col items-start gap-2 rounded-none border border-border bg-muted/50 px-4 py-6 text-xs text-muted-foreground">
-              <p className="text-[0.65rem] uppercase tracking-[0.28em]">
-                Empty channel
-              </p>
-              <p className="text-xs text-foreground">
-                Start with a clear request.
-              </p>
-            </div>
-          )}
-
-          {displayHistory.map((msg, i) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: stable order in append-only history
-              key={i}
-              className={cn(
-                "flex w-full flex-col gap-2",
-                msg.role === "user" ? "items-end mb-8" : "items-start",
-              )}
-            >
-              {msg.role === "user" ? (
-                <div className="max-w-[85%] rounded-none border border-primary/40 bg-primary px-4 py-2 text-xs text-primary-foreground shadow-xs whitespace-break-spaces">
-                  {msg.message}
-                </div>
-              ) : (
-                <>
-                  {msg.segments?.map((segment, segIdx) => (
-                    <div
-                      // biome-ignore lint/suspicious/noArrayIndexKey: stable order
-                      key={segIdx}
-                      className="w-full"
-                    >
-                      {segment._tag === "text" ? (
-                        <div className="w-full py-2 text-xs whitespace-pre-wrap">
-                          {segment.content}
-                        </div>
-                      ) : (
-                        <div className="rounded-none border border-border bg-muted/50 p-3 text-xs">
-                          <span className="font-mono text-muted-foreground">
-                            Tool: {segment.tool.name} [{segment.tool.status}]
-                          </span>
-                          {segment.tool.result && (
-                            <pre className="mt-1 text-xs overflow-auto">
-                              {segment.tool.result}
-                            </pre>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                  {msg.usage && msg.finishReason && (
-                    <div className="text-[0.6rem] text-muted-foreground">
-                      {msg.usage.totalTokens} tokens | {msg.finishReason}
-                    </div>
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-0 p-0">
+        <MessageScrollerProvider>
+          <MessageScroller className="flex-1">
+            <MessageScrollerViewport className="px-4">
+              <MessageScrollerContent className="py-6">
+                {displayHistory.length === 0 &&
+                  currentSegments.length === 0 && (
+                    <Marker variant="border" className="bg-muted/50 px-4 py-6">
+                      <MarkerContent className="flex flex-col gap-2">
+                        <span className="text-[0.65rem] uppercase tracking-[0.28em]">
+                          Empty channel
+                        </span>
+                        <span className="text-xs text-foreground">
+                          Start with a clear request.
+                        </span>
+                      </MarkerContent>
+                    </Marker>
                   )}
-                </>
-              )}
-            </div>
-          ))}
 
-          {currentResult._tag === "streaming" && currentResult.reasoning && (
-            <div className="flex w-full flex-col gap-2 items-start">
-              <div className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-0.5 text-[0.65rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-                Reasoning: {currentResult.reasoning}
-              </div>
-            </div>
-          )}
+                {displayHistory.map((msg, i) => (
+                  <MessageScrollerItem
+                    key={msg.id}
+                    scrollAnchor={i === displayHistory.length - 1}
+                  >
+                    {msg.role === "user" ? (
+                      <Message align="end">
+                        <MessageContent>
+                          <Bubble align="end">
+                            <BubbleContent className="whitespace-break-spaces">
+                              {msg.message}
+                            </BubbleContent>
+                          </Bubble>
+                        </MessageContent>
+                      </Message>
+                    ) : (
+                      <Message align="start">
+                        <MessageContent>
+                          <MessageGroup>
+                            {msg.segments?.map((segment, segIdx) => (
+                              <AssistantSegment
+                                // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+                                key={segIdx}
+                                segment={segment}
+                              />
+                            ))}
+                          </MessageGroup>
+                          {msg.usage && msg.finishReason && (
+                            <MessageFooter className="text-[0.6rem]">
+                              {msg.usage.totalTokens} tokens |{" "}
+                              {msg.finishReason}
+                            </MessageFooter>
+                          )}
+                        </MessageContent>
+                      </Message>
+                    )}
+                  </MessageScrollerItem>
+                ))}
 
-          {currentResult._tag === "error" && (
-            <div className="text-destructive text-xs p-3 border border-destructive/40 bg-destructive/10 rounded-none">
-              <p className="font-medium text-foreground">
-                {currentResult.error.message}
-              </p>
-              {currentResult.error.recoverable && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="mt-2"
-                  onClick={() => {
-                    const messages = historyToMessages(history);
-                    sendMessages(messages);
-                  }}
-                >
-                  Retry
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
+                {currentResult._tag === "streaming" &&
+                  currentResult.reasoning && (
+                    <Marker>
+                      <MarkerContent className="shimmer">
+                        Reasoning: {currentResult.reasoning}
+                      </MarkerContent>
+                    </Marker>
+                  )}
 
-      <div className="border-t border-border p-4">
-        <div className="flex w-full gap-2">
-          <Input
-            type="text"
-            placeholder="Send a message"
+                {currentResult._tag === "error" && (
+                  <Bubble variant="destructive" className="max-w-full">
+                    <BubbleContent className="flex flex-col gap-2">
+                      <p className="font-medium">
+                        {currentResult.error.message}
+                      </p>
+                      {currentResult.error.recoverable && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="mt-2"
+                          onClick={() => {
+                            const messages = historyToMessages(history);
+                            sendMessages(messages);
+                          }}
+                        >
+                          Retry
+                        </Button>
+                      )}
+                    </BubbleContent>
+                  </Bubble>
+                )}
+
+                {asyncFailureMessage && currentResult._tag !== "error" && (
+                  <Bubble variant="destructive" className="max-w-full">
+                    <BubbleContent>
+                      <pre className="whitespace-pre-wrap text-xs">
+                        {asyncFailureMessage}
+                      </pre>
+                    </BubbleContent>
+                  </Bubble>
+                )}
+              </MessageScrollerContent>
+            </MessageScrollerViewport>
+            <MessageScrollerButton />
+          </MessageScroller>
+        </MessageScrollerProvider>
+
+        <div className="border-t border-border p-4">
+          <div className="flex w-full gap-2">
+            <Input
+              type="text"
+              placeholder="Send a message"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSend()}
@@ -531,22 +554,80 @@ export function ChatBox() {
               onClick={handleSend}
               disabled={!input.trim() || isStarting || isWaiting || isStreaming}
             >
-            Send
-          </Button>
+              Send
+            </Button>
+          </div>
         </div>
-      </div>
       </CardContent>
     </Card>
   );
 }
 
-const historyToMessages = (messages: Message[]) =>
+function StatusMarker({
+  label,
+  status,
+}: {
+  label: string;
+  status: "active" | "error" | "pending";
+}) {
+  const Icon =
+    status === "error"
+      ? CircleAlertIcon
+      : status === "active"
+        ? CircleCheckIcon
+        : LoaderCircleIcon;
+
+  return (
+    <Marker variant={status === "active" ? "border" : "default"}>
+      <MarkerIcon
+        className={
+          status === "error"
+            ? "text-destructive"
+            : status === "pending"
+              ? "animate-spin"
+              : undefined
+        }
+      >
+        <Icon />
+      </MarkerIcon>
+      <MarkerContent>{label}</MarkerContent>
+    </Marker>
+  );
+}
+
+function AssistantSegment({ segment }: { segment: MessageSegment }) {
+  return segment._tag === "text" ? (
+    <Bubble variant="ghost" className="max-w-full">
+      <BubbleContent className="whitespace-pre-wrap">
+        {segment.content}
+      </BubbleContent>
+    </Bubble>
+  ) : (
+    <Bubble variant="muted" className="max-w-full">
+      <BubbleContent>
+        <Marker>
+          <MarkerContent className="font-mono">
+            Tool: {segment.tool.name} [{segment.tool.status}]
+          </MarkerContent>
+        </Marker>
+        {segment.tool.result && (
+          <pre className="mt-2 overflow-auto text-xs">
+            {segment.tool.result}
+          </pre>
+        )}
+      </BubbleContent>
+    </Bubble>
+  );
+}
+
+const historyToMessages = (messages: ChatEntry[]) =>
   messages.map((msg) => {
     if (msg.role === "assistant" && msg.segments) {
-      const textContent = msg.segments
-        .filter((seg) => seg._tag === "text")
-        .map((seg) => seg.content)
-        .join("");
+      const textContent = msg.segments.reduce(
+        (content, seg) =>
+          seg._tag === "text" ? content + seg.content : content,
+        "",
+      );
       return {
         role: msg.role,
         content: textContent || msg.message,

--- a/packages/catalog/src/registry/content/client-foldkit.ts
+++ b/packages/catalog/src/registry/content/client-foldkit.ts
@@ -49,8 +49,8 @@ export const foldkitThemeInitContents = `(function () {
 })();
 `;
 
-export const foldkitViteConfigContents = `import tailwindcss from "@tailwindcss/vite";
-import foldkit from "@foldkit/vite-plugin";
+export const foldkitViteConfigContents = `import { foldkit } from "@foldkit/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -136,7 +136,7 @@ export const foldkitStylesContents = `@import "tailwindcss";
 `;
 
 export const foldkitEntryContents = `import { Runtime } from "foldkit";
-
+import "./styles.css";
 import { init, Model, subscriptions, update, view } from "./main";
 
 const program = Runtime.makeProgram({

--- a/packages/catalog/src/registry/content/client.ts
+++ b/packages/catalog/src/registry/content/client.ts
@@ -145,9 +145,6 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  optimizeDeps: {
-    include: ["@repo/domain"],
-  },
   server: {
     port: 3000,
     strictPort: true,

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -195,6 +195,20 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         value: "workspace:*",
       },
       {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "@effect/platform-browser",
+        value: "4.0.0-beta.93",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "@shadcn/react",
+        value: "^0.2.0",
+      },
+      {
         _tag: "jsx-slot",
         path: "{{targetPath}}/src/app.tsx",
         slotId: "components",
@@ -207,16 +221,9 @@ export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
     scripts: [
       {
-        label: "Install shadcn button component",
-        command: "bunx shadcn@latest add button --yes --overwrite",
-      },
-      {
-        label: "Install shadcn card component",
-        command: "bunx shadcn@latest add card --yes --overwrite",
-      },
-      {
-        label: "Install shadcn input component",
-        command: "bunx shadcn@latest add input --yes --overwrite",
+        label: "Install shadcn chat UI components",
+        command:
+          "bunx shadcn@latest add message-scroller message bubble attachment marker --yes --overwrite",
       },
     ],
   },

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -208,12 +208,9 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
     ],
     scripts: [
       {
-        label: "Install shadcn card component",
-        command: "bunx shadcn@latest add card --yes --overwrite",
-      },
-      {
-        label: "Install shadcn switch component",
-        command: "bunx shadcn@latest add switch --yes --overwrite",
+        label: "Install shadcn client components",
+        command:
+          "bunx shadcn@latest add button card input switch --yes --overwrite",
       },
     ],
   },


### PR DESCRIPTION
## Goals/Scope

Migrate the chat box UI to use shadcn message components.

## Description

- Refactored chat box to use shadcn message components.
- Corrected imports for the Vite plugin and updated Tailwind style handling.
- Updated model streaming to provide a proper stream so it doesn’t terminate unexpectedly.