### PR TITLE
fix: honor Node runtime in generated targets

### DIFF
--- a/.changeset/metal-rocks-serve.md
+++ b/.changeset/metal-rocks-serve.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+`stack-effect` now generates Node-compatible shared, server, and CLI targets when the Node runtime is selected ([#185](https://github.com/lloydrichards/stack-effect/issues/185)).

--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -52,6 +52,75 @@ describe("add", () => {
     );
 
     it.effect(
+      "generates Node-compatible package, server, and CLI targets",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const root = `${cli.workdir}/node-targets`;
+
+          yield* cli.run(
+            "init",
+            "node-targets",
+            "--yes",
+            "--runtime",
+            "node",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* Effect.forEach(
+            [
+              "package/domain:domain-api-contracts",
+              "server/api:server-http-api",
+              "cli/app:cli-command-hello",
+            ],
+            (target) =>
+              Effect.gen(function* () {
+                yield* cli.run(
+                  "add",
+                  "--yes",
+                  "--root",
+                  root,
+                  "--target",
+                  target,
+                );
+                yield* cli.expectExitCode(0);
+              }),
+            { discard: true },
+          );
+
+          yield* cli.withinProject("node-targets", function* (project) {
+            yield* Effect.forEach(
+              [
+                "packages/domain/package.json",
+                "apps/server-api/package.json",
+                "apps/cli-app/package.json",
+              ],
+              (packageJson) =>
+                project.expectFileContaining(
+                  packageJson,
+                  /^(?![\s\S]*@types\/bun)[\s\S]*$/,
+                ),
+              { discard: true },
+            );
+
+            yield* project.expectFileContaining(
+              "apps/server-api/src/index.ts",
+              'from "@effect/platform-node"',
+            );
+            yield* project.expectFileContaining(
+              "apps/cli-app/src/index.ts",
+              'from "@effect/platform-node"',
+            );
+            yield* project.expectTypeCheckPasses();
+            yield* project.expectBuildSucceeds();
+          });
+        }).pipe(Effect.provide(CLI.layer)),
+      { timeout: 180_000 },
+    );
+
+    it.effect(
       "resolves cross-target implications in non-interactive mode",
       () =>
         Effect.gen(function* () {

--- a/packages/catalog/src/registry/content/cli.ts
+++ b/packages/catalog/src/registry/content/cli.ts
@@ -8,12 +8,12 @@ export const cliPackageJsonContents = `{
   },
   "scripts": {},
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.98",
+    "{{#if runtime=bun}}@effect/platform-bun{{/if}}{{#if runtime=node}}@effect/platform-node{{/if}}": "4.0.0-beta.98",
     "effect": "4.0.0-beta.98"
   },
   "devDependencies": {
     "@repo/config-typescript": "{{workspaceDependency}}",
-    "@types/bun": "^1.2.17",
+    "{{#if runtime=bun}}@types/bun{{/if}}{{#if runtime=node}}@types/node{{/if}}": "{{#if runtime=bun}}^1.2.17{{/if}}{{#if runtime=node}}^24.0.0{{/if}}",
     "vitest": "^4.1.4"
   }
 }
@@ -25,7 +25,7 @@ export const cliTsconfigContents = `{
     "rootDir": "../..",
     "outDir": "dist",
     "noEmit": true,
-    "types": ["@types/bun"]
+    "types": ["{{#if runtime=bun}}bun{{/if}}{{#if runtime=node}}node{{/if}}"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
@@ -37,11 +37,11 @@ export const cliTsconfigContents = `{
  *
  * This is a minimal CLI entrypoint that includes:
  * - A root command with version flag
- * - BunRuntime for execution
+ * - Runtime-specific platform services for execution
  *
  * Additional subcommands are added by modules.
  */
-export const cliIndexContents = `import { BunRuntime, BunServices } from "@effect/platform-bun";
+export const cliIndexContents = `{{#if runtime=bun}}import { BunRuntime, BunServices } from "@effect/platform-bun";{{/if}}{{#if runtime=node}}import { NodeRuntime, NodeServices } from "@effect/platform-node";{{/if}}
 import { Effect, Layer } from "effect";
 import { Command } from "effect/unstable/cli";
 
@@ -51,13 +51,13 @@ const root = Command.make("{{packageName}}");
 const AllCommands = Command.withSubcommands([]);
 
 // NOTE: Modules append additional runtime layers through Layer.mergeAll.
-const RuntimeLayers = Layer.mergeAll(BunServices.layer);
+const RuntimeLayers = Layer.mergeAll({{#if runtime=bun}}BunServices{{/if}}{{#if runtime=node}}NodeServices{{/if}}.layer);
 
 root.pipe(
   AllCommands,
   Command.run({ version: "0.0.0" }),
   Effect.provide(RuntimeLayers),
-  BunRuntime.runMain,
+  {{#if runtime=bun}}BunRuntime{{/if}}{{#if runtime=node}}NodeRuntime{{/if}}.runMain,
 );
 `;
 

--- a/packages/catalog/src/registry/content/server.ts
+++ b/packages/catalog/src/registry/content/server.ts
@@ -5,12 +5,12 @@ export const serverPackageJsonContents = `{
   "type": "module",
   "scripts": {},
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.98",
+    "{{#if runtime=bun}}@effect/platform-bun{{/if}}{{#if runtime=node}}@effect/platform-node{{/if}}": "4.0.0-beta.98",
     "effect": "4.0.0-beta.98"
   },
   "devDependencies": {
     "@repo/config-typescript": "{{workspaceDependency}}",
-    "@types/bun": "^1.2.17",
+    "{{#if runtime=bun}}@types/bun{{/if}}{{#if runtime=node}}@types/node{{/if}}": "{{#if runtime=bun}}^1.2.17{{/if}}{{#if runtime=node}}^24.0.0{{/if}}",
     "vitest": "^4.1.4"
   }
 }
@@ -22,7 +22,7 @@ export const serverTsconfigContents = `{
     "rootDir": "../..",
     "outDir": "dist",
     "noEmit": true,
-    "types": ["@types/bun"]
+    "types": ["{{#if runtime=bun}}bun{{/if}}{{#if runtime=node}}node{{/if}}"]
   },
   "include": ["src/**/*", "../../packages/ai/src/LanguageModel.ts"],
   "exclude": ["node_modules", "dist"]
@@ -38,7 +38,8 @@ export const serverTsconfigContents = `{
  *
  * Additional capabilities (RPC, WebSocket) are added by modules.
  */
-export const serverIndexContents = `import { BunHttpServer, BunRuntime } from "@effect/platform-bun";
+export const serverIndexContents = `{{#if runtime=bun}}import { BunHttpServer, BunRuntime } from "@effect/platform-bun";{{/if}}{{#if runtime=node}}import { NodeHttpServer, NodeRuntime } from "@effect/platform-node";
+import { createServer } from "node:http";{{/if}}
 import { Api } from "@repo/domain/Api";
 import { Config, Effect, Layer } from "effect";
 import { HttpRouter, HttpServer } from "effect/unstable/http";
@@ -67,7 +68,7 @@ const AllRouters = Layer.mergeAll(ApiRouter).pipe(
 );
 
 // NOTE: Modules append additional server layers through Layer.mergeAll.
-const ServerLayers = Layer.mergeAll(BunHttpServer.layerConfig(ServerConfig));
+const ServerLayers = Layer.mergeAll({{#if runtime=bun}}BunHttpServer.layerConfig(ServerConfig){{/if}}{{#if runtime=node}}NodeHttpServer.layerConfig(createServer, ServerConfig){{/if}});
 
 const HttpLive = Effect.gen(function* () {
   const config = yield* ServerConfig;
@@ -94,7 +95,7 @@ const HttpLive = Effect.gen(function* () {
   );
 }).pipe(Layer.unwrap, Layer.launch);
 
-BunRuntime.runMain(HttpLive);
+{{#if runtime=bun}}BunRuntime{{/if}}{{#if runtime=node}}NodeRuntime{{/if}}.runMain(HttpLive);
 `;
 
 export const serverDevToolsContents = `import { Config, Effect, Layer } from "effect";

--- a/packages/catalog/src/registry/content/shared.ts
+++ b/packages/catalog/src/registry/content/shared.ts
@@ -9,7 +9,6 @@ export const packagePackageJsonContents = `{
   },
   "devDependencies": {
     "@repo/config-typescript": "{{workspaceDependency}}",
-    "@types/bun": "^1.2.17",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/catalog/src/registry/targetRegistry.ts
+++ b/packages/catalog/src/registry/targetRegistry.ts
@@ -355,9 +355,24 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "{{#if runtime=node}}esbuild{{/if}}",
+        value: "^0.27.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "{{#if runtime=node}}tsx{{/if}}",
+        value: "^4.20.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "build",
-        value: "bun build src/index.ts --outdir=dist --target=bun --minify",
+        value:
+          "{{#if runtime=bun}}bun build src/index.ts --outdir=dist --target=bun --minify{{/if}}{{#if runtime=node}}esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js{{/if}}",
       },
       {
         _tag: "pkg-json-entry",
@@ -371,14 +386,16 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "dev",
-        value: "bun run src/index.ts",
+        value:
+          "{{#if runtime=bun}}bun run src/index.ts{{/if}}{{#if runtime=node}}tsx src/index.ts{{/if}}",
       },
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "dev:watch",
-        value: "bun --watch run src/index.ts",
+        value:
+          "{{#if runtime=bun}}bun --watch run src/index.ts{{/if}}{{#if runtime=node}}tsx watch src/index.ts{{/if}}",
       },
       {
         _tag: "pkg-json-entry",
@@ -430,9 +447,24 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "{{#if runtime=node}}esbuild{{/if}}",
+        value: "^0.27.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "{{#if runtime=node}}tsx{{/if}}",
+        value: "^4.20.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "build",
-        value: "bun build src/index.ts --outdir=dist --target=bun --minify",
+        value:
+          "{{#if runtime=bun}}bun build src/index.ts --outdir=dist --target=bun --minify{{/if}}{{#if runtime=node}}esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js{{/if}}",
       },
       {
         _tag: "pkg-json-entry",
@@ -446,7 +478,8 @@ export const targetRegistry: ReadonlyArray<typeof TargetDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "dev",
-        value: "bun --watch run src/index.ts",
+        value:
+          "{{#if runtime=bun}}bun --watch run src/index.ts{{/if}}{{#if runtime=node}}tsx watch src/index.ts{{/if}}",
       },
       {
         _tag: "pkg-json-entry",


### PR DESCRIPTION
## Goals/Scope

Ensure generated catalog targets respect the configured Node runtime

---

- [x] closes #185