### PR TITLE
fix: validate jsx-slot in planning

### DIFF
--- a/.changeset/curly-papayas-start.md
+++ b/.changeset/curly-papayas-start.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+`stack-effect` now plans missing JSX slots explicitly and avoids duplicate slot content on repeated application ([#178](https://github.com/lloydrichards/stack-effect/issues/178)).

--- a/packages/domain/src/Plan.test.ts
+++ b/packages/domain/src/Plan.test.ts
@@ -105,6 +105,16 @@ describe("@repo/domain Plan", () => {
       ],
       conflicts: [
         {
+          _tag: "jsxSlotTargetNotFound",
+          path: "apps/web/src/App.tsx",
+          slotId: "footer",
+        },
+        {
+          _tag: "jsxSlotTargetNotFound",
+          path: "apps/web/src/App.tsx",
+          slotId: "components",
+        },
+        {
           _tag: "tsconfig",
           path: "packages/domain/tsconfig.json",
         },
@@ -122,7 +132,21 @@ describe("@repo/domain Plan", () => {
     ]);
     expect(plan.conflicts.map((conflict) => conflict.path)).toEqual([
       "packages/domain/src/index.ts",
+      "apps/web/src/App.tsx",
+      "apps/web/src/App.tsx",
       "packages/domain/tsconfig.json",
+    ]);
+    expect(plan.conflicts.slice(1, 3)).toEqual([
+      {
+        _tag: "jsxSlotTargetNotFound",
+        path: "apps/web/src/App.tsx",
+        slotId: "components",
+      },
+      {
+        _tag: "jsxSlotTargetNotFound",
+        path: "apps/web/src/App.tsx",
+        slotId: "footer",
+      },
     ]);
   });
 });

--- a/packages/domain/src/Plan.ts
+++ b/packages/domain/src/Plan.ts
@@ -158,6 +158,10 @@ export const PlanConflict = Schema.TaggedUnion({
     targetVariable: Schema.String,
     functionName: Schema.String,
   },
+  jsxSlotTargetNotFound: {
+    path: Schema.String,
+    slotId: Schema.String,
+  },
 });
 
 /**
@@ -195,6 +199,8 @@ export class Plan extends Schema.Class<Plan>("Plan")({
               completeFile: (c) => `completeFile:${c.path}`,
               compositionTargetNotFound: (c) =>
                 `compositionTargetNotFound:${c.path}:${c.targetVariable}:${c.functionName}`,
+              jsxSlotTargetNotFound: (c) =>
+                `jsxSlotTargetNotFound:${c.path}:${c.slotId}`,
             }),
         ),
       ),

--- a/packages/scaffold/src/service/JsxSlot.ts
+++ b/packages/scaffold/src/service/JsxSlot.ts
@@ -1,0 +1,27 @@
+import {
+  type JsxExpression,
+  Project,
+  type SourceFile,
+  SyntaxKind,
+} from "ts-morph";
+
+export const makeJsxSourceFile = (contents: string): SourceFile =>
+  new Project({
+    useInMemoryFileSystem: true,
+    skipAddingFilesFromTsConfig: true,
+  }).createSourceFile("temp.tsx", contents);
+
+export const jsxSlotMarker = (slotId: string) => `{/* @slot:${slotId} */}`;
+
+export const findJsxSlotMarker = (
+  sourceFile: SourceFile,
+  slotId: string,
+): JsxExpression | undefined => {
+  const marker = jsxSlotMarker(slotId);
+  return sourceFile
+    .getDescendantsOfKind(SyntaxKind.JsxExpression)
+    .find((expression) => expression.getText() === marker);
+};
+
+export const isJsxSlotMarker = (expression: JsxExpression): boolean =>
+  /^\{\/\* @slot:[^*]+ \*\/\}$/u.test(expression.getText());

--- a/packages/scaffold/src/service/ScaffolFormatter.ts
+++ b/packages/scaffold/src/service/ScaffolFormatter.ts
@@ -386,6 +386,7 @@ const formatConflictLine = (conflict: typeof PlanConflict.Type) =>
         tsconfig: () => "merge: tsconfig",
         compositionTargetNotFound: (c) =>
           `composition target not found: ${c.targetVariable} (${c.functionName})`,
+        jsxSlotTargetNotFound: (c) => `JSX slot target not found: ${c.slotId}`,
       }),
       Match.exhaustive,
     ),

--- a/packages/scaffold/src/service/ScaffoldFormatter.test.ts
+++ b/packages/scaffold/src/service/ScaffoldFormatter.test.ts
@@ -240,5 +240,40 @@ describe("ScaffoldFormatter", () => {
           );
         }),
     );
+
+    it.effect("formats a missing JSX slot conflict", () =>
+      Effect.gen(function* () {
+        const formatter = yield* ScaffoldFormatter;
+        const plan = new Plan({
+          outcomes: [
+            {
+              _tag: "composed",
+              path: "apps/web/src/App.tsx",
+              classification: "conflict",
+              operations: [
+                {
+                  _tag: "ts-jsx-slot",
+                  fileType: "typescript",
+                  slotId: "components",
+                  content: "<Card />",
+                },
+              ],
+            },
+          ],
+          conflicts: [
+            {
+              _tag: "jsxSlotTargetNotFound",
+              path: "apps/web/src/App.tsx",
+              slotId: "components",
+            },
+          ],
+        });
+
+        const result = yield* formatter.formatPlan(plan);
+        expect(Box.renderPlainSync(result.tree)).toContain(
+          "JSX slot target not found: components",
+        );
+      }),
+    );
   });
 });

--- a/packages/scaffold/src/service/apply/TypeScriptComposer.test.ts
+++ b/packages/scaffold/src/service/apply/TypeScriptComposer.test.ts
@@ -1,0 +1,118 @@
+/** @effect-diagnostics globalErrorInEffectFailure:skip-file */
+import { describe, expect, it } from "@effect/vitest";
+import type { CompositionOperation } from "@repo/domain/Plan";
+import { Effect } from "effect";
+import { TypeScriptComposer } from "./TypeScriptComposer";
+
+const compose = (
+  contents: string,
+  operations: ReadonlyArray<typeof CompositionOperation.cases.typescript.Type>,
+) =>
+  Effect.gen(function* () {
+    const composer = yield* TypeScriptComposer;
+    return yield* composer.compose(contents, operations);
+  }).pipe(Effect.provide(TypeScriptComposer.layer));
+
+const jsxSlot = (slotId: string, content: string) =>
+  ({
+    _tag: "ts-jsx-slot",
+    fileType: "typescript",
+    slotId,
+    content,
+  }) as const;
+
+describe("TypeScriptComposer JSX slots", () => {
+  it.effect("fails when the requested marker is absent", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(
+        compose("export const App = () => <main />;", [
+          jsxSlot("components", "<Card />"),
+        ]),
+      );
+
+      expect(failure).toMatchObject({
+        _tag: "ApplyFailure",
+        reason: "repoRootInvalid",
+        message:
+          "Could not find JSX slot {/* @slot:components */} during TypeScript composition.",
+      });
+    }),
+  );
+
+  it.effect("preserves contribution order and is idempotent", () =>
+    Effect.gen(function* () {
+      const input = `export const App = () => (\n  <main>\n    {/* @slot:components */}\n  </main>\n);\n`;
+      const operations = [
+        jsxSlot("components", "<Alpha />"),
+        {
+          _tag: "ts-add-import",
+          fileType: "typescript",
+          moduleSpecifier: "./cards",
+          namedImports: ["Alpha", "Beta"],
+        } as const,
+        jsxSlot("components", "<Beta />"),
+      ];
+
+      const once = yield* compose(input, operations);
+      const twice = yield* compose(once, operations);
+
+      expect(once.indexOf("<Alpha />")).toBeLessThan(once.indexOf("<Beta />"));
+      expect(twice).toBe(once);
+      expect(twice.match(/<Alpha \/>/g)).toHaveLength(1);
+      expect(twice.match(/<Beta \/>/g)).toHaveLength(1);
+      expect(twice.match(/from "\.\/cards"/g)).toHaveLength(1);
+    }),
+  );
+
+  it.effect(
+    "does not treat matching content outside the slot as inserted",
+    () =>
+      Effect.gen(function* () {
+        const input = `export const App = () => (\n  <>\n    <main>\n      {/* @slot:components */}\n    </main>\n    <aside><Card /></aside>\n  </>\n);\n`;
+
+        const output = yield* compose(input, [
+          jsxSlot("components", "<Card />"),
+        ]);
+
+        expect(output.match(/<Card \/>/g)).toHaveLength(2);
+      }),
+  );
+
+  it.effect("bounds duplicate detection at the next sibling slot", () =>
+    Effect.gen(function* () {
+      const input = `export const App = () => (
+  <main>
+    {/* @slot:first */}
+    {/* @slot:second */}
+    <Card />
+  </main>
+);
+`;
+
+      const output = yield* compose(input, [jsxSlot("first", "<Card />")]);
+
+      expect(output.match(/<Card \/>/g)).toHaveLength(2);
+      expect(output.indexOf("<Card />")).toBeLessThan(
+        output.indexOf("{/* @slot:second */}"),
+      );
+    }),
+  );
+
+  it.effect("is idempotent when the slot belongs to a JSX fragment", () =>
+    Effect.gen(function* () {
+      const input = `export const App = () => (
+  <>
+    {/* @slot:components */}
+  </>
+);
+`;
+      const operations = [jsxSlot("components", "<Card />")];
+
+      const once = yield* compose(input, operations);
+      const twice = yield* compose(once, operations);
+
+      expect(twice).toBe(once);
+      expect(twice.match(/<Card \/>/g)).toHaveLength(1);
+    }),
+  );
+});

--- a/packages/scaffold/src/service/apply/TypeScriptComposer.ts
+++ b/packages/scaffold/src/service/apply/TypeScriptComposer.ts
@@ -23,6 +23,7 @@ import type {
   SourceFile,
 } from "ts-morph";
 import { Project, SyntaxKind } from "ts-morph";
+import { findJsxSlotMarker, isJsxSlotMarker, jsxSlotMarker } from "../JsxSlot";
 
 export interface TypeScriptComposerShape {
   readonly compose: (
@@ -49,7 +50,14 @@ export class TypeScriptComposer extends Context.Service<
         skipAddingFilesFromTsConfig: true,
       });
 
-      const sourceFile = project.createSourceFile("temp.ts", contents);
+      const sourceFile = project.createSourceFile(
+        operations.some((operation) => operation._tag === "ts-jsx-slot")
+          ? "temp.tsx"
+          : "temp.ts",
+        contents,
+      );
+
+      const previousJsxSlotContents = new Map<string, string>();
 
       yield* Effect.forEach(
         operations,
@@ -68,7 +76,7 @@ export class TypeScriptComposer extends Context.Service<
               applyTsObjectField(sourceFile, fieldOp),
             ),
             Match.tag("ts-jsx-slot", (slotOp) =>
-              Effect.sync(() => applyTsJsxSlot(sourceFile, slotOp)),
+              applyTsJsxSlot(sourceFile, slotOp, previousJsxSlotContents),
             ),
             Match.exhaustive,
           ),
@@ -306,14 +314,59 @@ const missingTarget = (targetVariable: string, functionName: string) =>
 const applyTsJsxSlot = (
   sourceFile: SourceFile,
   op: typeof TsJsxSlotOp.Type,
-): void => {
-  const text = sourceFile.getFullText();
-  const slotMarker = `{/* @slot:${op.slotId} */}`;
-  const index = text.indexOf(slotMarker);
+  previousContents: Map<string, string>,
+) =>
+  Effect.suspend(() => {
+    const text = sourceFile.getFullText();
+    const marker = findJsxSlotMarker(sourceFile, op.slotId);
 
-  if (index === -1) return;
+    if (!marker) {
+      return Effect.fail(
+        new ApplyFailure({
+          reason: "repoRootInvalid",
+          message: `Could not find JSX slot ${jsxSlotMarker(op.slotId)} during TypeScript composition.`,
+        }),
+      );
+    }
 
-  const insertPos = index + slotMarker.length;
-  const newText = `${text.slice(0, insertPos)}\n        ${op.content}${text.slice(insertPos)}`;
-  sourceFile.replaceWithText(newText);
-};
+    const markerEnd = marker.getEnd();
+    const parent = marker.getParent();
+    const children =
+      parent.getKind() === SyntaxKind.JsxElement
+        ? parent.asKindOrThrow(SyntaxKind.JsxElement).getJsxChildren()
+        : parent.getKind() === SyntaxKind.JsxFragment
+          ? parent.asKindOrThrow(SyntaxKind.JsxFragment).getJsxChildren()
+          : [];
+    const markerIndex = children.findIndex((child) => child === marker);
+    const slotChildren = children.slice(markerIndex + 1);
+    const nextMarkerIndex = slotChildren.findIndex(
+      (child) =>
+        child.getKind() === SyntaxKind.JsxExpression &&
+        isJsxSlotMarker(child.asKindOrThrow(SyntaxKind.JsxExpression)),
+    );
+    const boundedSlotChildren =
+      nextMarkerIndex === -1
+        ? slotChildren
+        : slotChildren.slice(0, nextMarkerIndex);
+    const existingChild = boundedSlotChildren.find(
+      (child) => child.getText().trim() === op.content.trim(),
+    );
+
+    if (existingChild !== undefined) {
+      previousContents.set(op.slotId, op.content);
+      return Effect.void;
+    }
+
+    const previousContent = previousContents.get(op.slotId);
+    const previousChild = boundedSlotChildren.find(
+      (child) => child.getText().trim() === previousContent?.trim(),
+    );
+    const insertPos =
+      previousContent !== undefined && previousChild !== undefined
+        ? previousChild.getEnd()
+        : markerEnd;
+    const newText = `${text.slice(0, insertPos)}\n        ${op.content}${text.slice(insertPos)}`;
+    sourceFile.replaceWithText(newText);
+    previousContents.set(op.slotId, op.content);
+    return Effect.void;
+  });

--- a/packages/scaffold/src/service/plan/PlanAssessor.test.ts
+++ b/packages/scaffold/src/service/plan/PlanAssessor.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { PlanAssessor, type PlanningIntentPath } from "./PlanAssessor";
+
+const makeJsxSlotPath = (
+  contents: string | undefined = undefined,
+): PlanningIntentPath => ({
+  path: "apps/web/src/App.tsx",
+  contents,
+  exports: [],
+  dependencies: [],
+  scripts: [],
+  barrelExports: [],
+  compositions: [],
+  objectFields: [],
+  jsxSlots: [
+    {
+      slotId: "components",
+      content: "<Card />",
+      import: undefined,
+    },
+  ],
+  tsconfig: undefined,
+});
+
+describe("PlanAssessor JSX slots", () => {
+  it.effect("plans a JSX-slot-only contribution to an existing target", () =>
+    Effect.gen(function* () {
+      const assessor = yield* PlanAssessor;
+      const assessment = assessor.assessPlanningPath({
+        planningPath: makeJsxSlotPath(),
+        snapshotPath: {
+          _tag: "file",
+          path: "apps/web/src/App.tsx",
+          contents:
+            "export const App = () => <>\n{/* @slot:components */}\n</>;\n",
+        },
+      });
+
+      expect(assessment).toEqual({
+        classification: "modify",
+        conflicts: [],
+      });
+    }).pipe(Effect.provide(PlanAssessor.layer)),
+  );
+
+  it.effect("reports the slot when a JSX-only target file is missing", () =>
+    Effect.gen(function* () {
+      const assessor = yield* PlanAssessor;
+      const assessment = assessor.assessPlanningPath({
+        planningPath: makeJsxSlotPath(),
+        snapshotPath: {
+          _tag: "missing",
+          path: "apps/web/src/App.tsx",
+        },
+      });
+
+      expect(assessment).toEqual({
+        classification: "conflict",
+        conflicts: [
+          {
+            _tag: "jsxSlotTargetNotFound",
+            path: "apps/web/src/App.tsx",
+            slotId: "components",
+          },
+        ],
+      });
+    }).pipe(Effect.provide(PlanAssessor.layer)),
+  );
+
+  it.effect("reports an existing file without the exact JSX slot marker", () =>
+    Effect.gen(function* () {
+      const assessor = yield* PlanAssessor;
+      const assessment = assessor.assessPlanningPath({
+        planningPath: makeJsxSlotPath(),
+        snapshotPath: {
+          _tag: "file",
+          path: "apps/web/src/App.tsx",
+          contents: "export const App = () => <></>;\n",
+        },
+      });
+
+      expect(assessment.conflicts).toEqual([
+        {
+          _tag: "jsxSlotTargetNotFound",
+          path: "apps/web/src/App.tsx",
+          slotId: "components",
+        },
+      ]);
+    }).pipe(Effect.provide(PlanAssessor.layer)),
+  );
+
+  it.effect("does not accept marker text outside a JSX expression", () =>
+    Effect.gen(function* () {
+      const assessor = yield* PlanAssessor;
+      const assessment = assessor.assessPlanningPath({
+        planningPath: makeJsxSlotPath(),
+        snapshotPath: {
+          _tag: "file",
+          path: "apps/web/src/App.tsx",
+          contents: `const misleading = "{/* @slot:components */}";
+export const App = () => <main />;
+`,
+        },
+      });
+
+      expect(assessment).toEqual({
+        classification: "conflict",
+        conflicts: [
+          {
+            _tag: "jsxSlotTargetNotFound",
+            path: "apps/web/src/App.tsx",
+            slotId: "components",
+          },
+        ],
+      });
+    }).pipe(Effect.provide(PlanAssessor.layer)),
+  );
+
+  it.effect("keeps authoritative seeded creation valid", () =>
+    Effect.gen(function* () {
+      const assessor = yield* PlanAssessor;
+      const assessment = assessor.assessPlanningPath({
+        planningPath: makeJsxSlotPath(
+          "export const App = () => <>\n{/* @slot:components */}\n</>;\n",
+        ),
+        snapshotPath: {
+          _tag: "missing",
+          path: "apps/web/src/App.tsx",
+        },
+      });
+
+      expect(assessment).toEqual({
+        classification: "create",
+        conflicts: [],
+      });
+    }).pipe(Effect.provide(PlanAssessor.layer)),
+  );
+
+  it.effect(
+    "reports a missing marker in an existing authoritative target",
+    () =>
+      Effect.gen(function* () {
+        const assessor = yield* PlanAssessor;
+        const assessment = assessor.assessPlanningPath({
+          planningPath: makeJsxSlotPath(
+            "export const App = () => <>\n{/* @slot:components */}\n</>;\n",
+          ),
+          snapshotPath: {
+            _tag: "file",
+            path: "apps/web/src/App.tsx",
+            contents: "export const App = () => <></>;\n",
+          },
+        });
+
+        expect(assessment.classification).toBe("conflict");
+        expect(assessment.conflicts).toHaveLength(1);
+      }).pipe(Effect.provide(PlanAssessor.layer)),
+  );
+});

--- a/packages/scaffold/src/service/plan/PlanAssessor.ts
+++ b/packages/scaffold/src/service/plan/PlanAssessor.ts
@@ -20,6 +20,7 @@ import {
   Schema,
   String as Str,
 } from "effect";
+import { findJsxSlotMarker, makeJsxSourceFile } from "../JsxSlot";
 
 type PlanningIntentPackageJsonDependency = {
   readonly section: "dependencies" | "devDependencies";
@@ -275,7 +276,8 @@ function assessPlanningPath({
   const hasTsconfig = planningPath.tsconfig !== undefined;
   const hasCompositions =
     planningPath.compositions.length > 0 ||
-    planningPath.objectFields.length > 0;
+    planningPath.objectFields.length > 0 ||
+    planningPath.jsxSlots.length > 0;
 
   return Match.value({
     hasContents,
@@ -471,13 +473,28 @@ const planCompositionMerge = (
   if (existingContents === undefined) {
     return createPathAssessment({
       classification: "conflict",
-      conflicts: Arr.map(planningPath.compositions, (composition) =>
-        planConflict.compositionTargetNotFound(
-          planningPath.path,
-          composition.targetVariable,
-          composition.functionName,
+      conflicts: [
+        ...Arr.map(planningPath.compositions, (composition) =>
+          planConflict.compositionTargetNotFound(
+            planningPath.path,
+            composition.targetVariable,
+            composition.functionName,
+          ),
         ),
-      ),
+        ...collectMissingJsxSlotConflicts(planningPath, existingContents),
+      ],
+    });
+  }
+
+  const jsxSlotConflicts = collectMissingJsxSlotConflicts(
+    planningPath,
+    existingContents,
+  );
+
+  if (jsxSlotConflicts.length > 0) {
+    return createPathAssessment({
+      classification: "conflict",
+      conflicts: jsxSlotConflicts,
     });
   }
 
@@ -554,7 +571,34 @@ const assessCompositionMerge = (
     return createPathAssessment({ classification: "create" });
   }
 
+  const jsxSlotConflicts = collectMissingJsxSlotConflicts(
+    planningPath,
+    existingContents,
+  );
+
+  if (jsxSlotConflicts.length > 0) {
+    return createPathAssessment({
+      classification: "conflict",
+      conflicts: jsxSlotConflicts,
+    });
+  }
+
   return createPathAssessment({ classification: "modify" });
+};
+
+const collectMissingJsxSlotConflicts = (
+  planningPath: PlanningIntentPath,
+  contents: string | undefined,
+) => {
+  const sourceFile =
+    contents === undefined ? undefined : makeJsxSourceFile(contents);
+
+  return Arr.flatMap(planningPath.jsxSlots, ({ slotId }) =>
+    sourceFile !== undefined &&
+    findJsxSlotMarker(sourceFile, slotId) !== undefined
+      ? []
+      : [planConflict.jsxSlotTargetNotFound(planningPath.path, slotId)],
+  );
 };
 
 /**
@@ -641,6 +685,8 @@ const planConflict = {
       targetVariable,
       functionName,
     }),
+  jsxSlotTargetNotFound: (path: string, slotId: string) =>
+    PlanConflict.cases.jsxSlotTargetNotFound.make({ path, slotId }),
 } as const;
 
 const collectInvalidPackageJsonConflicts = (

--- a/packages/scaffold/src/service/plan/PlanRenderer.test.ts
+++ b/packages/scaffold/src/service/plan/PlanRenderer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { renderPlanForLlm } from "./PlanRenderer";
+
+describe("renderPlanForLlm", () => {
+  it("renders a missing JSX slot with its path and slot id", () => {
+    const rendered = renderPlanForLlm({
+      outcomes: [],
+      conflicts: [
+        {
+          _tag: "jsxSlotTargetNotFound",
+          path: "apps/web/src/App.tsx",
+          slotId: "components",
+        },
+      ],
+      summary: {
+        total: 1,
+        create: 0,
+        modify: 0,
+        unchanged: 0,
+        conflict: 1,
+      },
+      tree: "",
+    });
+
+    expect(rendered.conflicts).toEqual([
+      {
+        path: "apps/web/src/App.tsx",
+        kind: "jsx-slot-target-not-found",
+        description:
+          "Cannot find JSX slot `@slot:components` in apps/web/src/App.tsx; add the content manually",
+      },
+    ]);
+  });
+});

--- a/packages/scaffold/src/service/plan/PlanRenderer.ts
+++ b/packages/scaffold/src/service/plan/PlanRenderer.ts
@@ -132,6 +132,11 @@ const renderConflict = (
       kind: "target-not-found",
       description: `Cannot find \`const ${c.targetVariable} = ${c.functionName}(...)\` in ${c.path}; add the argument manually`,
     })),
+    Match.tag("jsxSlotTargetNotFound", (c) => ({
+      path: c.path,
+      kind: "jsx-slot-target-not-found",
+      description: `Cannot find JSX slot \`@slot:${c.slotId}\` in ${c.path}; add the content manually`,
+    })),
     Match.exhaustive,
   );
 


### PR DESCRIPTION
## Goals/Scope

Validate JSX slot planning in the scaffolding flow and ensure JSX slot composition is idempotent (re-running doesn’t change results).

## Description

- Add validation logic for JSX slot planning to catch/handle invalid cases.
- Make JSX slot composition deterministic and safe to apply multiple times.

---

- [x] closes #178