### PR TITLE
style: format package.json in apply

### DIFF
--- a/packages/scaffold/src/service/apply/ApplyPreviewService.test.ts
+++ b/packages/scaffold/src/service/apply/ApplyPreviewService.test.ts
@@ -150,11 +150,14 @@ describe("ApplyPreviewService", () => {
         });
 
         expect(result.apply.modified).toEqual(["package.json"]);
-        expect(JSON.parse(result.files[0]?.contents ?? "")).toEqual({
-          name: "app",
-          private: true,
-          scripts: { dev: "vite" },
-        });
+        expect(result.files[0]?.contents).toBe(`{
+  "name": "app",
+  "private": true,
+  "scripts": {
+    "dev": "vite"
+  }
+}
+`);
         expect(
           yield* hostFileSystem.readFileString(`${repoRoot}/package.json`),
         ).toBe(original);

--- a/packages/scaffold/src/service/apply/JsonComposer.ts
+++ b/packages/scaffold/src/service/apply/JsonComposer.ts
@@ -2,9 +2,8 @@ import { ApplyFailure } from "@repo/domain/Apply";
 import type { JsonCompositionOperation } from "@repo/domain/Plan";
 import { Array as Arr, Context, Effect, Layer, Match, Schema } from "effect";
 
-const PackageJsonFromString = Schema.fromJsonString(
-  Schema.Record(Schema.String, Schema.Unknown),
-);
+const PackageJson = Schema.Record(Schema.String, Schema.Unknown);
+const PackageJsonFromString = Schema.fromJsonString(PackageJson);
 
 export interface JsonComposerShape {
   readonly compose: (
@@ -43,7 +42,7 @@ export class JsonComposer extends Context.Service<
           { discard: true },
         );
 
-        return yield* Schema.encodeUnknownEffect(PackageJsonFromString)(
+        const encoded = yield* Schema.encodeUnknownEffect(PackageJson)(
           mutablePkg,
         ).pipe(
           Effect.mapError(
@@ -54,6 +53,8 @@ export class JsonComposer extends Context.Service<
               }),
           ),
         );
+
+        return `${JSON.stringify(encoded, null, 2)}\n`;
       }),
   } satisfies JsonComposerShape),
 }) {


### PR DESCRIPTION
## Goals/Scope

Format `package.json` using `apply` to match the repository’s style/linting expectations.