### PR TITLE
feat: add create command preview

### DIFF
--- a/.changeset/brave-goats-filter.md
+++ b/.changeset/brave-goats-filter.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+`stack-effect add` ignores selected modules that are not supported by the edited target.

--- a/.changeset/fresh-maps-fold.md
+++ b/.changeset/fresh-maps-fold.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+empty or punctuation-only target names resolve to catalog defaults instead of generating punctuation-only target paths.

--- a/.changeset/quiet-bikes-skip.md
+++ b/.changeset/quiet-bikes-skip.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+dry-run previews skip conflicted planned paths instead of failing because conflict decisions are missing.

--- a/.changeset/smart-rivers-preview.md
+++ b/.changeset/smart-rivers-preview.md
@@ -1,0 +1,7 @@
+---
+"stack-effect": minor
+---
+
+dry-run and plan previews show the equivalent `stack-effect create` command for the selected scaffold.
+
+For example, a preview can show `stack-effect create my-app --target server/api:server-http-api` so the same scaffold can be repeated non-interactively.

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -51,9 +51,7 @@ type CollectedTarget = {
   confirmed: boolean;
 };
 
-const TargetNameInput = Schema.Trim.check(
-  Schema.isNonEmpty({ message: "Target name cannot be empty" }),
-);
+const TargetNameInput = Schema.Trim;
 
 const validateTargetName = (value: string) =>
   Schema.decodeUnknownEffect(TargetNameInput)(value).pipe(

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -822,6 +822,7 @@ export const add = Command.make(
           providerStrategy: { _tag: "fail-on-ambiguous" },
         },
       );
+      const createCommand = recipes.renderCreateCommand({ config, selection });
 
       yield* pipeline.run({
         selection,
@@ -830,6 +831,7 @@ export const add = Command.make(
         dryRun: flags.dryRun,
         trust: flags.trust || flags.yes,
         config,
+        createCommand,
       });
     }).pipe(
       Effect.retry({

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -452,6 +452,18 @@ const ensureTargetModule = (
   });
 };
 
+const supportedModulesForTarget = (
+  identity: TargetIdentity,
+  moduleIds: ReadonlyArray<typeof ModuleId.Type>,
+) =>
+  Effect.gen(function* () {
+    const catalog = yield* CatalogService;
+
+    return yield* Effect.filter(moduleIds, (moduleId) =>
+      catalog.isSupportedOn(moduleId, identity),
+    );
+  });
+
 const resolveCapabilities = <E, R>(
   targets: Array<CollectedTarget>,
   confirmed: boolean,
@@ -629,8 +641,17 @@ const collectTargetsInteractive = Effect.gen(function* () {
           choices: moduleTree,
         })
       : [];
+    const supportedModules = yield* supportedModulesForTarget(
+      new TargetIdentity({ kind, name }),
+      modules,
+    );
 
-    targets.push({ kind, name, modules: [...modules], confirmed: false });
+    targets.push({
+      kind,
+      name,
+      modules: [...supportedModules],
+      confirmed: false,
+    });
   });
 
   yield* addTarget;
@@ -717,12 +738,16 @@ const collectTargetsInteractive = Effect.gen(function* () {
                       choices: moduleTree,
                       initialSelected: t.modules,
                     });
-                    t.modules = [...newModules];
+                    const supportedModules = yield* supportedModulesForTarget(
+                      new TargetIdentity({ kind: t.kind, name: t.name }),
+                      newModules,
+                    );
+                    t.modules = [...supportedModules];
                     t.confirmed = true;
 
                     // NOTE: Prune implied modules that were invalidated by explicit edits before resolving again.
                     const pinned = new Set(
-                      Arr.map(newModules, (m) => `${t.kind}:${m}`),
+                      Arr.map(supportedModules, (m) => `${t.kind}:${m}`),
                     );
                     yield* removeOrphanedImplications(targets, pinned);
                     yield* resolveDependenciesInteractive(targets);

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -19,7 +19,6 @@ import {
   yesFlag,
 } from "../flags";
 import { resolveNameAndRoot } from "../lib/project";
-import { encodeRecipeTargetSpecs } from "../lib/recipeTargets";
 import { CONFIG_FILENAME, ConfigureService } from "../service/ConfigureService";
 import { RecipeService } from "../service/RecipeService";
 import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
@@ -32,11 +31,6 @@ const DEFAULTS = {
   format: "biome",
   test: "vitest",
 } as const;
-
-const quoteShellArg = (value: string) =>
-  /^[A-Za-z0-9_./:,@+-]+$/.test(value)
-    ? value
-    : `'${value.replaceAll("'", "'\\''")}'`;
 
 const validateRuntimeOptions = Effect.fn("create.validateRuntimeOptions")(
   function* ({
@@ -134,68 +128,6 @@ const buildRecipeSpec = (
   ],
 });
 
-const renderCreateCommand = ({
-  name,
-  targets,
-  runtime,
-  packageManager,
-  monorepo,
-  lint,
-  format,
-  test,
-  noGit,
-}: {
-  readonly name: string;
-  readonly targets: ReadonlyArray<RecipeTargetSpec>;
-  readonly runtime: Option.Option<"bun" | "node">;
-  readonly packageManager: Option.Option<"bun" | "pnpm" | "npm">;
-  readonly monorepo: Option.Option<string>;
-  readonly lint: Option.Option<string>;
-  readonly format: Option.Option<string>;
-  readonly test: Option.Option<string>;
-  readonly noGit: boolean;
-}) =>
-  [
-    "stack-effect",
-    "create",
-    quoteShellArg(name),
-    ...encodeRecipeTargetSpecs(targets).flatMap((target) => [
-      "--target",
-      quoteShellArg(target),
-    ]),
-    ...Option.match(runtime, {
-      onNone: () => [],
-      onSome: (value) =>
-        value === DEFAULTS.runtime ? [] : ["--runtime", value],
-    }),
-    ...Option.match(packageManager, {
-      onNone: () => [],
-      onSome: (value) =>
-        value === DEFAULTS.packageManager ? [] : ["--package-manager", value],
-    }),
-    ...Option.match(monorepo, {
-      onNone: () => [],
-      onSome: (value) =>
-        value === DEFAULTS.monorepo ? [] : ["--monorepo", quoteShellArg(value)],
-    }),
-    ...Option.match(lint, {
-      onNone: () => [],
-      onSome: (value) =>
-        value === DEFAULTS.lint ? [] : ["--lint", quoteShellArg(value)],
-    }),
-    ...Option.match(format, {
-      onNone: () => [],
-      onSome: (value) =>
-        value === DEFAULTS.format ? [] : ["--format", quoteShellArg(value)],
-    }),
-    ...Option.match(test, {
-      onNone: () => [],
-      onSome: (value) =>
-        value === DEFAULTS.test ? [] : ["--test", quoteShellArg(value)],
-    }),
-    ...(noGit ? ["--no-git"] : []),
-  ].join(" ");
-
 export const create = Command.make(
   "create",
   {
@@ -254,6 +186,7 @@ export const create = Command.make(
         config,
         providerStrategy: { _tag: "fail-on-ambiguous" },
       });
+      const createCommand = recipes.renderCreateCommand({ config, selection });
 
       const existing = yield* configure
         .readConfig(repoRoot)
@@ -267,19 +200,9 @@ export const create = Command.make(
         );
       }
 
-      yield* Console.log(
-        `Create command: ${renderCreateCommand({
-          name: flags.name.value,
-          targets: flags.target.value,
-          runtime: flags.runtime,
-          packageManager: flags.packageManager,
-          monorepo: flags.monorepo,
-          lint: flags.lint,
-          format: flags.format,
-          test: flags.test,
-          noGit: flags.noGit,
-        })}`,
-      );
+      if (!flags.dryRun) {
+        yield* Console.log(`Create command: ${createCommand}`);
+      }
 
       if (!flags.dryRun) {
         yield* configure.writeConfig(repoRoot, config);
@@ -293,6 +216,7 @@ export const create = Command.make(
         dryRun: flags.dryRun,
         trust: flags.trust || flags.yes,
         config,
+        createCommand,
       });
     }),
 ).pipe(

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -22,6 +22,7 @@ import { Command, Flag } from "effect/unstable/cli";
 import { Box } from "effect-boxes";
 import { rootFlag } from "../flags";
 import { ConfigureService } from "../service/ConfigureService";
+import { RecipeService } from "../service/RecipeService";
 
 /**
  * Reads a PlanInput from stdin, runs Blueprint → Plan, and outputs structured
@@ -94,6 +95,11 @@ export const plan = Command.make(
 
       const blueprintService = yield* BlueprintService;
       const blueprint = yield* blueprintService.resolve(input.selection);
+      const recipes = yield* RecipeService;
+      const createCommand = recipes.renderCreateCommand({
+        config,
+        selection: input.selection,
+      });
 
       const planService = yield* PlanService;
       const planResult = yield* planService.build({
@@ -111,10 +117,15 @@ export const plan = Command.make(
           ),
         );
 
-      const finalize = scripts.map((s) => ({
-        label: s.label,
-        command: s.command,
+      const finalize = Arr.map(scripts, (script) => ({
+        label: script.label,
+        command: script.command,
       }));
+      const createFinalizeCommand = {
+        label: "Create equivalent project",
+        command: createCommand,
+      };
+      const finalizeWithCreateCommand = [createFinalizeCommand, ...finalize];
 
       const formatter = yield* ScaffoldFormatter;
       const formattedPlan = yield* formatter.formatPlan(planResult);
@@ -133,8 +144,15 @@ export const plan = Command.make(
       const outputText = yield* Match.value(format).pipe(
         Match.when("tree", () =>
           Box.renderPlain(
-            Box.hcat(
-              [Box.text(formattedPlan.summary), formattedPlan.tree],
+            Box.vsep(
+              [
+                Box.hcat(
+                  [Box.text(formattedPlan.summary), formattedPlan.tree],
+                  Box.left,
+                ),
+                Box.text(`Create command: ${createCommand}`),
+              ],
+              1,
               Box.left,
             ),
           ),
@@ -144,7 +162,7 @@ export const plan = Command.make(
             renderPlanForLlm({
               outcomes: planResult.outcomes,
               conflicts: planResult.conflicts,
-              finalize,
+              finalize: finalizeWithCreateCommand,
               summary,
               tree,
             }),
@@ -155,6 +173,7 @@ export const plan = Command.make(
             outcomes: planResult.outcomes,
             conflicts: planResult.conflicts,
             summary,
+            createCommand,
             finalize,
             tree,
           }),

--- a/apps/cli/src/components/DryRunPreview.ts
+++ b/apps/cli/src/components/DryRunPreview.ts
@@ -10,6 +10,7 @@ export const DryRunPreview = ({
   plan,
   apply,
   scripts,
+  createCommand,
 }: {
   blueprint: Box.Box<Ansi.AnsiStyle>;
   plan: {
@@ -24,8 +25,10 @@ export const DryRunPreview = ({
     phase: string;
     origin: string;
   }>;
+  createCommand?: string | undefined;
 }) => {
   const terminalWidth = process.stdout.columns ?? 80;
+  const commandWidth = Math.max(32, terminalWidth - 8);
 
   const blueprintContent = Box.vsep(
     [sectionTitle("Blueprint"), blueprint],
@@ -101,7 +104,18 @@ export const DryRunPreview = ({
       : Box.text("(none)").pipe(Box.annotate(Ansi.dim));
 
   const finalizeContent = Box.vsep(
-    [sectionTitle("Finalize"), scriptGroups],
+    [
+      ...(createCommand === undefined
+        ? []
+        : [
+            sectionTitle("Create Command"),
+            Box.para(createCommand, Box.left, commandWidth).pipe(
+              Box.annotate(Ansi.bold),
+            ),
+          ]),
+      sectionTitle("Finalize"),
+      scriptGroups,
+    ],
     1,
     Box.left,
   );

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -692,6 +692,82 @@ describe("RecipeService", () => {
     );
   });
 
+  describe("renderCreateCommand", () => {
+    it.effect("should render selected targets as create target flags", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const selection = yield* service.resolve(
+          {
+            targets: [
+              {
+                target: new TargetIdentity({
+                  kind: TargetKind.make("server"),
+                  name: "api",
+                }),
+                modules: [ModuleId.make("server-http-api")],
+              },
+              {
+                target: new TargetIdentity({
+                  kind: TargetKind.make("workspace"),
+                  name: "recipe-app",
+                }),
+                modules: [ModuleId.make("workspace-devenv-git")],
+              },
+            ],
+          },
+          {
+            config: testConfig,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        assert.strictEqual(
+          service.renderCreateCommand({ config: testConfig, selection }),
+          "stack-effect create recipe-app --target server/api:server-http-api",
+        );
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("should render non-default config flags and --no-git", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const config = new StackConfig({
+          name: "node app" as typeof Schema.NonEmptyString.Type,
+          runtime: { _tag: "node", packageManager: "pnpm" },
+          monorepo: "turbo",
+          lint: "eslint",
+          format: "prettier",
+          test: "vitest",
+        });
+        const selection = yield* service.resolve(
+          {
+            targets: [
+              {
+                target: new TargetIdentity({
+                  kind: TargetKind.make("client-react"),
+                  name: "web",
+                }),
+                modules: [
+                  ModuleId.make("client-react-vite"),
+                  ModuleId.make("client-react-chat"),
+                ],
+              },
+            ],
+          },
+          {
+            config,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        assert.strictEqual(
+          service.renderCreateCommand({ config, selection }),
+          "stack-effect create 'node app' --target client-react/web:client-react-vite,client-react-chat --runtime node --package-manager pnpm --lint eslint --format prettier --no-git",
+        );
+      }).pipe(Effect.provide(TestLayer)),
+    );
+  });
+
   describe("errors", () => {
     it("should expose recoverable error tags when recipe resolution fails", () => {
       const invalid = new InvalidRecipeSpec({

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -315,6 +315,45 @@ describe("RecipeService", () => {
         }).pipe(Effect.provide(TestLayer)),
     );
 
+    it.effect(
+      "should resolve empty and punctuation-only app target names to catalog defaults",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* RecipeService;
+          const selection = yield* service.resolve(
+            {
+              targets: [
+                {
+                  target: new TargetIdentity({
+                    kind: TargetKind.make("client-react"),
+                    name: "",
+                  }),
+                  modules: [ModuleId.make("client-react-http-api")],
+                },
+                {
+                  target: new TargetIdentity({
+                    kind: TargetKind.make("server"),
+                    name: ".",
+                  }),
+                  modules: [ModuleId.make("server-http-api")],
+                },
+              ],
+            },
+            {
+              config: testConfig,
+              providerStrategy: { _tag: "fail-on-ambiguous" },
+            },
+          );
+
+          assertTargetModules(selection, "apps/client-react-web", [
+            ModuleId.make("client-react-http-api"),
+          ]);
+          assertTargetModules(selection, "apps/server-api", [
+            ModuleId.make("server-http-api"),
+          ]);
+        }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect("should allow recipes to omit explicit workspace targets", () =>
       Effect.gen(function* () {
         const service = yield* RecipeService;

--- a/apps/cli/src/service/RecipeService.ts
+++ b/apps/cli/src/service/RecipeService.ts
@@ -61,7 +61,7 @@ const resolveTargetIdentity = (
       });
     }
 
-    if (identity.name.length > 0) return identity;
+    if (identity.hasExplicitName()) return identity;
 
     const targetDefinition = yield* catalog.getTarget(identity.kind).pipe(
       Effect.mapError(

--- a/apps/cli/src/service/RecipeService.ts
+++ b/apps/cli/src/service/RecipeService.ts
@@ -1,9 +1,10 @@
 import { CatalogService } from "@repo/catalog";
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
-import type { RecipeSpec } from "@repo/domain/Recipe";
+import type { RecipeSpec, RecipeTargetSpec } from "@repo/domain/Recipe";
 import { StackConfig } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
-import { Array as Arr, Context, Effect, Layer, Option } from "effect";
+import { Array as Arr, Context, Effect, Layer, Option, pipe } from "effect";
+import { encodeRecipeTargetSpecs } from "../lib/recipeTargets";
 import { toWorkspaceModuleId } from "../lib/workspace";
 import {
   AmbiguousRecipeProvider,
@@ -29,12 +30,35 @@ interface RecipeServiceShape {
     spec: RecipeSpec,
     options: RecipeResolveOptions,
   ) => Effect.Effect<typeof Selection.Type, RecipeError, never>;
+  readonly renderCreateCommand: (options: {
+    readonly config: typeof StackConfig.Type;
+    readonly selection: typeof Selection.Type;
+  }) => string;
 }
 
 type CollectedRecipeTarget = {
   readonly identity: TargetIdentity;
   readonly modules: ReadonlyArray<typeof ModuleId.Type>;
 };
+
+const DEFAULTS = {
+  runtime: "bun",
+  packageManager: "bun",
+  monorepo: "turbo",
+  lint: "biome",
+  format: "biome",
+  test: "vitest",
+} as const;
+
+const quoteShellArg = (value: string) =>
+  /^[A-Za-z0-9_./:,@+-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", "'\\''")}'`;
+
+const configPackageManager = (
+  runtime: (typeof StackConfig.Type)["runtime"],
+): "bun" | "pnpm" | "npm" =>
+  runtime._tag === "bun" ? "bun" : runtime.packageManager;
 
 const configWorkspaceModules = (
   config: typeof StackConfig.Type,
@@ -133,6 +157,36 @@ const toSelection = (
   })),
 });
 
+const selectionTargetToRecipeTargetSpec = (
+  target: (typeof Selection.Type)["targets"][number],
+): RecipeTargetSpec => ({
+  target: target.identity,
+  modules: Arr.map(target.modules, (moduleSelection) => moduleSelection.id),
+});
+
+const selectionIncludesWorkspaceModule = (
+  selection: typeof Selection.Type,
+  moduleId: string,
+) =>
+  Arr.some(
+    selection.targets,
+    (target) =>
+      target.identity.kind === "workspace" &&
+      Arr.some(
+        target.modules,
+        (moduleSelection) => moduleSelection.id === moduleId,
+      ),
+  );
+
+const renderChangedFlag = (
+  flag: string,
+  value: string | undefined,
+  defaultValue: string,
+) =>
+  value === undefined || value === defaultValue
+    ? []
+    : [flag, quoteShellArg(value)];
+
 export class RecipeService extends Context.Service<
   RecipeService,
   RecipeServiceShape
@@ -168,8 +222,43 @@ export class RecipeService extends Context.Service<
       );
     });
 
+    const renderCreateCommand: RecipeServiceShape["renderCreateCommand"] = ({
+      config,
+      selection,
+    }) => {
+      const packageManager = configPackageManager(config.runtime);
+      const targetFlags = pipe(
+        selection.targets,
+        Arr.filter((target) => target.identity.kind !== "workspace"),
+        Arr.map(selectionTargetToRecipeTargetSpec),
+        encodeRecipeTargetSpecs,
+        Arr.flatMap((target) => ["--target", quoteShellArg(target)]),
+      );
+
+      return [
+        "stack-effect",
+        "create",
+        quoteShellArg(config.name),
+        ...targetFlags,
+        ...(config.runtime._tag === DEFAULTS.runtime
+          ? []
+          : ["--runtime", "node"]),
+        ...(packageManager === DEFAULTS.packageManager
+          ? []
+          : ["--package-manager", packageManager]),
+        ...renderChangedFlag("--monorepo", config.monorepo, DEFAULTS.monorepo),
+        ...renderChangedFlag("--lint", config.lint, DEFAULTS.lint),
+        ...renderChangedFlag("--format", config.format, DEFAULTS.format),
+        ...renderChangedFlag("--test", config.test, DEFAULTS.test),
+        ...(selectionIncludesWorkspaceModule(selection, "workspace-devenv-git")
+          ? []
+          : ["--no-git"]),
+      ].join(" ");
+    };
+
     return {
       resolve,
+      renderCreateCommand,
     } satisfies RecipeServiceShape;
   });
 

--- a/apps/cli/src/service/ScaffoldPipeline.test.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { ApplyResult } from "@repo/domain/Apply";
+import { type Apply, ApplyResult } from "@repo/domain/Apply";
 import { Blueprint } from "@repo/domain/Blueprint";
 import { Plan } from "@repo/domain/Plan";
 import { StackConfig } from "@repo/domain/Scaffold";
@@ -18,6 +18,17 @@ import { FinalizeScriptFailure, ScaffoldPipeline } from "./ScaffoldPipeline";
 
 const blueprint = new Blueprint({ nodes: [], edges: [] });
 const plan = new Plan({ outcomes: [], conflicts: [] });
+const conflictPlan = new Plan({
+  outcomes: [
+    {
+      _tag: "complete",
+      path: "package.json",
+      classification: "conflict",
+      contents: "{}",
+    },
+  ],
+  conflicts: [{ _tag: "completeFile", path: "package.json" }],
+});
 const applyResult = new ApplyResult({
   created: [],
   modified: [],
@@ -60,7 +71,18 @@ const executable = {
     }),
 };
 
-const layerWithFinalizeRun = (run: (typeof FinalizeService.Service)["run"]) =>
+const layerWithServices = ({
+  plan: planned = plan,
+  preview = () => Effect.succeed(applyResult),
+  run,
+}: {
+  plan?: Plan;
+  preview?: (input: {
+    readonly apply: typeof Apply.Type;
+    readonly repoRoot: string;
+  }) => Effect.Effect<ApplyResult, never, never>;
+  run: (typeof FinalizeService.Service)["run"];
+}) =>
   Layer.mergeAll(
     ScaffoldPipeline.layer,
     Layer.succeed(ScaffoldFormatter, {
@@ -78,11 +100,11 @@ const layerWithFinalizeRun = (run: (typeof FinalizeService.Service)["run"]) =>
       resolve: () => Effect.succeed(blueprint),
     }),
     Layer.succeed(PlanService, {
-      build: () => Effect.succeed(plan),
+      build: () => Effect.succeed(planned),
     }),
     Layer.succeed(ApplyService, {
       apply: () => Effect.succeed(applyResult),
-      preview: () => Effect.succeed(applyResult),
+      preview,
     }),
     Layer.succeed(FinalizeService, {
       preview: () => Effect.succeed([script]),
@@ -111,7 +133,9 @@ describe("ScaffoldPipeline", () => {
         failed: 1,
       });
     }).pipe(
-      Effect.provide(layerWithFinalizeRun(() => Effect.succeed([executable]))),
+      Effect.provide(
+        layerWithServices({ run: () => Effect.succeed([executable]) }),
+      ),
     ),
   );
 
@@ -125,9 +149,35 @@ describe("ScaffoldPipeline", () => {
       expect(Exit.isSuccess(exit)).toBe(true);
     }).pipe(
       Effect.provide(
-        layerWithFinalizeRun(() =>
-          Effect.die(new Error("dry-run should not run finalize scripts")),
-        ),
+        layerWithServices({
+          run: () =>
+            Effect.die(new Error("dry-run should not run finalize scripts")),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("previews dry-run conflicts as skipped decisions", () =>
+    Effect.gen(function* () {
+      const pipeline = yield* ScaffoldPipeline;
+      const exit = yield* Effect.exit(
+        pipeline.run({ ...runInput, dryRun: true }),
+      );
+
+      expect(Exit.isSuccess(exit)).toBe(true);
+    }).pipe(
+      Effect.provide(
+        layerWithServices({
+          plan: conflictPlan,
+          preview: ({ apply }) => {
+            expect(apply.decisions).toEqual([
+              { path: "package.json", value: "skip" },
+            ]);
+            return Effect.succeed(applyResult);
+          },
+          run: () =>
+            Effect.die(new Error("dry-run should not run finalize scripts")),
+        }),
       ),
     ),
   );

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -70,6 +70,7 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
         dryRun,
         trust,
         config,
+        createCommand,
       }: {
         selection: typeof Selection.Type;
         repoRoot: string;
@@ -77,6 +78,7 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
         dryRun: boolean;
         trust: boolean;
         config: typeof StackConfig.Type;
+        createCommand?: string;
       }) =>
         Effect.gen(function* () {
           const formatter = yield* ScaffoldFormatter;
@@ -158,6 +160,7 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
                   plan: pl,
                   apply: result,
                   scripts: previewScripts,
+                  createCommand,
                 }),
               ),
             );

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -41,6 +41,12 @@ const skippedFinalizeScripts = (
     .filter((script) => !selectedCommands.has(script.command))
     .map((script) => ({ label: script.label, command: script.command }));
 
+const skipConflictDecisions = (plan: Plan) =>
+  plan.conflicts.map((conflict) => ({
+    path: conflict.path,
+    value: "skip" as const,
+  }));
+
 export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
   "ScaffoldPipeline",
   {
@@ -140,7 +146,10 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
 
           if (dryRun) {
             const result = yield* applyService.preview({
-              apply: new Apply({ plan, decisions: [] }),
+              apply: new Apply({
+                plan,
+                decisions: skipConflictDecisions(plan),
+              }),
               repoRoot,
             });
 

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -31,6 +31,10 @@ export class TargetIdentity extends Schema.Class<TargetIdentity>(
   kind: TargetKind,
   name: Schema.String,
 }) {
+  hasExplicitName(): boolean {
+    return targetNameSlug(this).length > 0;
+  }
+
   toPath(): typeof TargetPath.Type {
     return TargetPath.make(toTargetPathString(this));
   }
@@ -45,16 +49,15 @@ export class TargetIdentity extends Schema.Class<TargetIdentity>(
    * - Apps use their folder name: `<kind>` or `<kind>-<name>`
    */
   toPackageName(): string {
-    const resolvedName = this.name.trim() || this.kind;
+    const slug = targetNameSlug(this);
+    const resolvedName = slug || this.kind;
     switch (this.kind) {
       case "workspace":
         return resolvedName;
       case "package":
-        return `@repo/${Str.kebabCase(resolvedName)}`;
+        return `@repo/${resolvedName}`;
       default:
-        return this.name
-          ? `${this.kind}-${Str.kebabCase(this.name.trim())}`
-          : this.kind;
+        return slug ? `${this.kind}-${slug}` : this.kind;
     }
   }
 
@@ -66,16 +69,19 @@ export class TargetIdentity extends Schema.Class<TargetIdentity>(
   }
 }
 
+const targetNameSlug = (identity: TargetIdentity): string =>
+  Str.kebabCase(identity.name.trim());
+
 const toTargetPathString = (identity: TargetIdentity): string => {
-  const trimmedName = identity.name.trim();
+  const slug = targetNameSlug(identity);
 
   switch (identity.kind) {
     case "workspace":
       return ".";
     case "package":
-      return `packages/${Str.kebabCase(trimmedName)}`;
+      return `packages/${slug}`;
     default:
-      return `apps/${identity.kind}${identity.name ? `-${Str.kebabCase(trimmedName)}` : ""}`;
+      return `apps/${identity.kind}${slug ? `-${slug}` : ""}`;
   }
 };
 

--- a/packages/domain/src/Scaffold.test.ts
+++ b/packages/domain/src/Scaffold.test.ts
@@ -35,6 +35,18 @@ describe("@repo/domain Scaffold", () => {
     expect(identity.toPackageName()).toBe("server");
   });
 
+  it("treats punctuation-only app target names as unnamed", () => {
+    const identity = Schema.decodeUnknownSync(TargetIdentity)({
+      kind: "client-react",
+      name: ".",
+    });
+
+    expect(identity.hasExplicitName()).toBe(false);
+    expect(identity.toKey()).toBe("apps/client-react");
+    expect(identity.toPath()).toBe("apps/client-react");
+    expect(identity.toPackageName()).toBe("client-react");
+  });
+
   it("slugifies uppercase names into canonical keys and paths", () => {
     const identity = Schema.decodeUnknownSync(TargetIdentity)({
       kind: "server",


### PR DESCRIPTION
## Goals/Scope

Generate a preview of the “create” command based on selected modules/targets, ensuring correctness and stable output.

## Description

- Render the create command from user selections
- Filter selected modules to only those supported by the chosen targets
- Normalize explicit target names for consistent preview behavior
- Skip detected conflicts during dry-run previews to prevent misleading output
