### PR TITLE
feat: add typescript 7 support and modules

### DIFF
--- a/.changeset/bright-carpets-dance.md
+++ b/.changeset/bright-carpets-dance.md
@@ -1,0 +1,11 @@
+---
+"stack-effect": minor
+---
+
+The `init` and `create` commands now support TypeScript 6 and 7 selection with `--typescript`.
+
+For example:
+
+```sh
+stack-effect init my-app --typescript 7
+```

--- a/.changeset/fresh-snails-smile.md
+++ b/.changeset/fresh-snails-smile.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+New projects now apply the patch for their configured Effect TypeScript integration during dependency installation.

--- a/.docs/domain-lexicon.md
+++ b/.docs/domain-lexicon.md
@@ -442,7 +442,7 @@ Token-resolution context used when templating contribution contents.
 
 Invariants:
 
-- Includes target identity fields plus runtime, package manager, and project name inputs.
+- Includes target identity fields plus runtime, package manager, TypeScript version, and project name inputs.
 
 Connected terms:
 
@@ -460,6 +460,7 @@ Run-level configuration for runtime and toolchain choices.
 Invariants:
 
 - Runtime is `bun` or `node` with `pnpm|npm`.
+- TypeScript version is `6` or `7`; legacy configs without the field resolve to `6`.
 - Helper behavior derives runtime and package manager names from runtime shape.
 
 Connected terms:
@@ -468,7 +469,7 @@ Connected terms:
 
 In code:
 
-- `StackConfig`, `Runtime`
+- `StackConfig`, `Runtime`, `TypeScriptVersion`
 
 ## Planning and Conflict Terms
 

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -32,6 +32,26 @@ describe("init", () => {
             "scripts.prepare",
             "effect-language-service patch",
           );
+          yield* cli.expectJsonFile(
+            "my-app/package.json",
+            "devDependencies.typescript",
+            "6.0.3",
+          );
+          yield* cli.expectJsonFile(
+            "my-app/package.json",
+            "devDependencies.@effect/language-service",
+            "^0.87.0",
+          );
+          yield* cli.expectJsonFile(
+            "my-app/tsconfig.json",
+            "$schema",
+            "./node_modules/@effect/language-service/schema.json",
+          );
+          yield* cli.expectJsonFile(
+            "my-app/packages/config-typescript/base.json",
+            "$schema",
+            "../../node_modules/@effect/language-service/schema.json",
+          );
         }),
       { timeout: 30_000 },
     );
@@ -58,8 +78,33 @@ describe("init", () => {
             "typescript",
             "7",
           );
+          yield* cli.expectJsonFile(
+            "typescript-7-app/package.json",
+            "scripts.prepare",
+            "effect-tsgo patch",
+          );
+          yield* cli.expectJsonFile(
+            "typescript-7-app/package.json",
+            "devDependencies.typescript",
+            "7.0.2",
+          );
+          yield* cli.expectJsonFile(
+            "typescript-7-app/package.json",
+            "devDependencies.@effect/tsgo",
+            "^0.22.0",
+          );
+          yield* cli.expectJsonFile(
+            "typescript-7-app/tsconfig.json",
+            "$schema",
+            "./node_modules/@effect/tsgo/schema.json",
+          );
+          yield* cli.expectJsonFile(
+            "typescript-7-app/packages/config-typescript/base.json",
+            "$schema",
+            "../../node_modules/@effect/tsgo/schema.json",
+          );
         }),
-      { timeout: 30_000 },
+      { timeout: 60_000 },
     );
 
     it.effect(

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -22,6 +22,11 @@ describe("init", () => {
           yield* cli.expectFileExists("my-app/package.json");
           yield* cli.expectFileExists("my-app/tsconfig.json");
           yield* cli.expectJsonFile("my-app/package.json", "name", "my-app");
+          yield* cli.expectJsonFile(
+            "my-app/package.json",
+            "scripts.prepare",
+            "effect-language-service patch",
+          );
         }),
       { timeout: 30_000 },
     );

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -23,9 +23,40 @@ describe("init", () => {
           yield* cli.expectFileExists("my-app/tsconfig.json");
           yield* cli.expectJsonFile("my-app/package.json", "name", "my-app");
           yield* cli.expectJsonFile(
+            "my-app/stack.effect.json",
+            "typescript",
+            "6",
+          );
+          yield* cli.expectJsonFile(
             "my-app/package.json",
             "scripts.prepare",
             "effect-language-service patch",
+          );
+        }),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
+      "records an explicit TypeScript version",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "typescript-7-app",
+            "--yes",
+            "--typescript",
+            "7",
+            "--root",
+            cli.workdir,
+          );
+
+          yield* cli.expectExitCode(0);
+          yield* cli.expectJsonFile(
+            "typescript-7-app/stack.effect.json",
+            "typescript",
+            "7",
           );
         }),
       { timeout: 30_000 },

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -35,8 +35,9 @@ import {
 import { Command } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
-import { recipeTargetFlag, rootFlag } from "../flags";
+import { recipeTargetFlag, rootFlag, typescriptFlag } from "../flags";
 import { parseRecipeTargetSpecs } from "../lib/recipeTargets";
+import { toTypeScriptModuleId } from "../lib/workspace";
 import { RecipeService } from "../service/RecipeService";
 
 const defaultWorkspaceRoot = "workspace/catalog-built";
@@ -163,20 +164,23 @@ const buildWorkspaceSelection = Effect.fn("catalog.workspace.buildSelection")(
     }
 
     const initDefaultModules = [
-      ModuleCategory.make("monorepo"),
-      ModuleCategory.make("lint"),
-      ModuleCategory.make("format"),
-      ModuleCategory.make("test"),
-    ].flatMap((category) =>
-      pipe(
-        catalog.getModules({ category }),
-        Arr.head,
-        Option.match({
-          onNone: () => [],
-          onSome: (moduleDefinition) => [moduleDefinition.id],
-        }),
+      ModuleId.make(toTypeScriptModuleId(config.typescriptVersion)),
+      ...[
+        ModuleCategory.make("monorepo"),
+        ModuleCategory.make("lint"),
+        ModuleCategory.make("format"),
+        ModuleCategory.make("test"),
+      ].flatMap((category) =>
+        pipe(
+          catalog.getModules({ category }),
+          Arr.head,
+          Option.match({
+            onNone: () => [],
+            onSome: (moduleDefinition) => [moduleDefinition.id],
+          }),
+        ),
       ),
-    );
+    ];
 
     const initTarget = ensureTarget(
       new TargetIdentity({
@@ -553,7 +557,7 @@ const runFinalizeScripts = Effect.fn("catalog.workspace.runFinalizeScripts")(
 
 const reset = Command.make(
   "reset",
-  { root: rootFlag, target: recipeTargetFlag },
+  { root: rootFlag, target: recipeTargetFlag, typescript: typescriptFlag },
   (flags) =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -574,6 +578,7 @@ const reset = Command.make(
       const config = new StackConfig({
         name: "catalog-built" as typeof Schema.NonEmptyString.Type,
         runtime: { _tag: "bun" },
+        typescript: Option.getOrElse(flags.typescript, () => "6" as const),
         lint: "biome",
         format: "biome",
         test: "vitest",

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -16,6 +16,7 @@ import {
   runtimeFlag,
   testFlag,
   trustFlag,
+  typescriptFlag,
   yesFlag,
 } from "../flags";
 import { resolveNameAndRoot } from "../lib/project";
@@ -26,6 +27,7 @@ import { ScaffoldPipeline } from "../service/ScaffoldPipeline";
 const DEFAULTS = {
   runtime: "bun",
   packageManager: "bun",
+  typescript: "6",
   monorepo: "turbo",
   lint: "biome",
   format: "biome",
@@ -68,6 +70,7 @@ const buildConfig = ({
   projectName,
   runtime,
   packageManager,
+  typescript,
   monorepo,
   lint,
   format,
@@ -76,6 +79,7 @@ const buildConfig = ({
   readonly projectName: string;
   readonly runtime: Option.Option<"bun" | "node">;
   readonly packageManager: Option.Option<"bun" | "pnpm" | "npm">;
+  readonly typescript: Option.Option<"6" | "7">;
   readonly monorepo: Option.Option<string>;
   readonly lint: Option.Option<string>;
   readonly format: Option.Option<string>;
@@ -101,6 +105,7 @@ const buildConfig = ({
   return new StackConfig({
     name: projectName as typeof Schema.NonEmptyString.Type,
     runtime: runtimeConfig,
+    typescript: Option.getOrElse(typescript, () => DEFAULTS.typescript),
     monorepo: Option.getOrElse(monorepo, () => DEFAULTS.monorepo),
     lint: Option.getOrElse(lint, () => DEFAULTS.lint),
     format: Option.getOrElse(format, () => DEFAULTS.format),
@@ -136,6 +141,7 @@ export const create = Command.make(
     root: rootFlag,
     runtime: runtimeFlag,
     packageManager: packageManagerFlag,
+    typescript: typescriptFlag,
     monorepo: monorepoFlag,
     lint: lintFlag,
     format: formatFlag,
@@ -176,6 +182,7 @@ export const create = Command.make(
         projectName,
         runtime: flags.runtime,
         packageManager: flags.packageManager,
+        typescript: flags.typescript,
         monorepo: flags.monorepo,
         lint: flags.lint,
         format: flags.format,

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -16,6 +16,7 @@ import {
   rootFlag,
   runtimeFlag,
   trustFlag,
+  typescriptFlag,
   yesFlag,
 } from "../flags";
 import { resolveNameAndRoot } from "../lib/project";
@@ -86,6 +87,7 @@ export const init = Command.make(
     yes: yesFlag,
     dryRun: dryRunFlag,
     runtime: runtimeFlag,
+    typescript: typescriptFlag,
     noGit: noGitFlag,
     trust: trustFlag,
   },
@@ -172,6 +174,18 @@ export const init = Command.make(
               ],
             });
 
+      const typescript = Option.isSome(flags.typescript)
+        ? flags.typescript.value
+        : flags.yes
+          ? ("6" as const)
+          : yield* Select({
+              message: "What TypeScript version will you use?",
+              choices: [
+                { title: "TypeScript 6", value: "6" as const },
+                { title: "TypeScript 7", value: "7" as const },
+              ],
+            });
+
       let runtime: typeof StackConfig.fields.runtime.Type;
       if (runtimeChoice === "bun") {
         runtime = { _tag: "bun" };
@@ -238,6 +252,7 @@ export const init = Command.make(
       const config = new StackConfig({
         name: projectName as typeof Schema.NonEmptyString.Type,
         runtime,
+        typescript,
         ...Option.match(lint, {
           onNone: () => ({}),
           onSome: (v) => ({ lint: v }),
@@ -271,6 +286,7 @@ export const init = Command.make(
                   Box.text("Directory:"),
                   Box.text("Runtime:"),
                   Box.text("Package manager:"),
+                  Box.text("TypeScript:"),
                   Box.text("Monorepo:"),
                   Box.text("Lint:"),
                   Box.text("Format:"),
@@ -287,6 +303,7 @@ export const init = Command.make(
                   Box.text(repoRoot),
                   Box.text(config.runtimeName),
                   Box.text(config.packageManagerName),
+                  Box.text(config.typescriptVersion),
                   Box.text(config.monorepo ?? "none"),
                   Box.text(config.lint ?? "none"),
                   Box.text(config.format ?? "none"),

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -52,6 +52,11 @@ export const runtimeFlag = Flag.choice("runtime", ["bun", "node"]).pipe(
   Flag.withDescription("Runtime to use"),
 );
 
+export const typescriptFlag = Flag.choice("typescript", ["6", "7"]).pipe(
+  Flag.optional,
+  Flag.withDescription("TypeScript major version to configure"),
+);
+
 export const packageManagerFlag = Flag.choice("package-manager", [
   "bun",
   "pnpm",

--- a/apps/cli/src/lib/workspace.ts
+++ b/apps/cli/src/lib/workspace.ts
@@ -19,3 +19,6 @@ export const toWorkspaceModuleId = (toolValue: string): string =>
 
 export const toWorkspaceToolValue = (moduleId: string): string =>
   moduleToolValues[moduleId] ?? moduleId;
+
+export const toTypeScriptModuleId = (version: "6" | "7"): string =>
+  `workspace-typescript-${version}`;

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -738,6 +738,7 @@ describe("RecipeService", () => {
           lint: "eslint",
           format: "prettier",
           test: "vitest",
+          typescript: "7",
         });
         const selection = yield* service.resolve(
           {
@@ -762,7 +763,7 @@ describe("RecipeService", () => {
 
         assert.strictEqual(
           service.renderCreateCommand({ config, selection }),
-          "stack-effect create 'node app' --target client-react/web:client-react-vite,client-react-chat --runtime node --package-manager pnpm --lint eslint --format prettier --no-git",
+          "stack-effect create 'node app' --target client-react/web:client-react-vite,client-react-chat --runtime node --package-manager pnpm --typescript 7 --lint eslint --format prettier --no-git",
         );
       }).pipe(Effect.provide(TestLayer)),
     );

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -200,11 +200,36 @@ describe("RecipeService", () => {
           );
 
           assertTargetModules(selection, ".", [
+            ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
             ModuleId.make("workspace-quality-biome"),
             ModuleId.make("workspace-test-vitest"),
           ]);
         }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect("should select the TypeScript 7 workspace module", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const config = new StackConfig({
+          ...testConfig,
+          typescript: "7",
+        });
+        const selection = yield* service.resolve(
+          { targets: [] },
+          {
+            config,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        assertTargetModules(selection, ".", [
+          ModuleId.make("workspace-typescript-7"),
+          ModuleId.make("workspace-monorepo-turbo"),
+          ModuleId.make("workspace-quality-biome"),
+          ModuleId.make("workspace-test-vitest"),
+        ]);
+      }).pipe(Effect.provide(TestLayer)),
     );
 
     it.effect(
@@ -231,6 +256,7 @@ describe("RecipeService", () => {
           );
 
           assertTargetModules(selection, ".", [
+            ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
             ModuleId.make("workspace-quality-biome"),
             ModuleId.make("workspace-test-vitest"),
@@ -271,6 +297,7 @@ describe("RecipeService", () => {
             testConfig.name,
           );
           assertTargetModules(selection, ".", [
+            ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
             ModuleId.make("workspace-quality-biome"),
             ModuleId.make("workspace-test-vitest"),
@@ -307,6 +334,7 @@ describe("RecipeService", () => {
           );
 
           assertTargetModules(selection, ".", [
+            ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
             ModuleId.make("workspace-quality-biome"),
             ModuleId.make("workspace-test-vitest"),
@@ -366,6 +394,7 @@ describe("RecipeService", () => {
         );
 
         assertTargetModules(selection, ".", [
+          ModuleId.make("workspace-typescript-6"),
           ModuleId.make("workspace-monorepo-turbo"),
           ModuleId.make("workspace-quality-biome"),
           ModuleId.make("workspace-test-vitest"),

--- a/apps/cli/src/service/RecipeService.ts
+++ b/apps/cli/src/service/RecipeService.ts
@@ -44,6 +44,7 @@ type CollectedRecipeTarget = {
 const DEFAULTS = {
   runtime: "bun",
   packageManager: "bun",
+  typescript: "6",
   monorepo: "turbo",
   lint: "biome",
   format: "biome",
@@ -246,6 +247,11 @@ export class RecipeService extends Context.Service<
         ...(packageManager === DEFAULTS.packageManager
           ? []
           : ["--package-manager", packageManager]),
+        ...renderChangedFlag(
+          "--typescript",
+          config.typescriptVersion,
+          DEFAULTS.typescript,
+        ),
         ...renderChangedFlag("--monorepo", config.monorepo, DEFAULTS.monorepo),
         ...renderChangedFlag("--lint", config.lint, DEFAULTS.lint),
         ...renderChangedFlag("--format", config.format, DEFAULTS.format),

--- a/apps/cli/src/service/RecipeService.ts
+++ b/apps/cli/src/service/RecipeService.ts
@@ -5,7 +5,7 @@ import { StackConfig } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
 import { Array as Arr, Context, Effect, Layer, Option, pipe } from "effect";
 import { encodeRecipeTargetSpecs } from "../lib/recipeTargets";
-import { toWorkspaceModuleId } from "../lib/workspace";
+import { toTypeScriptModuleId, toWorkspaceModuleId } from "../lib/workspace";
 import {
   AmbiguousRecipeProvider,
   InvalidRecipeSpec,
@@ -65,11 +65,16 @@ const configWorkspaceModules = (
   config: typeof StackConfig.Type,
 ): ReadonlyArray<typeof ModuleId.Type> =>
   Arr.dedupe(
-    [config.monorepo, config.lint, config.format, config.test].flatMap(
-      (moduleId) =>
-        moduleId === undefined
-          ? []
-          : [ModuleId.make(toWorkspaceModuleId(moduleId))],
+    [
+      toTypeScriptModuleId(config.typescriptVersion),
+      config.monorepo,
+      config.lint,
+      config.format,
+      config.test,
+    ].flatMap((moduleId) =>
+      moduleId === undefined
+        ? []
+        : [ModuleId.make(toWorkspaceModuleId(moduleId))],
     ),
   );
 

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -12,10 +12,8 @@ export const cliPackageJsonContents = `{
     "effect": "4.0.0-beta.98"
   },
   "devDependencies": {
-    "@effect/language-service": "^0.87.0",
     "@repo/config-typescript": "{{workspaceDependency}}",
     "@types/bun": "^1.2.17",
-    "typescript": "6.0.2",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/catalog/src/registry/content/client-foldkit.ts
+++ b/packages/catalog/src/registry/content/client-foldkit.ts
@@ -14,11 +14,9 @@ export const foldkitPackageJsonContents = `{
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@effect/language-service": "^0.87.0",
     "@foldkit/vite-plugin": "^0.6.0",
     "@repo/config-typescript": "{{workspaceDependency}}",
     "@tailwindcss/vite": "^4.1.13",
-    "typescript": "6.0.2",
     "vite": "^8.0.10",
     "vitest": "^4.1.4"
   }

--- a/packages/catalog/src/registry/content/client.ts
+++ b/packages/catalog/src/registry/content/client.ts
@@ -40,13 +40,11 @@ export const clientPackageJsonContents = `{
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@effect/language-service": "^0.87.0",
     "@repo/config-typescript": "{{workspaceDependency}}",
     "@tailwindcss/vite": "^4.1.13",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^5.1.0",
-    "typescript": "6.0.2",
     "vite": "^8.0.10",
     "vitest": "^4.1.4"
   }

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -39,7 +39,9 @@ export const rootPackageJsonContents = `{
   "name": "{{targetName}}",
   "private": true,
   "packageManager": "{{packageManagerSpec}}",
-  "scripts": {},
+  "scripts": {
+    "prepare": "effect-language-service patch"
+  },
   "devDependencies": {
     "@effect/language-service": "^0.87.0",
     "typescript": "6.0.2"

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -39,13 +39,8 @@ export const rootPackageJsonContents = `{
   "name": "{{targetName}}",
   "private": true,
   "packageManager": "{{packageManagerSpec}}",
-  "scripts": {
-    "prepare": "effect-language-service patch"
-  },
-  "devDependencies": {
-    "@effect/language-service": "^0.87.0",
-    "typescript": "6.0.2"
-  },
+  "scripts": {},
+  "devDependencies": {},
   "engines": {
     "node": ">=24"
   },
@@ -57,7 +52,7 @@ export const rootPackageJsonContents = `{
 `;
 
 export const rootTsconfigContents = `{
-  "$schema": "./node_modules/@effect/language-service/schema.json",
+  "$schema": "{{#if typescript=6}}./node_modules/@effect/language-service/schema.json{{/if}}{{#if typescript=7}}./node_modules/@effect/tsgo/schema.json{{/if}}",
   "extends": "./packages/config-typescript/base.json",
   "files": []
 }
@@ -73,7 +68,7 @@ allowBuilds:
 `;
 
 export const configTypescriptBaseContents = `{
-  "$schema": "../../node_modules/@effect/language-service/schema.json",
+  "$schema": "{{#if typescript=6}}../../node_modules/@effect/language-service/schema.json{{/if}}{{#if typescript=7}}../../node_modules/@effect/tsgo/schema.json{{/if}}",
   "display": "Default",
   "compilerOptions": {
     "moduleResolution": "bundler",

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -9,10 +9,8 @@ export const serverPackageJsonContents = `{
     "effect": "4.0.0-beta.98"
   },
   "devDependencies": {
-    "@effect/language-service": "^0.87.0",
     "@repo/config-typescript": "{{workspaceDependency}}",
     "@types/bun": "^1.2.17",
-    "typescript": "6.0.2",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/catalog/src/registry/content/shared.ts
+++ b/packages/catalog/src/registry/content/shared.ts
@@ -8,10 +8,8 @@ export const packagePackageJsonContents = `{
     "effect": "4.0.0-beta.98"
   },
   "devDependencies": {
-    "@effect/language-service": "^0.87.0",
     "@repo/config-typescript": "{{workspaceDependency}}",
     "@types/bun": "^1.2.17",
-    "typescript": "6.0.2",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -118,6 +118,89 @@ const devcontainerModule: typeof ModuleDefinition.Type = {
 
 export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
+    id: ModuleId.make("workspace-typescript-6"),
+    title: "TypeScript 6",
+    description: "TypeScript 6 with the Effect language-service plugin",
+    visibility: "internal",
+    categories: [ModuleCategory.make("typescript")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "@effect/language-service",
+        value: "^0.87.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "typescript",
+        value: "6.0.3",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "prepare",
+        value: "effect-language-service patch",
+      },
+    ],
+  },
+  {
+    id: ModuleId.make("workspace-typescript-7"),
+    title: "TypeScript 7",
+    description: "TypeScript 7 with the native Effect TypeScript-Go server",
+    visibility: "internal",
+    categories: [ModuleCategory.make("typescript")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "@effect/tsgo",
+        value: "^0.22.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "typescript",
+        value: "7.0.2",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "prepare",
+        value: "effect-tsgo patch",
+      },
+    ],
+    nextSteps: [
+      "TypeScript 7: Configure your editor to use Effect TSGo as its sole TypeScript language server.",
+    ],
+  },
+  {
     id: ModuleId.make("workspace-monorepo-turbo"),
     title: "Turborepo",
     description: "Monorepo build orchestration with caching",

--- a/packages/domain/src/Scaffold.test.ts
+++ b/packages/domain/src/Scaffold.test.ts
@@ -163,6 +163,44 @@ describe("@repo/domain Scaffold", () => {
   });
 });
 
+describe("StackConfig TypeScript version", () => {
+  it("accepts supported TypeScript major versions", () => {
+    const typescript6 = Schema.decodeUnknownSync(StackConfig)({
+      name: "typescript-6",
+      runtime: { _tag: "bun" },
+      typescript: "6",
+    });
+    const typescript7 = Schema.decodeUnknownSync(StackConfig)({
+      name: "typescript-7",
+      runtime: { _tag: "bun" },
+      typescript: "7",
+    });
+
+    expect(typescript6.typescript).toBe("6");
+    expect(typescript7.typescript).toBe("7");
+  });
+
+  it("keeps existing configs without a TypeScript version decodable", () => {
+    const config = Schema.decodeUnknownSync(StackConfig)({
+      name: "existing-project",
+      runtime: { _tag: "bun" },
+    });
+
+    expect(config.typescript).toBeUndefined();
+    expect(config.typescriptVersion).toBe("6");
+  });
+
+  it("rejects unsupported TypeScript major versions", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(StackConfig)({
+        name: "unsupported-version",
+        runtime: { _tag: "bun" },
+        typescript: "8",
+      }),
+    ).toThrow();
+  });
+});
+
 describe("ContributionTokenContext.resolve", () => {
   const makeContext = (
     configOverrides: Partial<typeof StackConfig.Type> = {},
@@ -201,6 +239,11 @@ describe("ContributionTokenContext.resolve", () => {
       expect(ctx.resolve("{{monorepo}}")).toBe("turbo");
     });
 
+    it("resolves {{typescript}} token", () => {
+      const ctx = makeContext({ typescript: "7" });
+      expect(ctx.resolve("{{typescript}}")).toBe("7");
+    });
+
     it("resolves workspace dependencies for Bun", () => {
       expect(makeContext().resolve("{{workspaceDependency}}")).toBe(
         "workspace:*",
@@ -227,6 +270,7 @@ describe("ContributionTokenContext.resolve", () => {
       expect(ctx.resolve("{{format}}")).toBe("");
       expect(ctx.resolve("{{test}}")).toBe("");
       expect(ctx.resolve("{{monorepo}}")).toBe("");
+      expect(ctx.resolve("{{typescript}}")).toBe("6");
     });
   });
 

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -24,14 +24,21 @@ const Runtime = Schema.TaggedUnion({
   },
 });
 
+export const TypeScriptVersion = Schema.Literals(["6", "7"]);
+
 export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   name: Schema.NonEmptyString,
   runtime: Runtime,
+  typescript: Schema.optional(TypeScriptVersion),
   lint: Schema.optional(Schema.String),
   format: Schema.optional(Schema.String),
   test: Schema.optional(Schema.String),
   monorepo: Schema.optional(Schema.String),
 }) {
+  get typescriptVersion(): typeof TypeScriptVersion.Type {
+    return this.typescript ?? "6";
+  }
+
   get runtimeName(): "bun" | "node" {
     return this.runtime._tag;
   }
@@ -74,6 +81,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
    * - `{{runtime}}` - "bun" or "node"
    * - `{{packageManager}}` - "bun", "npm", or "pnpm"
    * - `{{packageManagerSpec}}` - Full version spec (e.g., "bun@1.2.21")
+   * - `{{typescript}}` - TypeScript major version ("6" or "7"; defaults to "6")
    * - `{{workspaceDependency}}` - Package-manager-compatible local workspace range
    * - `{{lint}}` - Lint tool ("biome", "oxlint", or "")
    * - `{{format}}` - Format tool ("biome", "dprint", or "")
@@ -107,6 +115,8 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
           return this.config.runtimeName;
         case "packageManager":
           return this.config.packageManagerName;
+        case "typescript":
+          return this.config.typescriptVersion;
         case "lint":
           return this.config.lint ?? "";
         case "format":
@@ -143,6 +153,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
           .replaceAll("{{runtime}}", this.config.runtimeName)
           .replaceAll("{{packageManager}}", this.config.packageManagerName)
           .replaceAll("{{packageManagerSpec}}", this.config.packageManagerSpec)
+          .replaceAll("{{typescript}}", this.config.typescriptVersion)
           .replaceAll(
             "{{workspaceDependency}}",
             this.config.workspaceDependency,


### PR DESCRIPTION
## Goals/Scope

Enable TypeScript 7 support by patching language server initialization

## Description

- Patch language server initialization to apply required language fixes
- Support configuring TypeScript version per domain
- Configure TypeScript version during CLI project creation
- Provide TypeScript workspace modules and select them based on the configured TypeScript version
