### PR TITLE
fix: seperate quality-biome into lint and format modules

### DIFF
--- a/.changeset/open-pandas-cough.md
+++ b/.changeset/open-pandas-cough.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+seperate biome into lint and format so it can be mixed

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -202,7 +202,8 @@ describe("RecipeService", () => {
           assertTargetModules(selection, ".", [
             ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
-            ModuleId.make("workspace-quality-biome"),
+            ModuleId.make("workspace-quality-biome-lint"),
+            ModuleId.make("workspace-quality-biome-format"),
             ModuleId.make("workspace-test-vitest"),
           ]);
         }).pipe(Effect.provide(TestLayer)),
@@ -226,10 +227,38 @@ describe("RecipeService", () => {
         assertTargetModules(selection, ".", [
           ModuleId.make("workspace-typescript-7"),
           ModuleId.make("workspace-monorepo-turbo"),
-          ModuleId.make("workspace-quality-biome"),
+          ModuleId.make("workspace-quality-biome-lint"),
+          ModuleId.make("workspace-quality-biome-format"),
           ModuleId.make("workspace-test-vitest"),
         ]);
       }).pipe(Effect.provide(TestLayer)),
+    );
+
+    it.effect(
+      "should select independent Biome lint and dprint format modules",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* RecipeService;
+          const config = new StackConfig({
+            ...testConfig,
+            format: "dprint",
+          });
+          const selection = yield* service.resolve(
+            { targets: [] },
+            {
+              config,
+              providerStrategy: { _tag: "fail-on-ambiguous" },
+            },
+          );
+
+          assertTargetModules(selection, ".", [
+            ModuleId.make("workspace-typescript-6"),
+            ModuleId.make("workspace-monorepo-turbo"),
+            ModuleId.make("workspace-quality-biome-lint"),
+            ModuleId.make("workspace-quality-dprint"),
+            ModuleId.make("workspace-test-vitest"),
+          ]);
+        }).pipe(Effect.provide(TestLayer)),
     );
 
     it.effect(
@@ -258,7 +287,8 @@ describe("RecipeService", () => {
           assertTargetModules(selection, ".", [
             ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
-            ModuleId.make("workspace-quality-biome"),
+            ModuleId.make("workspace-quality-biome-lint"),
+            ModuleId.make("workspace-quality-biome-format"),
             ModuleId.make("workspace-test-vitest"),
             ModuleId.make("workspace-devenv-git"),
           ]);
@@ -299,7 +329,8 @@ describe("RecipeService", () => {
           assertTargetModules(selection, ".", [
             ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
-            ModuleId.make("workspace-quality-biome"),
+            ModuleId.make("workspace-quality-biome-lint"),
+            ModuleId.make("workspace-quality-biome-format"),
             ModuleId.make("workspace-test-vitest"),
             ModuleId.make("workspace-devenv-git"),
           ]);
@@ -320,7 +351,8 @@ describe("RecipeService", () => {
                     name: "recipe-app",
                   }),
                   modules: [
-                    ModuleId.make("workspace-quality-biome"),
+                    ModuleId.make("workspace-quality-biome-lint"),
+                    ModuleId.make("workspace-quality-biome-format"),
                     ModuleId.make("workspace-devenv-git"),
                     ModuleId.make("workspace-devenv-git"),
                   ],
@@ -336,7 +368,8 @@ describe("RecipeService", () => {
           assertTargetModules(selection, ".", [
             ModuleId.make("workspace-typescript-6"),
             ModuleId.make("workspace-monorepo-turbo"),
-            ModuleId.make("workspace-quality-biome"),
+            ModuleId.make("workspace-quality-biome-lint"),
+            ModuleId.make("workspace-quality-biome-format"),
             ModuleId.make("workspace-test-vitest"),
             ModuleId.make("workspace-devenv-git"),
           ]);
@@ -396,7 +429,8 @@ describe("RecipeService", () => {
         assertTargetModules(selection, ".", [
           ModuleId.make("workspace-typescript-6"),
           ModuleId.make("workspace-monorepo-turbo"),
-          ModuleId.make("workspace-quality-biome"),
+          ModuleId.make("workspace-quality-biome-lint"),
+          ModuleId.make("workspace-quality-biome-format"),
           ModuleId.make("workspace-test-vitest"),
         ]);
       }).pipe(Effect.provide(TestLayer)),

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -203,27 +203,27 @@ export const biomeJsoncContents = `{
 
 export const biomeVscodeSettingsContents = `{
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "biomejs.biome",
+  "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}",
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
   },
   "[javascriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
   },
   "[json]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
   }
 }
 `;

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -263,9 +263,8 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
   {
     id: ModuleId.make("workspace-quality-biome"),
     title: "Biome",
-    description: "Fast linter and formatter",
+    description: "Shared Biome dependency and configuration",
     visibility: "internal",
-    categories: [ModuleCategory.make("lint"), ModuleCategory.make("format")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
     dependencies: [
       {
@@ -294,6 +293,26 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         name: "@biomejs/biome",
         value: "2.5.2",
       },
+    ],
+  },
+  {
+    id: ModuleId.make("workspace-quality-biome-lint"),
+    title: "Biome",
+    description: "Fast linter with recommended defaults",
+    visibility: "internal",
+    categories: [ModuleCategory.make("lint")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+        moduleId: ModuleId.make("workspace-quality-biome"),
+      },
+    ],
+    contributions: [
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",
@@ -301,6 +320,26 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         name: "lint",
         value: "biome lint .",
       },
+    ],
+  },
+  {
+    id: ModuleId.make("workspace-quality-biome-format"),
+    title: "Biome",
+    description: "Fast formatter with recommended defaults",
+    visibility: "internal",
+    categories: [ModuleCategory.make("format")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-module",
+        target: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+        moduleId: ModuleId.make("workspace-quality-biome"),
+      },
+    ],
+    contributions: [
       {
         _tag: "pkg-json-entry",
         path: "{{targetPath}}/package.json",

--- a/packages/scaffold/src/service/recipe/RecipePreviewService.test.ts
+++ b/packages/scaffold/src/service/recipe/RecipePreviewService.test.ts
@@ -1,0 +1,41 @@
+import { assert, it } from "@effect/vitest";
+import { StackConfig } from "@repo/domain/Scaffold";
+import { Effect, Schema } from "effect";
+import { RecipePreviewService } from "./RecipePreviewService";
+
+it.effect(
+  "should generate Biome linting with dprint formatting when both are selected",
+  () =>
+    Effect.gen(function* () {
+      const previews = yield* RecipePreviewService;
+      const preview = yield* previews.preview({
+        config: new StackConfig({
+          name: "quality-app" as typeof Schema.NonEmptyString.Type,
+          runtime: { _tag: "bun" },
+          monorepo: "turbo",
+          lint: "biome",
+          format: "dprint",
+          test: "vitest",
+        }),
+        recipe: { targets: [] },
+      });
+      const fileContents = (path: string) =>
+        preview.files.find((file) => file.path === path)?.contents;
+      const packageJson = JSON.parse(fileContents("package.json") ?? "{}");
+
+      assert.strictEqual(packageJson.scripts.lint, "biome lint .");
+      assert.strictEqual(packageJson.scripts.format, "dprint fmt");
+      assert.strictEqual(packageJson.scripts["format:check"], "dprint check");
+      assert.strictEqual(
+        packageJson.devDependencies["@biomejs/biome"],
+        "2.5.2",
+      );
+      assert.strictEqual(packageJson.devDependencies.dprint, "^0.54.0");
+      assert.isDefined(fileContents("biome.jsonc"));
+      assert.isDefined(fileContents("dprint.json"));
+      assert.include(
+        fileContents(".vscode/settings.json"),
+        '"editor.defaultFormatter": "dprint.dprint"',
+      );
+    }).pipe(Effect.provide(RecipePreviewService.layer)),
+);

--- a/packages/scaffold/src/service/recipe/RecipeService.ts
+++ b/packages/scaffold/src/service/recipe/RecipeService.ts
@@ -63,15 +63,24 @@ const configWorkspaceModules = (
 ): ReadonlyArray<typeof ModuleId.Type> =>
   Arr.dedupe(
     [
-      toTypeScriptModuleId(config.typescriptVersion),
-      config.monorepo,
-      config.lint,
-      config.format,
-      config.test,
+      toWorkspaceModuleId(
+        "tool",
+        toTypeScriptModuleId(config.typescriptVersion),
+      ),
+      config.monorepo === undefined
+        ? undefined
+        : toWorkspaceModuleId("tool", config.monorepo),
+      config.lint === undefined
+        ? undefined
+        : toWorkspaceModuleId("lint", config.lint),
+      config.format === undefined
+        ? undefined
+        : toWorkspaceModuleId("format", config.format),
+      config.test === undefined
+        ? undefined
+        : toWorkspaceModuleId("tool", config.test),
     ].flatMap((moduleId) =>
-      moduleId === undefined
-        ? []
-        : [ModuleId.make(toWorkspaceModuleId(moduleId))],
+      moduleId === undefined ? [] : [ModuleId.make(moduleId)],
     ),
   );
 

--- a/packages/scaffold/src/service/recipe/WorkspaceModules.ts
+++ b/packages/scaffold/src/service/recipe/WorkspaceModules.ts
@@ -1,19 +1,35 @@
 const workspaceToolModules = {
   turbo: "workspace-monorepo-turbo",
-  biome: "workspace-quality-biome",
   dprint: "workspace-quality-dprint",
   oxlint: "workspace-quality-oxlint",
   vitest: "workspace-test-vitest",
 } as const;
 
+const workspaceLintModules = {
+  biome: "workspace-quality-biome-lint",
+} as const;
+
+const workspaceFormatModules = {
+  biome: "workspace-quality-biome-format",
+} as const;
+
 const moduleToolValues = Object.fromEntries(
-  Object.entries(workspaceToolModules).map(([tool, moduleId]) => [
-    moduleId,
-    tool,
-  ]),
+  [
+    ...Object.entries(workspaceToolModules),
+    ...Object.entries(workspaceLintModules),
+    ...Object.entries(workspaceFormatModules),
+  ].map(([tool, moduleId]) => [moduleId, tool]),
 );
 
-export const toWorkspaceModuleId = (toolValue: string): string =>
+export const toWorkspaceModuleId = (
+  category: "lint" | "format" | "tool",
+  toolValue: string,
+): string =>
+  (category === "lint"
+    ? workspaceLintModules[toolValue as keyof typeof workspaceLintModules]
+    : category === "format"
+      ? workspaceFormatModules[toolValue as keyof typeof workspaceFormatModules]
+      : undefined) ??
   workspaceToolModules[toolValue as keyof typeof workspaceToolModules] ??
   toolValue;
 


### PR DESCRIPTION
## Goals/Scope

Separate the existing `quality-biome` setup into **lint** and **format** modules

## Description

- Split `quality-biome` into dedicated **lint** and **format** modules
- Refactor configuration wiring so lint and format workflows don’t depend on each other