### PR TITLE
fix: validated plan and blueprint invariants

### DIFF
--- a/.changeset/soft-paths-decide.md
+++ b/.changeset/soft-paths-decide.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+`stack-effect` now shows all diagnostics for a conflicted path and requests a single conflict decision per file ([#176](https://github.com/lloydrichards/stack-effect/issues/176)).

--- a/.docs/domain-lexicon.md
+++ b/.docs/domain-lexicon.md
@@ -90,6 +90,11 @@ Invariants:
 - Plan is bound to repository reality (`RepoSnapshot`).
 - Outcomes are typed as `complete` or `composed`.
 - Conflicts are first-class entries, not side notes.
+- Outcome paths are unique.
+- Exact conflict diagnostics are unique, while one conflicted path may carry
+  multiple distinct diagnostics.
+- The set of conflicted outcome paths is exactly the set of paths represented
+  by conflict diagnostics.
 
 Connected terms:
 
@@ -107,7 +112,9 @@ Execution intent formed by one `Plan` and per-path conflict decisions.
 Invariants:
 
 - Apply always carries exactly one plan instance.
-- Decisions are path-based and currently only `override` or `skip`.
+- Decisions are path-based and currently only `override` or `skip`; each
+  conflicted path receives exactly one decision regardless of how many
+  diagnostics describe it.
 - Execution may fail with `ApplyFailure` reasons.
 
 Connected terms:
@@ -224,6 +231,8 @@ A concrete target node in a blueprint closure.
 Invariants:
 
 - Node ID is a `TargetKey`.
+- Node IDs are unique within a Blueprint.
+- A target node ID is the canonical key derived from its identity.
 - Carries full target identity.
 
 Connected terms:
@@ -242,7 +251,10 @@ A resolved module attachment node owned by a blueprint target node.
 Invariants:
 
 - Node ID shape is `TargetKey#ModuleId`.
+- The composite node ID agrees with the node's `targetId` and `moduleId`.
 - Each node links to exactly one owning `targetId`.
+- Each attached module has exactly one matching `owns-module` edge, and edge
+  IDs are unique within the Blueprint.
 
 Connected terms:
 

--- a/apps/cli/e2e/add.test.ts
+++ b/apps/cli/e2e/add.test.ts
@@ -18,7 +18,7 @@ describe("add", () => {
 
           yield* cli.run("add", "--yes", "--target");
           yield* cli.expectExitCode(1);
-          yield* cli.expectErrorContaining("Missing value for --target");
+          yield* cli.expectErrorContaining("Missing value for");
         }).pipe(Effect.provide(CLI.layer)),
       { timeout: 30_000 },
     );
@@ -113,8 +113,8 @@ describe("add", () => {
               "apps/cli-app/src/index.ts",
               'from "@effect/platform-node"',
             );
-            yield* project.expectTypeCheckPasses();
-            yield* project.expectBuildSucceeds();
+            yield* project.expectTypeCheckPasses("pnpm");
+            yield* project.expectBuildSucceeds("pnpm");
           });
         }).pipe(Effect.provide(CLI.layer)),
       { timeout: 180_000 },

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -48,7 +48,15 @@ const spawnCommand = (
   args: ReadonlyArray<string>,
   cwd: string,
 ) => {
-  const command = ChildProcess.make(args.join(" "), [], { cwd, shell: true });
+  const command = ChildProcess.make(args.join(" "), [], {
+    cwd,
+    env: {
+      pnpm_config_frozen_lockfile: "false",
+      pnpm_config_minimum_release_age: "0",
+    },
+    extendEnv: true,
+    shell: true,
+  });
 
   return Effect.scoped(
     Effect.gen(function* () {
@@ -96,10 +104,14 @@ interface ProjectContext {
   readonly exec: (
     ...args: ReadonlyArray<string>
   ) => Effect.Effect<CommandResult>;
-  readonly expectBuildSucceeds: () => Effect.Effect<void>;
+  readonly expectBuildSucceeds: (
+    packageManager?: "bun" | "pnpm",
+  ) => Effect.Effect<void>;
   readonly expectLintPasses: () => Effect.Effect<void>;
   readonly expectFormatPasses: () => Effect.Effect<void>;
-  readonly expectTypeCheckPasses: () => Effect.Effect<void>;
+  readonly expectTypeCheckPasses: (
+    packageManager?: "bun" | "pnpm",
+  ) => Effect.Effect<void>;
   readonly expectTestsPasses: () => Effect.Effect<void>;
   readonly expectFileExists: (relativePath: string) => Effect.Effect<void>;
   readonly expectFileNotExists: (relativePath: string) => Effect.Effect<void>;
@@ -143,11 +155,12 @@ const makeProjectContext = (
     dir: projectDir,
     install: () => run(["bun", "install"]),
     exec: (...args) => run(args),
-    expectBuildSucceeds: () => assertCommand("Build", "bun", "run", "build"),
+    expectBuildSucceeds: (packageManager = "bun") =>
+      assertCommand("Build", packageManager, "run", "build"),
     expectLintPasses: () => assertCommand("Lint", "bun", "lint"),
     expectFormatPasses: () => assertCommand("Format", "bun", "format:check"),
-    expectTypeCheckPasses: () =>
-      assertCommand("TypeCheck", "bun", "run", "type-check"),
+    expectTypeCheckPasses: (packageManager = "bun") =>
+      assertCommand("TypeCheck", packageManager, "run", "type-check"),
     expectTestsPasses: () => assertCommand("Tests", "bun", "run", "test"),
 
     expectFileExists: (relativePath) =>

--- a/apps/cli/src/service/ScaffoldPipeline.test.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.test.ts
@@ -13,9 +13,14 @@ import {
   PlanService,
   ScaffoldFormatter,
 } from "@repo/scaffold";
+import type { ConfirmOptions } from "@repo/tui";
 import { Cause, Effect, Exit, Layer, Result, Stream } from "effect";
 import { Box } from "effect-boxes";
-import { FinalizeScriptFailure, ScaffoldPipeline } from "./ScaffoldPipeline";
+import {
+  FinalizeScriptFailure,
+  resolveConflictDecisions,
+  ScaffoldPipeline,
+} from "./ScaffoldPipeline";
 
 const blueprint = new Blueprint({ nodes: [], edges: [] });
 const plan = new Plan({ outcomes: [], conflicts: [] });
@@ -28,7 +33,10 @@ const conflictPlan = new Plan({
       contents: "{}",
     },
   ],
-  conflicts: [{ _tag: "completeFile", path: "package.json" }],
+  conflicts: [
+    { _tag: "completeFile", path: "package.json" },
+    { _tag: "scripts", path: "package.json", name: "test" },
+  ],
 });
 const applyResult = new ApplyResult({
   created: [],
@@ -129,7 +137,46 @@ const squashFailure = (exit: Exit.Exit<unknown, unknown>) => {
 };
 
 describe("ScaffoldPipeline", () => {
-  it.effect("fails non-dry-run commands when a finalize script fails", () =>
+  it.effect(
+    "should resolve one decision per path in interactive and automatic modes",
+    () =>
+      Effect.gen(function* () {
+        const prompts: Array<ConfirmOptions> = [];
+        const planBox = Box.text("formatted plan");
+
+        const decisions = yield* resolveConflictDecisions({
+          plan: conflictPlan,
+          yes: false,
+          planBox,
+          confirm: (options) => {
+            prompts.push(options);
+            return Effect.succeed(false);
+          },
+        });
+
+        expect(prompts).toHaveLength(1);
+        expect(decisions).toEqual([{ path: "package.json", value: "skip" }]);
+        const options = prompts[0];
+        expect(options?.message).toBe(
+          "Conflict at package.json (completeFile, scripts). Override?",
+        );
+        expect(options?.children).toBe(planBox);
+
+        const automaticDecisions = yield* resolveConflictDecisions({
+          plan: conflictPlan,
+          yes: true,
+          planBox,
+          confirm: () =>
+            Effect.die(new Error("automatic mode should not prompt")),
+        });
+
+        expect(automaticDecisions).toEqual([
+          { path: "package.json", value: "skip" },
+        ]);
+      }),
+  );
+
+  it.effect("should fail when a non-dry-run finalize script fails", () =>
     Effect.gen(function* () {
       const pipeline = yield* ScaffoldPipeline;
       const exit = yield* Effect.exit(pipeline.run(runInput));
@@ -147,7 +194,7 @@ describe("ScaffoldPipeline", () => {
     ),
   );
 
-  it.effect("keeps dry-run finalize scripts as preview-only", () =>
+  it.effect("should not execute finalize scripts when running a dry run", () =>
     Effect.gen(function* () {
       const pipeline = yield* ScaffoldPipeline;
       const exit = yield* Effect.exit(
@@ -165,61 +212,69 @@ describe("ScaffoldPipeline", () => {
     ),
   );
 
-  it.effect("uses memory-backed apply when show-files is enabled", () =>
-    Effect.gen(function* () {
-      const exit = yield* Effect.gen(function* () {
-        const pipeline = yield* ScaffoldPipeline;
-        return yield* Effect.exit(
-          pipeline.run({ ...runInput, dryRun: true, showFiles: true }),
+  it.effect(
+    "should use memory-backed Apply when generated files are requested",
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.gen(function* () {
+          const pipeline = yield* ScaffoldPipeline;
+          return yield* Effect.exit(
+            pipeline.run({ ...runInput, dryRun: true, showFiles: true }),
+          );
+        }).pipe(
+          Effect.provide(
+            layerWithServices({
+              preview: () =>
+                Effect.die(
+                  new Error("ordinary preview should not be requested"),
+                ),
+              previewFiles: () =>
+                Effect.succeed({
+                  apply: applyResult,
+                  files: [
+                    {
+                      path: "package.json",
+                      status: "created",
+                      contents: "{}\n",
+                    },
+                  ],
+                }),
+              run: () =>
+                Effect.die(
+                  new Error("dry-run should not run finalize scripts"),
+                ),
+            }),
+          ),
         );
+
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "should preview one skipped decision per conflicted path during a dry run",
+    () =>
+      Effect.gen(function* () {
+        const pipeline = yield* ScaffoldPipeline;
+        const exit = yield* Effect.exit(
+          pipeline.run({ ...runInput, dryRun: true }),
+        );
+
+        expect(Exit.isSuccess(exit)).toBe(true);
       }).pipe(
         Effect.provide(
           layerWithServices({
-            preview: () =>
-              Effect.die(new Error("ordinary preview should not be requested")),
-            previewFiles: () =>
-              Effect.succeed({
-                apply: applyResult,
-                files: [
-                  {
-                    path: "package.json",
-                    status: "created",
-                    contents: "{}\n",
-                  },
-                ],
-              }),
+            plan: conflictPlan,
+            preview: ({ apply }) => {
+              expect(apply.decisions).toEqual([
+                { path: "package.json", value: "skip" },
+              ]);
+              return Effect.succeed(applyResult);
+            },
             run: () =>
               Effect.die(new Error("dry-run should not run finalize scripts")),
           }),
         ),
-      );
-
-      expect(Exit.isSuccess(exit)).toBe(true);
-    }),
-  );
-
-  it.effect("previews dry-run conflicts as skipped decisions", () =>
-    Effect.gen(function* () {
-      const pipeline = yield* ScaffoldPipeline;
-      const exit = yield* Effect.exit(
-        pipeline.run({ ...runInput, dryRun: true }),
-      );
-
-      expect(Exit.isSuccess(exit)).toBe(true);
-    }).pipe(
-      Effect.provide(
-        layerWithServices({
-          plan: conflictPlan,
-          preview: ({ apply }) => {
-            expect(apply.decisions).toEqual([
-              { path: "package.json", value: "skip" },
-            ]);
-            return Effect.succeed(applyResult);
-          },
-          run: () =>
-            Effect.die(new Error("dry-run should not run finalize scripts")),
-        }),
       ),
-    ),
   );
 });

--- a/apps/cli/src/service/ScaffoldPipeline.ts
+++ b/apps/cli/src/service/ScaffoldPipeline.ts
@@ -12,8 +12,17 @@ import {
   PlanService,
   ScaffoldFormatter,
 } from "@repo/scaffold";
-import { Confirm, MultiSelect } from "@repo/tui";
-import { Console, Context, Data, Effect, Layer, Result, Stream } from "effect";
+import { Confirm, type ConfirmOptions, MultiSelect } from "@repo/tui";
+import {
+  Array as Arr,
+  Console,
+  Context,
+  Data,
+  Effect,
+  Layer,
+  Result,
+  Stream,
+} from "effect";
 import { Ansi, Box } from "effect-boxes";
 import { DryRunPreview } from "../components/DryRunPreview";
 import { NextStepsPreview } from "../components/NextStepsPreview";
@@ -42,34 +51,58 @@ const skippedFinalizeScripts = (
     .filter((script) => !selectedCommands.has(script.command))
     .map((script) => ({ label: script.label, command: script.command }));
 
+const conflictGroupsFrom = (plan: Plan) =>
+  Arr.map(
+    Arr.dedupe(Arr.map(plan.conflicts, (conflict) => conflict.path)),
+    (path) => ({
+      path,
+      conflicts: Arr.filter(
+        plan.conflicts,
+        (conflict) => conflict.path === path,
+      ),
+    }),
+  );
+
 const skipConflictDecisions = (plan: Plan) =>
-  plan.conflicts.map((conflict) => ({
-    path: conflict.path,
+  conflictGroupsFrom(plan).map(({ path }) => ({
+    path,
     value: "skip" as const,
   }));
+
+export const resolveConflictDecisions = <E, R>({
+  plan,
+  yes,
+  planBox,
+  confirm,
+}: {
+  readonly plan: Plan;
+  readonly yes: boolean;
+  readonly planBox: Box.Box<Ansi.AnsiStyle>;
+  readonly confirm: (options: ConfirmOptions) => Effect.Effect<boolean, E, R>;
+}) =>
+  Effect.forEach(conflictGroupsFrom(plan), ({ path, conflicts }) =>
+    Effect.gen(function* () {
+      const override = yes
+        ? false
+        : yield* confirm({
+            message: `Conflict at ${path} (${Arr.join(
+              Arr.map(conflicts, (conflict) => conflict._tag),
+              ", ",
+            )}). Override?`,
+            children: planBox,
+            initial: false,
+          });
+      return {
+        path,
+        value: override ? ("override" as const) : ("skip" as const),
+      };
+    }),
+  );
 
 export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
   "ScaffoldPipeline",
   {
     make: Effect.gen(function* () {
-      const resolveConflicts = (plan: Plan, yes: boolean) =>
-        plan.conflicts.length > 0
-          ? Effect.forEach(plan.conflicts, (conflict) =>
-              Effect.gen(function* () {
-                const override = yes
-                  ? false
-                  : yield* Confirm({
-                      message: `Conflict at ${conflict.path} (${conflict._tag}). Override?`,
-                      initial: false,
-                    });
-                return {
-                  path: conflict.path,
-                  value: override ? ("override" as const) : ("skip" as const),
-                };
-              }),
-            )
-          : Effect.succeed([]);
-
       const run = ({
         selection,
         repoRoot,
@@ -187,7 +220,12 @@ export class ScaffoldPipeline extends Context.Service<ScaffoldPipeline>()(
             return;
           }
 
-          const decisions = yield* resolveConflicts(plan, yes);
+          const decisions = yield* resolveConflictDecisions({
+            plan,
+            yes,
+            planBox,
+            confirm: Confirm,
+          });
 
           if (!yes) {
             const proceed = yield* Confirm({

--- a/packages/domain/src/Blueprint.test.ts
+++ b/packages/domain/src/Blueprint.test.ts
@@ -88,38 +88,7 @@ const makeUnsortedBlueprint = () =>
   });
 
 describe("@repo/domain Blueprint", () => {
-  it("should expose target identity domain methods", () => {
-    const identity = new TargetIdentity({
-      kind: TargetKind.make("server"),
-      name: "api",
-    });
-
-    expect(identity.toKey()).toBe("apps/server-api");
-    expect(identity.toPath()).toBe("apps/server-api");
-    expect(
-      identity.matches({ _tag: "kind", kind: TargetKind.make("server") }),
-    ).toBe(true);
-    expect(
-      identity.matches({
-        _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("server"),
-          name: "api",
-        }),
-      }),
-    ).toBe(true);
-    expect(
-      identity.matches({
-        _tag: "identity",
-        identity: new TargetIdentity({
-          kind: TargetKind.make("client-react"),
-          name: "api",
-        }),
-      }),
-    ).toBe(false);
-  });
-
-  it("should slugify user-provided names when deriving key and path", () => {
+  it("should derive canonical paths and match identity rules when names need normalization", () => {
     const identity = new TargetIdentity({
       kind: TargetKind.make("server"),
       name: "My Api",
@@ -127,14 +96,9 @@ describe("@repo/domain Blueprint", () => {
 
     expect(identity.toKey()).toBe("apps/server-my-api");
     expect(identity.toPath()).toBe("apps/server-my-api");
-  });
-
-  it("should compare exact identity rules by canonical target identity", () => {
-    const identity = new TargetIdentity({
-      kind: TargetKind.make("server"),
-      name: "My Api",
-    });
-
+    expect(
+      identity.matches({ _tag: "kind", kind: TargetKind.make("server") }),
+    ).toBe(true);
     expect(
       identity.matches({
         _tag: "identity",
@@ -144,9 +108,18 @@ describe("@repo/domain Blueprint", () => {
         }),
       }),
     ).toBe(true);
+    expect(
+      identity.matches({
+        _tag: "identity",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("client-react"),
+          name: "my-api",
+        }),
+      }),
+    ).toBe(false);
   });
 
-  it("should decode target identities as domain class instances", () => {
+  it("should preserve target identity behavior when decoding", () => {
     const identity = Schema.decodeUnknownSync(TargetIdentity)({
       kind: "package",
       name: "domain",
@@ -157,7 +130,7 @@ describe("@repo/domain Blueprint", () => {
     expect(identity.toPath()).toBe("packages/domain");
   });
 
-  it("should sort blueprint nodes and edges deterministically", () => {
+  it("should sort nodes and edges deterministically when normalizing a Blueprint", () => {
     const blueprint = makeUnsortedBlueprint().toSorted();
 
     expect(blueprint.nodes.map((node) => node.id)).toEqual([
@@ -180,8 +153,9 @@ describe("@repo/domain Blueprint", () => {
     ]);
   });
 
-  it("should expose helper methods for querying targets", () => {
+  it("should return present and absent targets when querying a Blueprint", () => {
     const blueprint = makeUnsortedBlueprint().toSorted();
+    const emptyBlueprint = new Blueprint({ nodes: [], edges: [] });
 
     expect(blueprint.hasTarget("apps/server-api")).toBe(true);
     expect(blueprint.hasTarget("apps/cli-tooling")).toBe(false);
@@ -193,31 +167,143 @@ describe("@repo/domain Blueprint", () => {
         name: "domain",
       },
     });
+    expect(emptyBlueprint.hasTarget("apps/server-api")).toBe(false);
+    expect(emptyBlueprint.getTarget("apps/server-api")).toBeUndefined();
   });
 
-  it("should expose safe helper behavior for an empty blueprint", () => {
-    const blueprint = new Blueprint({
-      nodes: [],
-      edges: [],
+  const invalidBlueprints = [
+    {
+      name: "duplicate node IDs",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: [...blueprint.nodes, ...blueprint.nodes.slice(0, 1)],
+        edges: blueprint.edges,
+      }),
+      message: "Blueprint node id must be unique",
+    },
+    {
+      name: "duplicate edge IDs",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes,
+        edges: [
+          ...blueprint.edges,
+          {
+            id: "z-edge",
+            from: domainIdentity.toKey(),
+            to: serverApiIdentity.toKey(),
+            reason: "required-target" as const,
+          },
+        ],
+      }),
+      message: "Blueprint edge id must be unique",
+    },
+    {
+      name: "a non-canonical target ID",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes.map((node) =>
+          node._tag === "target" && node.id === domainIdentity.toKey()
+            ? { ...node, id: TargetKey.make("packages/not-domain") }
+            : node,
+        ),
+        edges: blueprint.edges,
+      }),
+      message: "Blueprint target id must match its canonical identity",
+    },
+    {
+      name: "a non-canonical attached-module ID",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes.map((node) =>
+          node._tag === "attached-module" &&
+          node.targetId === domainIdentity.toKey()
+            ? {
+                ...node,
+                id: toAttachedModuleNodeId(
+                  domainIdentity.toKey(),
+                  ModuleId.make("wrong-module"),
+                ),
+              }
+            : node,
+        ),
+        edges: blueprint.edges,
+      }),
+      message: "Blueprint attached-module id must match",
+    },
+    {
+      name: "a missing target",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes.filter(
+          (node) =>
+            !(node._tag === "target" && node.id === domainIdentity.toKey()),
+        ),
+        edges: blueprint.edges,
+      }),
+      message: "must resolve to exactly one target",
+    },
+    {
+      name: "a missing ownership edge",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes,
+        edges: blueprint.edges.filter((edge) => edge.id !== "m-edge"),
+      }),
+      message: "must have exactly one owns-module edge",
+    },
+    {
+      name: "multiple ownership edges for one attached module",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes,
+        edges: [
+          ...blueprint.edges,
+          {
+            id: "x-edge",
+            from: domainIdentity.toKey(),
+            to: toAttachedModuleNodeId(
+              domainIdentity.toKey(),
+              ModuleId.make("domain-api-contracts"),
+            ),
+            reason: "owns-module" as const,
+          },
+        ],
+      }),
+      message: "must have exactly one owns-module edge",
+    },
+    {
+      name: "a contradictory ownership edge",
+      mutate: (blueprint: Blueprint) => ({
+        nodes: blueprint.nodes,
+        edges: [
+          ...blueprint.edges,
+          {
+            id: "contradictory-edge",
+            from: serverApiIdentity.toKey(),
+            to: toAttachedModuleNodeId(
+              domainIdentity.toKey(),
+              ModuleId.make("domain-api-contracts"),
+            ),
+            reason: "owns-module" as const,
+          },
+        ],
+      }),
+      message: "does not match an attached module ownership relationship",
+    },
+  ] as const;
+
+  it("should reject invalid identities and ownership relationships during checked construction", () => {
+    invalidBlueprints.forEach(({ mutate, message, name }) => {
+      expect(
+        () => new Blueprint(mutate(makeUnsortedBlueprint())),
+        name,
+      ).toThrow(message);
     });
-
-    expect(blueprint.hasTarget("apps/server-api")).toBe(false);
-    expect(blueprint.getTarget("apps/server-api")).toBeUndefined();
   });
 
-  it("should enforce canonical target key formatting", async () => {
-    // NOTE: TargetKey is only branded here; blueprint construction owns format validation.
+  it("should reject invalid ownership relationships when decoding", async () => {
+    const blueprint = makeUnsortedBlueprint();
+    const invalid = {
+      nodes: blueprint.nodes,
+      edges: blueprint.edges.filter((edge) => edge.id !== "m-edge"),
+    };
+
     await expect(
-      Schema.decodeUnknownPromise(TargetKey)("apps/server-api"),
-    ).resolves.toBe("apps/server-api");
-    await expect(
-      Schema.decodeUnknownPromise(TargetKey)("packages/domain"),
-    ).resolves.toBe("packages/domain");
-    await expect(
-      Schema.decodeUnknownPromise(TargetKey)("apps/server-api#server-http-api"),
-    ).resolves.toBe("apps/server-api#server-http-api");
-    await expect(
-      Schema.decodeUnknownPromise(TargetKey)("server-api"),
-    ).resolves.toBe("server-api");
+      Schema.decodeUnknownPromise(Blueprint)(invalid),
+    ).rejects.toThrow("must have exactly one owns-module edge");
   });
 });

--- a/packages/domain/src/Blueprint.ts
+++ b/packages/domain/src/Blueprint.ts
@@ -1,4 +1,4 @@
-import { Data, Order, Schema } from "effect";
+import { Array as Arr, Data, Order, Schema } from "effect";
 import {
   CatalogNotFound,
   ModuleId,
@@ -54,6 +54,103 @@ export const blueprintNodeOrd = Order.mapInput(
   (node: typeof BlueprintNode.Type) => node,
 );
 
+const duplicates = (values: ReadonlyArray<string>): ReadonlyArray<string> =>
+  Arr.map(
+    Arr.filter(
+      Object.entries(Arr.groupBy(values, (value) => value)),
+      ([, groupedValues]) => groupedValues.length > 1,
+    ),
+    ([value]) => value,
+  );
+
+const BlueprintFields = Schema.Struct({
+  nodes: Schema.Array(BlueprintNode),
+  edges: Schema.Array(
+    Schema.Struct({
+      id: Schema.NonEmptyString,
+      from: Schema.NonEmptyString,
+      to: Schema.NonEmptyString,
+      reason: Schema.Literals([
+        "owns-module",
+        "required-target",
+        "required-module",
+      ]),
+    }),
+  ),
+}).check(
+  Schema.makeFilter((blueprint) => {
+    const duplicateNodeIds = Arr.map(
+      duplicates(Arr.map(blueprint.nodes, (node) => node.id)),
+      (id) => `Blueprint node id must be unique: ${id}`,
+    );
+    const duplicateEdgeIds = Arr.map(
+      duplicates(Arr.map(blueprint.edges, (edge) => edge.id)),
+      (id) => `Blueprint edge id must be unique: ${id}`,
+    );
+    const targetIdentityIssues = blueprint.nodes.flatMap((node) =>
+      node._tag === "target" && node.id !== node.identity.toKey()
+        ? [
+            `Blueprint target id must match its canonical identity: expected ${node.identity.toKey()}, received ${node.id}`,
+          ]
+        : [],
+    );
+    const attachedModules = blueprint.nodes.filter(
+      BlueprintNode.guards["attached-module"],
+    );
+    const attachedModuleIssues = attachedModules.flatMap((node) => {
+      const expectedId = toAttachedModuleNodeId(node.targetId, node.moduleId);
+      const matchingTargets = blueprint.nodes.filter(
+        (candidate) =>
+          candidate._tag === "target" && candidate.id === node.targetId,
+      );
+      const matchingOwnershipEdges = blueprint.edges.filter(
+        (edge) =>
+          edge.reason === "owns-module" &&
+          edge.from === node.targetId &&
+          edge.to === node.id,
+      );
+
+      return [
+        ...(node.id === expectedId
+          ? []
+          : [
+              `Blueprint attached-module id must match its target and module identities: expected ${expectedId}, received ${node.id}`,
+            ]),
+        ...(matchingTargets.length === 1
+          ? []
+          : [
+              `Blueprint attached module ${node.id} must resolve to exactly one target ${node.targetId}`,
+            ]),
+        ...(matchingOwnershipEdges.length === 1
+          ? []
+          : [
+              `Blueprint attached module ${node.id} must have exactly one owns-module edge from ${node.targetId}`,
+            ]),
+      ];
+    });
+    const contradictoryOwnershipIssues = blueprint.edges
+      .filter(
+        (edge) =>
+          edge.reason === "owns-module" &&
+          !attachedModules.some(
+            (node) => node.targetId === edge.from && node.id === edge.to,
+          ),
+      )
+      .map(
+        (edge) =>
+          `Blueprint owns-module edge ${edge.id} does not match an attached module ownership relationship`,
+      );
+
+    return [
+      ...duplicateNodeIds,
+      ...duplicateEdgeIds,
+      ...targetIdentityIssues,
+      ...attachedModuleIssues,
+      ...contradictoryOwnershipIssues,
+    ];
+  }),
+);
+
 /**
  * The resolved dependency closure for a Selection.
  *
@@ -68,21 +165,9 @@ export const blueprintNodeOrd = Order.mapInput(
  * @category Blueprint
  * @since 1.0.0
  */
-export class Blueprint extends Schema.Class<Blueprint>("Blueprint")({
-  nodes: Schema.Array(BlueprintNode),
-  edges: Schema.Array(
-    Schema.Struct({
-      id: Schema.NonEmptyString,
-      from: Schema.NonEmptyString,
-      to: Schema.NonEmptyString,
-      reason: Schema.Literals([
-        "owns-module",
-        "required-target",
-        "required-module",
-      ]),
-    }),
-  ),
-}) {
+export class Blueprint extends Schema.Class<Blueprint>("Blueprint")(
+  BlueprintFields,
+) {
   toSorted(): Blueprint {
     return new Blueprint({
       nodes: [...this.nodes].sort(blueprintNodeOrd),

--- a/packages/domain/src/Plan.test.ts
+++ b/packages/domain/src/Plan.test.ts
@@ -3,7 +3,7 @@ import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
 
 describe("@repo/domain Plan", () => {
-  it("accepts the supported plan classifications", () => {
+  it("should accept supported classifications and reject unsupported values", () => {
     expect(Schema.decodeUnknownSync(PlanEntryClassification)("create")).toBe(
       "create",
     );
@@ -16,58 +16,12 @@ describe("@repo/domain Plan", () => {
     expect(Schema.decodeUnknownSync(PlanEntryClassification)("conflict")).toBe(
       "conflict",
     );
-  });
-
-  it("rejects unsupported classifications", () => {
     expect(() =>
       Schema.decodeUnknownSync(PlanEntryClassification)("delete"),
     ).toThrow();
   });
 
-  it("models a deterministic narrow public plan", () => {
-    const plan = new Plan({
-      outcomes: [
-        {
-          _tag: "composed",
-          path: "packages/domain/package.json",
-          classification: "modify",
-          operations: [
-            {
-              _tag: "json-pkg-exports",
-              fileType: "json",
-              entries: [
-                {
-                  name: "./Api",
-                  value: "./src/Api.ts",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          _tag: "complete",
-          path: "packages/domain/src/Api.ts",
-          classification: "create",
-          contents: 'export const Api = "Api";\n',
-        },
-      ],
-      conflicts: [
-        {
-          _tag: "exports",
-          path: "packages/domain/package.json",
-          name: "./Api",
-        },
-      ],
-    });
-
-    expect(plan.outcomes.map((outcome) => outcome.path)).toStrictEqual([
-      "packages/domain/package.json",
-      "packages/domain/src/Api.ts",
-    ]);
-    expect(plan.conflicts).toHaveLength(1);
-  });
-
-  it("allows planned file outcomes to be decoded independently", () => {
+  it("should decode outcome and conflict fields independently", () => {
     const outcome = Schema.decodeUnknownSync(Plan.fields.outcomes.value)({
       _tag: "complete",
       path: "packages/domain/tsconfig.json",
@@ -76,9 +30,6 @@ describe("@repo/domain Plan", () => {
     });
 
     expect(outcome._tag).toBe("complete");
-  });
-
-  it("allows conflicts to be decoded independently", () => {
     const conflict = Schema.decodeUnknownSync(Plan.fields.conflicts.value)({
       _tag: "completeFile",
       path: "package.json",
@@ -87,7 +38,7 @@ describe("@repo/domain Plan", () => {
     expect(conflict._tag).toBe("completeFile");
   });
 
-  it("sorts planned file outcomes and conflicts deterministically", () => {
+  it("should sort outcomes and distinct same-path diagnostics deterministically", () => {
     const plan = new Plan({
       outcomes: [
         {
@@ -98,9 +49,21 @@ describe("@repo/domain Plan", () => {
         },
         {
           _tag: "complete",
-          path: "README.md",
-          classification: "modify",
-          contents: "# Repo\n",
+          path: "apps/web/src/App.tsx",
+          classification: "conflict",
+          contents: "export const App = () => null;\n",
+        },
+        {
+          _tag: "complete",
+          path: "packages/domain/tsconfig.json",
+          classification: "conflict",
+          contents: "{}\n",
+        },
+        {
+          _tag: "complete",
+          path: "packages/domain/src/index.ts",
+          classification: "conflict",
+          contents: "export {};\n",
         },
       ],
       conflicts: [
@@ -127,8 +90,10 @@ describe("@repo/domain Plan", () => {
     }).toSorted();
 
     expect(plan.outcomes.map((outcome) => outcome.path)).toEqual([
-      "README.md",
+      "apps/web/src/App.tsx",
       "packages/domain/src/Api.ts",
+      "packages/domain/src/index.ts",
+      "packages/domain/tsconfig.json",
     ]);
     expect(plan.conflicts.map((conflict) => conflict.path)).toEqual([
       "packages/domain/src/index.ts",
@@ -148,5 +113,88 @@ describe("@repo/domain Plan", () => {
         slotId: "footer",
       },
     ]);
+  });
+
+  const invalidPlans: ReadonlyArray<{
+    readonly name: string;
+    readonly construct: () => Plan;
+  }> = [
+    {
+      name: "duplicate outcome paths",
+      construct: () =>
+        new Plan({
+          outcomes: [
+            {
+              _tag: "complete",
+              path: "README.md",
+              classification: "create",
+              contents: "# Repo\n",
+            },
+            {
+              _tag: "complete",
+              path: "README.md",
+              classification: "modify",
+              contents: "# Updated\n",
+            },
+          ],
+          conflicts: [],
+        }),
+    },
+    {
+      name: "duplicate exact conflict diagnostics",
+      construct: () =>
+        new Plan({
+          outcomes: [
+            {
+              _tag: "complete",
+              path: "package.json",
+              classification: "conflict",
+              contents: "{}\n",
+            },
+          ],
+          conflicts: [
+            { _tag: "scripts", path: "package.json", name: "test" },
+            { _tag: "scripts", path: "package.json", name: "test" },
+          ],
+        }),
+    },
+    {
+      name: "orphan conflict diagnostics",
+      construct: () =>
+        new Plan({
+          outcomes: [],
+          conflicts: [{ _tag: "completeFile", path: "README.md" }],
+        }),
+    },
+    {
+      name: "conflicted outcomes without diagnostics",
+      construct: () =>
+        new Plan({
+          outcomes: [
+            {
+              _tag: "complete",
+              path: "README.md",
+              classification: "conflict",
+              contents: "# Repo\n",
+            },
+          ],
+          conflicts: [],
+        }),
+    },
+  ];
+
+  it("should reject invalid relationships during checked construction", () => {
+    invalidPlans.forEach(({ construct, name }) => {
+      expect(construct, name).toThrow();
+    });
+  });
+
+  it("should reject invalid relationships when decoding", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(Plan)({
+        outcomes: [],
+        conflicts: [{ _tag: "completeFile", path: "README.md" }],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/domain/src/Plan.ts
+++ b/packages/domain/src/Plan.ts
@@ -1,4 +1,4 @@
-import { Order, Schema } from "effect";
+import { Array as Arr, Order, Schema } from "effect";
 import { pathOrd } from "./Order";
 
 export const RepoSnapshotPath = Schema.TaggedUnion({
@@ -164,6 +164,66 @@ export const PlanConflict = Schema.TaggedUnion({
   },
 });
 
+const planConflictKey = (conflict: typeof PlanConflict.Type): string =>
+  PlanConflict.match(conflict, {
+    exports: (c) => JSON.stringify([c._tag, c.path, c.name]),
+    dependencies: (c) => JSON.stringify([c._tag, c.path, c.section, c.name]),
+    scripts: (c) => JSON.stringify([c._tag, c.path, c.name]),
+    barrelExport: (c) => JSON.stringify([c._tag, c.path, c.exportPath]),
+    tsconfig: (c) => JSON.stringify([c._tag, c.path]),
+    completeFile: (c) => JSON.stringify([c._tag, c.path]),
+    compositionTargetNotFound: (c) =>
+      JSON.stringify([c._tag, c.path, c.targetVariable, c.functionName]),
+    jsxSlotTargetNotFound: (c) => JSON.stringify([c._tag, c.path, c.slotId]),
+  });
+
+const duplicates = (values: ReadonlyArray<string>): ReadonlyArray<string> =>
+  Arr.map(
+    Arr.filter(
+      Object.entries(Arr.groupBy(values, (value) => value)),
+      ([, groupedValues]) => groupedValues.length > 1,
+    ),
+    ([value]) => value,
+  );
+
+const PlanFields = Schema.Struct({
+  outcomes: Schema.Array(PlanOutcome),
+  conflicts: Schema.Array(PlanConflict),
+}).check(
+  Schema.makeFilter(({ conflicts, outcomes }) => {
+    const outcomePaths = outcomes.map((outcome) => outcome.path);
+    const conflictKeys = conflicts.map(planConflictKey);
+    const conflictedOutcomePaths = new Set(
+      outcomes
+        .filter((outcome) => outcome.classification === "conflict")
+        .map((outcome) => outcome.path),
+    );
+    const conflictPaths = new Set(conflicts.map((conflict) => conflict.path));
+
+    return [
+      ...duplicates(outcomePaths).map(
+        (path) => `Plan outcome paths must be unique; duplicate path: ${path}`,
+      ),
+      ...duplicates(conflictKeys).map(
+        (key) =>
+          `Plan conflict diagnostics must be unique; duplicate identity: ${key}`,
+      ),
+      ...[...conflictPaths]
+        .filter((path) => !conflictedOutcomePaths.has(path))
+        .map(
+          (path) =>
+            `Plan conflict diagnostic path must reference a conflicted outcome: ${path}`,
+        ),
+      ...[...conflictedOutcomePaths]
+        .filter((path) => !conflictPaths.has(path))
+        .map(
+          (path) =>
+            `Plan conflicted outcome must have at least one conflict diagnostic: ${path}`,
+        ),
+    ];
+  }),
+);
+
 /**
  * The repo-aware outcome of applying a Blueprint to the current filesystem.
  *
@@ -178,31 +238,12 @@ export const PlanConflict = Schema.TaggedUnion({
  * @category Plan
  * @since 1.0.0
  */
-export class Plan extends Schema.Class<Plan>("Plan")({
-  outcomes: Schema.Array(PlanOutcome),
-  conflicts: Schema.Array(PlanConflict),
-}) {
+export class Plan extends Schema.Class<Plan>("Plan")(PlanFields) {
   toSorted(): Plan {
     return new Plan({
       outcomes: [...this.outcomes].sort(pathOrd),
       conflicts: [...this.conflicts].sort(
-        Order.mapInput(
-          Order.String,
-          (conflict: typeof PlanConflict.Type): string =>
-            PlanConflict.match(conflict, {
-              exports: (c) => `exports:${c.path}:${c.name}`,
-              dependencies: (c) =>
-                `dependencies:${c.path}:${c.section}:${c.name}`,
-              scripts: (c) => `scripts:${c.path}:${c.name}`,
-              barrelExport: (c) => `barrelExport:${c.path}:${c.exportPath}`,
-              tsconfig: (c) => `tsconfig:${c.path}`,
-              completeFile: (c) => `completeFile:${c.path}`,
-              compositionTargetNotFound: (c) =>
-                `compositionTargetNotFound:${c.path}:${c.targetVariable}:${c.functionName}`,
-              jsxSlotTargetNotFound: (c) =>
-                `jsxSlotTargetNotFound:${c.path}:${c.slotId}`,
-            }),
-        ),
+        Order.mapInput(Order.String, planConflictKey),
       ),
     });
   }

--- a/packages/scaffold/src/service/ScaffoldFormatter.test.ts
+++ b/packages/scaffold/src/service/ScaffoldFormatter.test.ts
@@ -92,7 +92,7 @@ const makeUnsortedBlueprint = () =>
 
 describe("ScaffoldFormatter", () => {
   layer(ScaffoldFormatter.layer)("formatters", (it) => {
-    it.effect("formats an empty blueprint", () =>
+    it.effect("should format an empty Blueprint when no nodes exist", () =>
       Effect.gen(function* () {
         const formatter = yield* ScaffoldFormatter;
         const blueprint = new Blueprint({
@@ -105,7 +105,7 @@ describe("ScaffoldFormatter", () => {
       }),
     );
 
-    it.effect("formats a normalized dependency blueprint", () =>
+    it.effect("should format dependencies when a Blueprint is normalized", () =>
       Effect.gen(function* () {
         const formatter = yield* ScaffoldFormatter;
         const blueprint = makeUnsortedBlueprint().toSorted();
@@ -122,7 +122,7 @@ describe("ScaffoldFormatter", () => {
       }),
     );
 
-    it.effect("formats an empty plan", () =>
+    it.effect("should format an empty Plan when no outcomes exist", () =>
       Effect.gen(function* () {
         const formatter = yield* ScaffoldFormatter;
         const plan = new Plan({
@@ -141,7 +141,7 @@ describe("ScaffoldFormatter", () => {
     );
 
     it.effect(
-      "formats a plan with create, modify, unchanged, and merge conflicts",
+      "should format outcomes and diagnostics when a Plan is mixed",
       () =>
         Effect.gen(function* () {
           const formatter = yield* ScaffoldFormatter;
@@ -205,6 +205,11 @@ describe("ScaffoldFormatter", () => {
                 exportPath: "./Api",
               },
               {
+                _tag: "barrelExport",
+                path: "packages/domain/src/index.ts",
+                exportPath: "./Health",
+              },
+              {
                 _tag: "tsconfig",
                 path: "packages/domain/tsconfig.json",
               },
@@ -232,7 +237,8 @@ describe("ScaffoldFormatter", () => {
               |│       ├── src
               |│       │   ├── [+] Api.ts
               |│       │   ╰── [!] index.ts
-              |│       │       ╰── merge: export ./Api
+              |│       │       ├── merge: export ./Api
+              |│       │       ╰── merge: export ./Health
               |│       ╰── [!] tsconfig.json
               |│           ╰── merge: tsconfig
               |├── [=] package.json
@@ -241,7 +247,7 @@ describe("ScaffoldFormatter", () => {
         }),
     );
 
-    it.effect("formats a missing JSX slot conflict", () =>
+    it.effect("should identify the slot when JSX composition conflicts", () =>
       Effect.gen(function* () {
         const formatter = yield* ScaffoldFormatter;
         const plan = new Plan({

--- a/packages/scaffold/src/service/apply/ApplyPreviewService.test.ts
+++ b/packages/scaffold/src/service/apply/ApplyPreviewService.test.ts
@@ -40,7 +40,15 @@ const makeApply = (
   decisions: ReadonlyArray<typeof ApplyDecision.Type> = [],
 ) =>
   new Apply({
-    plan: new Plan({ outcomes: [...outcomes], conflicts: [] }),
+    plan: new Plan({
+      outcomes: [...outcomes],
+      conflicts: outcomes
+        .filter((outcome) => outcome.classification === "conflict")
+        .map((outcome) => ({
+          _tag: "completeFile" as const,
+          path: outcome.path,
+        })),
+    }),
     decisions: [...decisions],
   });
 
@@ -63,7 +71,7 @@ const runWithHost = <A, E>(
   });
 
 describe("ApplyPreviewService", () => {
-  it.effect("returns generated contents for a greenfield create", () =>
+  it.effect("should return contents when creating a file", () =>
     runWithHost(
       Effect.gen(function* () {
         const service = yield* ApplyPreviewService;
@@ -86,39 +94,37 @@ describe("ApplyPreviewService", () => {
     ),
   );
 
-  it.effect(
-    "uses an isolated Apply layer when a host Apply layer is live",
-    () =>
-      Effect.gen(function* () {
-        const hostFileSystem = yield* MemoryFileSystem.make;
-        const hostLayer = Layer.mergeAll(
-          Layer.succeed(FileSystem.FileSystem, hostFileSystem),
-          Path.layer,
-        );
-        const layer = Layer.mergeAll(
-          ApplyService.layer,
-          ApplyPreviewService.layer,
-        ).pipe(Layer.provide(hostLayer));
+  it.effect("should isolate writes when host Apply is live", () =>
+    Effect.gen(function* () {
+      const hostFileSystem = yield* MemoryFileSystem.make;
+      const hostLayer = Layer.mergeAll(
+        Layer.succeed(FileSystem.FileSystem, hostFileSystem),
+        Path.layer,
+      );
+      const layer = Layer.mergeAll(
+        ApplyService.layer,
+        ApplyPreviewService.layer,
+      ).pipe(Layer.provide(hostLayer));
 
-        const result = yield* Effect.gen(function* () {
-          const service = yield* ApplyPreviewService;
-          return yield* service.preview({
-            apply: makeApply([
-              complete("src/index.ts", "create", "export const ok = true;\n"),
-            ]),
-            repoRoot,
-          });
-        }).pipe(Effect.provide(layer));
+      const result = yield* Effect.gen(function* () {
+        const service = yield* ApplyPreviewService;
+        return yield* service.preview({
+          apply: makeApply([
+            complete("src/index.ts", "create", "export const ok = true;\n"),
+          ]),
+          repoRoot,
+        });
+      }).pipe(Effect.provide(layer));
 
-        expect(result.apply.failed).toEqual([]);
-        expect(result.files.map((file) => file.path)).toEqual(["src/index.ts"]);
-        expect(yield* hostFileSystem.exists("/workspace/src/index.ts")).toBe(
-          false,
-        );
-      }),
+      expect(result.apply.failed).toEqual([]);
+      expect(result.files.map((file) => file.path)).toEqual(["src/index.ts"]);
+      expect(yield* hostFileSystem.exists("/workspace/src/index.ts")).toBe(
+        false,
+      );
+    }),
   );
 
-  it.effect("composes from an existing host file without mutating it", () =>
+  it.effect("should preserve the host file when composing", () =>
     runWithHost(
       Effect.gen(function* () {
         const hostFileSystem = yield* FileSystem.FileSystem;
@@ -156,7 +162,7 @@ describe("ApplyPreviewService", () => {
     ),
   );
 
-  it.effect("keeps virtual paths POSIX with a Windows host path service", () =>
+  it.effect("should use POSIX paths when the host uses Windows", () =>
     Effect.gen(function* () {
       const hostFileSystem = yield* MemoryFileSystem.make;
       const posixPath = yield* Path.Path.pipe(Effect.provide(Path.layer));
@@ -217,7 +223,7 @@ describe("ApplyPreviewService", () => {
     }),
   );
 
-  it.effect("does not return contents for skipped conflicts", () =>
+  it.effect("should omit contents when a conflict is skipped", () =>
     runWithHost(
       Effect.gen(function* () {
         const service = yield* ApplyPreviewService;
@@ -235,7 +241,7 @@ describe("ApplyPreviewService", () => {
     ),
   );
 
-  it.effect("sorts returned files by path", () =>
+  it.effect("should sort files when returning a preview", () =>
     runWithHost(
       Effect.gen(function* () {
         const service = yield* ApplyPreviewService;

--- a/packages/scaffold/src/service/apply/ApplyService.test.ts
+++ b/packages/scaffold/src/service/apply/ApplyService.test.ts
@@ -176,7 +176,12 @@ const makeApply = ({
   new ApplyIntent({
     plan: new Plan({
       outcomes: [...outcomes],
-      conflicts: [],
+      conflicts: outcomes
+        .filter((outcome) => outcome.classification === "conflict")
+        .map((outcome) => ({
+          _tag: "completeFile" as const,
+          path: outcome.path,
+        })),
     }),
     decisions: [...decisions],
   });

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -49,13 +49,23 @@ export class BlueprintService extends Context.Service<BlueprintService>()(
         const state = yield* resolveSelection(selection, catalog);
         const finalState = yield* Ref.get(state);
 
-        return new Blueprint({
+        const blueprint = yield* Blueprint.makeEffect({
           nodes: [
             ...HashMap.values(finalState.targets),
             ...HashMap.values(finalState.attachedModules),
           ],
           edges: Arr.fromIterable(HashMap.values(finalState.edges)),
-        }).toSorted();
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new BlueprintFailure({
+                message: `Invalid resolved Blueprint: ${cause.message}`,
+                cause,
+              }),
+          ),
+        );
+
+        return blueprint.toSorted();
       });
 
       return { resolve };

--- a/packages/scaffold/src/service/finalize/FinalizeService.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.ts
@@ -64,14 +64,21 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
 
         const moduleScripts = yield* Effect.forEach(moduleNodes, (moduleNode) =>
           Effect.gen(function* () {
-            const targetNode = Arr.findFirst(
-              targetNodes,
-              (t) => t.id === moduleNode.targetId,
+            const targetNode = yield* Option.match(
+              Arr.findFirst(targetNodes, (t) => t.id === moduleNode.targetId),
+              {
+                onNone: () =>
+                  Effect.die(
+                    new Error(
+                      `Validated Blueprint is missing target ${moduleNode.targetId}`,
+                    ),
+                  ),
+                onSome: Effect.succeed,
+              },
             );
-            if (Option.isNone(targetNode)) return [];
 
             const definition = yield* catalog.getModule(moduleNode.moduleId);
-            const context = createTokenContext(config, targetNode.value);
+            const context = createTokenContext(config, targetNode);
             return Arr.map(definition.scripts ?? [], (s) => ({
               label: s.label,
               command: context.resolve(s.command),
@@ -152,16 +159,23 @@ export class FinalizeService extends Context.Service<FinalizeService>()(
 
           const moduleSteps = yield* Effect.forEach(moduleNodes, (moduleNode) =>
             Effect.gen(function* () {
-              const targetNode = Arr.findFirst(
-                targetNodes,
-                (t) => t.id === moduleNode.targetId,
+              const targetNode = yield* Option.match(
+                Arr.findFirst(targetNodes, (t) => t.id === moduleNode.targetId),
+                {
+                  onNone: () =>
+                    Effect.die(
+                      new Error(
+                        `Validated Blueprint is missing target ${moduleNode.targetId}`,
+                      ),
+                    ),
+                  onSome: Effect.succeed,
+                },
               );
-              if (Option.isNone(targetNode)) return [];
 
               const definition = yield* catalog.getModule(moduleNode.moduleId);
               return resolveNextSteps(
                 definition.nextSteps,
-                createTokenContext(config, targetNode.value),
+                createTokenContext(config, targetNode),
               );
             }),
           ).pipe(Effect.map(Arr.flatten));

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -8,7 +8,7 @@ import {
   type StackConfig,
   TargetContribution,
 } from "@repo/domain/Scaffold";
-import { Array as Arr, Context, Effect, Layer, pipe, Result } from "effect";
+import { Array as Arr, Context, Effect, Layer, Option } from "effect";
 
 export class ContributionResolver extends Context.Service<ContributionResolver>()(
   "ContributionResolver",
@@ -48,19 +48,22 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
           Arr.map(targetResults, (r) => [r.contribution.targetKey, r.context]),
         );
 
-        const moduleContributions = yield* pipe(
+        const moduleContributions = yield* Effect.forEach(
           Arr.filter(blueprint.nodes, BlueprintNode.guards["attached-module"]),
-          Arr.filterMap((node) =>
-            Result.map(
-              Result.fromNullishOr(
-                targetContexts.get(node.targetId),
-                () => "missing" as const,
-              ),
-              (context) => ({ node, context }) as const,
-            ),
-          ),
-          Effect.forEach(({ node, context }) =>
+          (node) =>
             Effect.gen(function* () {
+              const context = yield* Option.match(
+                Option.fromNullishOr(targetContexts.get(node.targetId)),
+                {
+                  onNone: () =>
+                    Effect.die(
+                      new Error(
+                        `Validated Blueprint is missing target context ${node.targetId}`,
+                      ),
+                    ),
+                  onSome: Effect.succeed,
+                },
+              );
               const moduleDefinition = yield* catalog.getModule(node.moduleId);
 
               return ModuleContribution.make({
@@ -72,7 +75,6 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
                 ),
               });
             }),
-          ),
         );
 
         return {

--- a/packages/scaffold/src/service/plan/PlanService.test.ts
+++ b/packages/scaffold/src/service/plan/PlanService.test.ts
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import { describe, expect, it } from "@effect/vitest";
 import { Blueprint, toAttachedModuleNodeId } from "@repo/domain/Blueprint";
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
-import type {
-  Plan,
+import {
+  type Plan,
   PlanFailure,
-  PlanOutcome,
-  RepoSnapshot,
+  type PlanOutcome,
+  type RepoSnapshot,
 } from "@repo/domain/Plan";
 import { StackConfig } from "@repo/domain/Scaffold";
 import { Cause, Effect, Exit, Layer } from "effect";
@@ -164,28 +164,37 @@ const getOutcome = (
   return outcome;
 };
 
+const squashFailure = (exit: Exit.Exit<unknown, unknown>) => {
+  expect(Exit.isFailure(exit)).toBe(true);
+  assert(Exit.isFailure(exit), "Expected effect to fail");
+  return Cause.squash(exit.cause);
+};
+
 const makePlanServiceLayer = (
   load: (args: {
     readonly paths: ReadonlyArray<string>;
     readonly repoRoot: string;
   }) => Effect.Effect<typeof RepoSnapshot.Type, PlanFailure, never>,
+  assessorLayer = PlanAssessor.layer,
 ) =>
   Layer.effect(PlanService)(PlanService.make).pipe(
     Layer.provide(ContributionResolver.layer),
     Layer.provide(PlanningIntentCompiler.layer),
     Layer.provide(makeRepoSnapshotServiceLayer(load)),
-    Layer.provide(PlanAssessor.layer),
+    Layer.provide(assessorLayer),
   );
 
 const buildPlan = ({
   blueprint,
   load,
+  assessorLayer,
 }: {
   blueprint: typeof Blueprint.Type;
   load: (args: {
     readonly paths: ReadonlyArray<string>;
     readonly repoRoot: string;
   }) => Effect.Effect<typeof RepoSnapshot.Type, PlanFailure, never>;
+  assessorLayer?: Layer.Layer<PlanAssessor>;
 }) =>
   Effect.gen(function* () {
     const planService = yield* PlanService;
@@ -197,9 +206,43 @@ const buildPlan = ({
         runtime: { _tag: "bun" },
       }),
     });
-  }).pipe(Effect.provide(makePlanServiceLayer(load)));
+  }).pipe(Effect.provide(makePlanServiceLayer(load, assessorLayer)));
 
 describe("PlanService", () => {
+  it.effect(
+    "should return PlanFailure when projection violates Plan invariants",
+    () =>
+      Effect.gen(function* () {
+        const invalidAssessorLayer = Layer.effect(PlanAssessor)(
+          PlanAssessor.make.pipe(
+            Effect.map((assessor) => ({
+              ...assessor,
+              assessPlanningPath: (input) => ({
+                ...assessor.assessPlanningPath(input),
+                classification: "conflict" as const,
+                conflicts: [],
+              }),
+            })),
+          ),
+        );
+
+        const exit = yield* Effect.exit(
+          buildPlan({
+            blueprint: makeDomainBlueprint(),
+            load: ({ paths }) =>
+              Effect.succeed({
+                paths: paths.map((path) => ({ _tag: "missing", path })),
+              }),
+            assessorLayer: invalidAssessorLayer,
+          }),
+        );
+
+        const failure = squashFailure(exit);
+        expect(failure).toBeInstanceOf(PlanFailure);
+        expect(failure).toMatchObject({ reason: "invalidPlanIntent" });
+      }),
+  );
+
   describe("when building target plans", () => {
     it.effect(
       "should classify projected target and module files as create when they are missing",

--- a/packages/scaffold/src/service/plan/PlanService.ts
+++ b/packages/scaffold/src/service/plan/PlanService.ts
@@ -111,7 +111,7 @@ export class PlanService extends Context.Service<
             }),
         );
 
-        return new Plan({
+        const plan = yield* Plan.makeEffect({
           outcomes: Arr.map(assessedPaths, ({ planningPath, assessment }) =>
             assessor.toPlannedFileOutcome({
               planningPath,
@@ -122,7 +122,17 @@ export class PlanService extends Context.Service<
             assessedPaths,
             ({ assessment }) => assessment.conflicts,
           ),
-        }).toSorted();
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new PlanFailure({
+                reason: "invalidPlanIntent",
+                message: `Invalid projected Plan: ${cause.message}`,
+              }),
+          ),
+        );
+
+        return plan.toSorted();
       });
 
     return { build } satisfies PlanServiceShape;


### PR DESCRIPTION
## Goals/Scope

Enforce Blueprint and Plan invariants at the domain layer and preserve validated planning contracts through scaffolding behavior.

## Description

- Added invariant enforcement for Blueprint/Plan directly in the domain layer.
- Updated scaffolding to maintain validated planning contract guarantees.
- Improved CLI conflict resolution by deduping handling per path.

---

- [x] closes #176