### PR TITLE
feat: add vite+ modules

### DIFF
--- a/.changeset/cool-signs-float.md
+++ b/.changeset/cool-signs-float.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add oxfm module for formatting

--- a/.changeset/frank-deserts-study.md
+++ b/.changeset/frank-deserts-study.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+add vite-plus module for managing monorepo using vite+

--- a/.docs/how-to/add-new-module.md
+++ b/.docs/how-to/add-new-module.md
@@ -38,7 +38,7 @@ Use contribution tokens for dynamic values:
 | `{{workspaceDependency}}` | Compatible local workspace dependency range |
 | `{{projectName}}`        | Project name from config       |
 | `{{lint}}`               | Lint tool ("biome", "oxlint", or "") |
-| `{{format}}`             | Format tool ("biome", "dprint", or "") |
+| `{{format}}`             | Format tool ("biome", "dprint", "oxfmt", or "") |
 | `{{test}}`               | Test framework ("vitest" or "") |
 | `{{monorepo}}`           | Monorepo tool ("turbo" or "") |
 

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -101,6 +101,7 @@ class WorkspaceContainer extends Context.Service<WorkspaceContainer>()(
 interface ProjectContext {
   readonly dir: string;
   readonly install: () => Effect.Effect<CommandResult>;
+  readonly expectInstallSucceeds: () => Effect.Effect<void>;
   readonly exec: (
     ...args: ReadonlyArray<string>
   ) => Effect.Effect<CommandResult>;
@@ -113,6 +114,14 @@ interface ProjectContext {
     packageManager?: "bun" | "pnpm",
   ) => Effect.Effect<void>;
   readonly expectTestsPasses: () => Effect.Effect<void>;
+  readonly expectCommandSucceeds: (
+    label: string,
+    ...args: ReadonlyArray<string>
+  ) => Effect.Effect<void>;
+  readonly writeFile: (
+    relativePath: string,
+    contents: string,
+  ) => Effect.Effect<void>;
   readonly expectFileExists: (relativePath: string) => Effect.Effect<void>;
   readonly expectFileNotExists: (relativePath: string) => Effect.Effect<void>;
   readonly expectFileContaining: (
@@ -154,6 +163,7 @@ const makeProjectContext = (
   return {
     dir: projectDir,
     install: () => run(["bun", "install"]),
+    expectInstallSucceeds: () => assertCommand("Install", "bun", "install"),
     exec: (...args) => run(args),
     expectBuildSucceeds: (packageManager = "bun") =>
       assertCommand("Build", packageManager, "run", "build"),
@@ -162,6 +172,13 @@ const makeProjectContext = (
     expectTypeCheckPasses: (packageManager = "bun") =>
       assertCommand("TypeCheck", packageManager, "run", "type-check"),
     expectTestsPasses: () => assertCommand("Tests", "bun", "run", "test"),
+    expectCommandSucceeds: assertCommand,
+    writeFile: (relativePath, contents) =>
+      Effect.gen(function* () {
+        const filePath = path.join(projectDir, relativePath);
+        yield* fs.makeDirectory(path.dirname(filePath), { recursive: true });
+        yield* fs.writeFileString(filePath, contents);
+      }).pipe(Effect.orDie),
 
     expectFileExists: (relativePath) =>
       fs.exists(path.join(projectDir, relativePath)).pipe(

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -162,6 +162,120 @@ describe("init", () => {
     );
 
     it.effect(
+      "should remain valid and idempotent when an Oxfmt workspace is generated",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "create",
+            "oxfmt-app",
+            "--target",
+            "package/domain:domain-api-contracts",
+            "--yes",
+            "--format",
+            "oxfmt",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileExists("oxfmt-app/.oxfmtrc.jsonc");
+          yield* cli.expectFileExists("oxfmt-app/.vscode/settings.json");
+          yield* cli.expectFileExists("oxfmt-app/.vscode/extensions.json");
+          yield* cli.expectFileNotExists("oxfmt-app/dprint.json");
+          yield* cli.expectFileContaining(
+            "oxfmt-app/biome.jsonc",
+            /^(?![\s\S]*"formatter"\s*:)[\s\S]*$/,
+          );
+
+          yield* cli.withinProject("oxfmt-app", function* (project) {
+            yield* project.expectInstallSucceeds();
+            yield* project.expectFormatPasses();
+            yield* project.expectLintPasses();
+            yield* project.expectTypeCheckPasses();
+            yield* project.expectCommandSucceeds(
+              "Tests",
+              "bun",
+              "run",
+              "test",
+              "--",
+              "--",
+              "--passWithNoTests",
+            );
+            yield* project.expectBuildSucceeds();
+
+            yield* project.writeFile("generated/invalid.ts", "const =\n");
+            yield* project.expectCommandSucceeds(
+              "First format",
+              "bun",
+              "run",
+              "format",
+            );
+            yield* project.expectCommandSucceeds(
+              "Stage first format",
+              "git",
+              "add",
+              "-A",
+            );
+            yield* project.expectCommandSucceeds(
+              "Second format",
+              "bun",
+              "run",
+              "format",
+            );
+            yield* project.expectCommandSucceeds(
+              "Idempotency diff",
+              "git",
+              "diff",
+              "--exit-code",
+            );
+            yield* project.expectFormatPasses();
+            yield* project.expectFileContaining(
+              "generated/invalid.ts",
+              "const =\n",
+            );
+          });
+        }),
+      { timeout: 120_000 },
+    );
+
+    it.effect(
+      "should select Oxfmt when the catalog workspace is reset",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "catalog",
+            "workspace",
+            "reset",
+            "--format",
+            "oxfmt",
+            "--root",
+            `${cli.workdir}/catalog-oxfmt`,
+          );
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileExists("catalog-oxfmt/.oxfmtrc.jsonc");
+          yield* cli.expectFileNotExists("catalog-oxfmt/dprint.json");
+          yield* cli.expectJsonFile(
+            "catalog-oxfmt/package.json",
+            "scripts.format",
+            "oxfmt",
+          );
+          yield* cli.expectJsonFile(
+            "catalog-oxfmt/package.json",
+            "devDependencies.oxfmt",
+            "^0.62.0",
+          );
+          yield* cli.expectFileContaining(
+            "catalog-oxfmt/.catalog-build-manifest.json",
+            '"moduleId": "workspace-quality-oxfmt"',
+          );
+        }),
+      { timeout: 120_000 },
+    );
+
+    it.effect(
       "should generate only Vite+ orchestration when Vite+ is selected",
       () =>
         Effect.gen(function* () {

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -108,7 +108,7 @@ describe("init", () => {
     );
 
     it.effect(
-      "scaffolds expected monorepo structure",
+      "should generate only Turbo orchestration when using the default monorepo",
       () =>
         Effect.gen(function* () {
           const cli = yield* CLI;
@@ -119,6 +119,112 @@ describe("init", () => {
           yield* cli.expectFileExists("mono-app/turbo.json");
           yield* cli.expectFileExists("mono-app/biome.jsonc");
           yield* cli.expectFileExists("mono-app/package.json");
+          yield* cli.expectFileNotExists("mono-app/vite.config.ts");
+          yield* cli.expectJsonFile(
+            "mono-app/package.json",
+            "scripts.build",
+            "turbo run build",
+          );
+          yield* cli.expectJsonFile(
+            "mono-app/package.json",
+            "scripts.dev",
+            "turbo run dev",
+          );
+          yield* cli.expectJsonFile(
+            "mono-app/package.json",
+            "scripts.type-check",
+            "turbo run type-check",
+          );
+          yield* cli.expectJsonFile(
+            "mono-app/package.json",
+            "scripts.test",
+            "turbo run test",
+          );
+          yield* cli.expectJsonFile(
+            "mono-app/package.json",
+            "scripts.clean",
+            "turbo run clean && git clean -xdf node_modules .cache .turbo dist tsconfig.tsbuildinfo",
+          );
+          yield* cli.expectFileContaining(
+            "mono-app/package.json",
+            /^(?![\s\S]*"vite-plus"\s*:)[\s\S]*$/,
+          );
+          yield* cli.expectFileContaining(
+            "mono-app/.gitignore",
+            /^(?![\s\S]*node_modules\/\.vite\/task-cache)[\s\S]*$/,
+          );
+          yield* cli.expectFileContaining(
+            "mono-app/package.json",
+            /"build": "turbo run build"[\s\S]*"dev": "turbo run dev"[\s\S]*"type-check": "turbo run type-check"[\s\S]*"clean": "turbo run clean[^\n]+"[\s\S]*"format":[\s\S]*"lint":[\s\S]*"test": "turbo run test"/,
+          );
+        }),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
+      "should generate only Vite+ orchestration when Vite+ is selected",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "create",
+            "vite-plus-app",
+            "--target",
+            "package/domain:domain-api-contracts",
+            "--yes",
+            "--no-git",
+            "--monorepo",
+            "vite-plus",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.expectFileExists("vite-plus-app/vite.config.ts");
+          yield* cli.expectFileContaining(
+            "vite-plus-app/vite.config.ts",
+            /cache:\s*\{\s*scripts: true,\s*tasks: true,/,
+          );
+          yield* cli.expectJsonFile(
+            "vite-plus-app/package.json",
+            "devDependencies.vite-plus",
+            "^0.2.8",
+          );
+          yield* cli.expectJsonFile(
+            "vite-plus-app/package.json",
+            "scripts.build",
+            "vp run -r build",
+          );
+          yield* cli.expectJsonFile(
+            "vite-plus-app/package.json",
+            "scripts.dev",
+            "vp run -r --parallel --no-cache dev",
+          );
+          yield* cli.expectJsonFile(
+            "vite-plus-app/package.json",
+            "scripts.type-check",
+            "vp run -r type-check",
+          );
+          yield* cli.expectJsonFile(
+            "vite-plus-app/package.json",
+            "scripts.test",
+            "vp run -r test",
+          );
+          yield* cli.expectJsonFile(
+            "vite-plus-app/package.json",
+            "scripts.clean",
+            'vp cache clean && vp run --no-cache --filter "./apps/*" --filter "./packages/*" clean && git clean -xdf node_modules .cache dist tsconfig.tsbuildinfo',
+          );
+          yield* cli.expectFileContaining(
+            "vite-plus-app/.gitignore",
+            "node_modules/.vite/task-cache",
+          );
+          yield* cli.expectFileNotExists("vite-plus-app/turbo.json");
+          yield* cli.expectFileContaining(
+            "vite-plus-app/package.json",
+            /^(?![\s\S]*"turbo"\s*:)[\s\S]*$/,
+          );
         }),
       { timeout: 30_000 },
     );

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -40,6 +40,7 @@ import { Command } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import {
+  formatFlag,
   monorepoFlag,
   recipeTargetFlag,
   rootFlag,
@@ -174,20 +175,15 @@ const buildWorkspaceSelection = Effect.fn("catalog.workspace.buildSelection")(
       ...(config.monorepo === undefined
         ? []
         : [ModuleId.make(toWorkspaceModuleId("tool", config.monorepo))]),
-      ...[
-        ModuleCategory.make("lint"),
-        ModuleCategory.make("format"),
-        ModuleCategory.make("test"),
-      ].flatMap((category) =>
-        pipe(
-          catalog.getModules({ category }),
-          Arr.head,
-          Option.match({
-            onNone: () => [],
-            onSome: (moduleDefinition) => [moduleDefinition.id],
-          }),
-        ),
-      ),
+      ...(config.lint === undefined
+        ? []
+        : [ModuleId.make(toWorkspaceModuleId("lint", config.lint))]),
+      ...(config.format === undefined
+        ? []
+        : [ModuleId.make(toWorkspaceModuleId("format", config.format))]),
+      ...(config.test === undefined
+        ? []
+        : [ModuleId.make(toWorkspaceModuleId("tool", config.test))]),
     ];
 
     const initTarget = ensureTarget(
@@ -566,6 +562,7 @@ const runFinalizeScripts = Effect.fn("catalog.workspace.runFinalizeScripts")(
 const reset = Command.make(
   "reset",
   {
+    format: formatFlag,
     root: rootFlag,
     target: recipeTargetFlag,
     typescript: typescriptFlag,
@@ -593,7 +590,7 @@ const reset = Command.make(
         runtime: { _tag: "bun" },
         typescript: Option.getOrElse(flags.typescript, () => "6" as const),
         lint: "biome",
-        format: "biome",
+        format: Option.getOrElse(flags.format, () => "biome"),
         test: "vitest",
         monorepo: Option.getOrElse(flags.monorepo, () => "turbo"),
       });
@@ -616,12 +613,12 @@ const reset = Command.make(
         `${JSON.stringify(manifest, null, 2)}\n`,
       );
 
+      yield* runGit(repoRoot, ["init", "--initial-branch=main"]);
       yield* runFinalizeScripts({ blueprint, config, repoRoot });
       yield* Console.log(
         "Finalize complete; run catalog workspace validate for post-format format/lint/type-check results.",
       );
 
-      yield* runGit(repoRoot, ["init", "--initial-branch=main"]);
       yield* runGit(repoRoot, ["add", "."]);
       yield* runGit(repoRoot, [
         "-c",

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -20,6 +20,7 @@ import {
   parseRecipeTargetSpecs,
   RecipeService,
   toTypeScriptModuleId,
+  toWorkspaceModuleId,
 } from "@repo/scaffold";
 import {
   Array as Arr,
@@ -38,7 +39,12 @@ import {
 import { Command } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
-import { recipeTargetFlag, rootFlag, typescriptFlag } from "../flags";
+import {
+  monorepoFlag,
+  recipeTargetFlag,
+  rootFlag,
+  typescriptFlag,
+} from "../flags";
 
 const defaultWorkspaceRoot = "workspace/catalog-built";
 
@@ -165,8 +171,10 @@ const buildWorkspaceSelection = Effect.fn("catalog.workspace.buildSelection")(
 
     const initDefaultModules = [
       ModuleId.make(toTypeScriptModuleId(config.typescriptVersion)),
+      ...(config.monorepo === undefined
+        ? []
+        : [ModuleId.make(toWorkspaceModuleId("tool", config.monorepo))]),
       ...[
-        ModuleCategory.make("monorepo"),
         ModuleCategory.make("lint"),
         ModuleCategory.make("format"),
         ModuleCategory.make("test"),
@@ -557,7 +565,12 @@ const runFinalizeScripts = Effect.fn("catalog.workspace.runFinalizeScripts")(
 
 const reset = Command.make(
   "reset",
-  { root: rootFlag, target: recipeTargetFlag, typescript: typescriptFlag },
+  {
+    root: rootFlag,
+    target: recipeTargetFlag,
+    typescript: typescriptFlag,
+    monorepo: monorepoFlag,
+  },
   (flags) =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -582,7 +595,7 @@ const reset = Command.make(
         lint: "biome",
         format: "biome",
         test: "vitest",
-        monorepo: "turbo",
+        monorepo: Option.getOrElse(flags.monorepo, () => "turbo"),
       });
 
       const selection = yield* buildWorkspaceSelection(config, flags.target);

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -130,6 +130,31 @@ describe("RecipeService", () => {
   });
 
   describe("resolve", () => {
+    it.effect("should select the Vite+ workspace module when configured", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const config = new StackConfig({
+          ...testConfig,
+          monorepo: "vite-plus",
+        });
+        const selection = yield* service.resolve(
+          { targets: [] },
+          {
+            config,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        assertTargetModules(selection, ".", [
+          ModuleId.make("workspace-typescript-6"),
+          ModuleId.make("workspace-monorepo-vite-plus"),
+          ModuleId.make("workspace-quality-biome-lint"),
+          ModuleId.make("workspace-quality-biome-format"),
+          ModuleId.make("workspace-test-vitest"),
+        ]);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect(
       "should return a Selection when recipe targets are requested",
       () =>
@@ -756,6 +781,30 @@ describe("RecipeService", () => {
   });
 
   describe("renderCreateCommand", () => {
+    it.effect(
+      "should render an explicit monorepo flag when Vite+ is configured",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* RecipeService;
+          const config = new StackConfig({
+            ...testConfig,
+            monorepo: "vite-plus",
+          });
+          const selection = yield* service.resolve(
+            { targets: [] },
+            {
+              config,
+              providerStrategy: { _tag: "fail-on-ambiguous" },
+            },
+          );
+
+          assert.strictEqual(
+            service.renderCreateCommand({ config, selection }),
+            "bunx stack-effect@latest create recipe-app --monorepo vite-plus --no-git",
+          );
+        }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect("should render selected targets as create target flags", () =>
       Effect.gen(function* () {
         const service = yield* RecipeService;

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -260,29 +260,56 @@ describe("RecipeService", () => {
     );
 
     it.effect(
-      "should select independent Biome lint and dprint format modules",
+      "should select independent lint and format modules when quality tools are configured",
       () =>
         Effect.gen(function* () {
           const service = yield* RecipeService;
-          const config = new StackConfig({
-            ...testConfig,
-            format: "dprint",
-          });
-          const selection = yield* service.resolve(
-            { targets: [] },
+          const cases = [
             {
-              config,
-              providerStrategy: { _tag: "fail-on-ambiguous" },
+              lint: "biome",
+              format: "dprint",
+              modules: [
+                "workspace-quality-biome-lint",
+                "workspace-quality-dprint",
+              ],
             },
-          );
+            {
+              lint: "biome",
+              format: "oxfmt",
+              modules: [
+                "workspace-quality-biome-lint",
+                "workspace-quality-oxfmt",
+              ],
+            },
+            {
+              lint: "oxlint",
+              format: "oxfmt",
+              modules: ["workspace-quality-oxlint", "workspace-quality-oxfmt"],
+            },
+          ] as const;
 
-          assertTargetModules(selection, ".", [
-            ModuleId.make("workspace-typescript-6"),
-            ModuleId.make("workspace-monorepo-turbo"),
-            ModuleId.make("workspace-quality-biome-lint"),
-            ModuleId.make("workspace-quality-dprint"),
-            ModuleId.make("workspace-test-vitest"),
-          ]);
+          yield* Effect.forEach(cases, ({ lint, format, modules }) =>
+            service
+              .resolve(
+                { targets: [] },
+                {
+                  config: new StackConfig({ ...testConfig, lint, format }),
+                  providerStrategy: { _tag: "fail-on-ambiguous" },
+                },
+              )
+              .pipe(
+                Effect.tap((selection) =>
+                  Effect.sync(() =>
+                    assertTargetModules(selection, ".", [
+                      ModuleId.make("workspace-typescript-6"),
+                      ModuleId.make("workspace-monorepo-turbo"),
+                      ...modules.map(ModuleId.make),
+                      ModuleId.make("workspace-test-vitest"),
+                    ]),
+                  ),
+                ),
+              ),
+          );
         }).pipe(Effect.provide(TestLayer)),
     );
 

--- a/apps/docs/app/features/recipe-builder/stack-configurator.tsx
+++ b/apps/docs/app/features/recipe-builder/stack-configurator.tsx
@@ -181,8 +181,10 @@ export function StackConfigurator() {
           />
         ))}
 
-        <FieldSet className="gap-2 sm:col-span-2">
-          <FieldLegend variant="label">Repository and DX</FieldLegend>
+        <FieldSet className="sm:col-span-2">
+          <FieldLegend variant="label" className="mb-2">
+            Repository and DX
+          </FieldLegend>
           <FieldGroup
             variant="outlined"
             className="grid grid-cols-1 sm:grid-cols-3"

--- a/packages/catalog/src/CatalogService.test.ts
+++ b/packages/catalog/src/CatalogService.test.ts
@@ -1,0 +1,24 @@
+import { assert, layer } from "@effect/vitest";
+import { ModuleId } from "@repo/domain/Catalog";
+import { Effect } from "effect";
+import { CatalogService } from "./CatalogService";
+
+layer(CatalogService.layer)("CatalogService", (it) => {
+  it.effect(
+    "should expose module incompatibilities when building the public catalog tree",
+    () =>
+      Effect.gen(function* () {
+        const catalog = yield* CatalogService;
+        const workspace = catalog.toCatalogTree.targets.find(
+          (target) => target.kind === "workspace",
+        );
+        const vitePlus = workspace?.modules.find(
+          (module) => module.id === "workspace-monorepo-vite-plus",
+        );
+
+        assert.deepStrictEqual(vitePlus?.conflictsWith, [
+          ModuleId.make("workspace-monorepo-turbo"),
+        ]);
+      }),
+  );
+});

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -426,6 +426,7 @@ export class CatalogService extends Context.Service<CatalogService>()(
                   targetKind: imp.targetKind,
                   moduleId: imp.moduleId,
                 })),
+                conflictsWith: mod.conflictsWith ?? [],
               });
             },
           ),

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -185,11 +185,11 @@ export const biomeJsoncContents = `{
     "parser": {
       "tailwindDirectives": true
     }
-  },
+  }{{#if format=biome}},
   "formatter": {
     "enabled": true,
     "indentStyle": "space"
-  },
+  }{{/if}},
   "linter": {
     "enabled": true,
     "rules": {
@@ -199,12 +199,12 @@ export const biomeJsoncContents = `{
         "noUnknownAtRules": "off"
       }
     }
-  },
+  }{{#if format=biome}},
   "javascript": {
     "formatter": {
       "quoteStyle": "double"
     }
-  },
+  }{{/if}},
   "assist": {
     "enabled": true,
     "actions": {
@@ -216,30 +216,60 @@ export const biomeJsoncContents = `{
 }
 `;
 
-export const biomeVscodeSettingsContents = `{
+export const workspaceVscodeSettingsContents = `{
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}",
+  "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"{{#if lint=biome}},
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit"
-  },
+  }{{/if}},
   "[javascript]": {
-    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
   },
   "[javascriptreact]": {
-    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
   },
   "[json]": {
-    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}"
+    "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
   }
+}
+`;
+
+// -- oxfmt ------------------------------------------------------------------
+
+export const oxfmtJsoncContents = `{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "sortImports": false,
+  "sortTailwindcss": false,
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
+    "**/generated/**",
+    "**/.cache/**",
+    "**/.turbo/**"
+  ]
+}
+`;
+
+export const oxfmtVscodeExtensionsContents = `{
+  "recommendations": ["oxc.oxc-vscode"]
 }
 `;
 
@@ -357,13 +387,15 @@ export const devcontainerJsonContents = `{
       "settings": {
         "editor.formatOnSave": true{{#if format=biome}},
         "editor.defaultFormatter": "biomejs.biome"{{/if}}{{#if format=dprint}},
-        "editor.defaultFormatter": "dprint.dprint"{{/if}}
+        "editor.defaultFormatter": "dprint.dprint"{{/if}}{{#if format=oxfmt}},
+        "editor.defaultFormatter": "oxc.oxc-vscode"{{/if}}
       },
       "extensions": [
         {{#if lint=biome}}"biomejs.biome",
         {{/if}}{{#if format=biome}}"biomejs.biome",
         {{/if}}{{#if lint=oxlint}}"oxlint.oxlint-vscode",
         {{/if}}{{#if format=dprint}}"dprint.dprint",
+        {{/if}}{{#if format=oxfmt}}"oxc.oxc-vscode",
         {{/if}}{{#if runtime=bun}}"oven.bun-vscode",
         {{/if}}"effectful-tech.effect-vscode",
         "YoavBls.pretty-ts-errors"

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -1,7 +1,8 @@
 // -- bootstrap ---------------------------------------------------------
 
 export const gitignoreContents = `# dependencies
-node_modules
+node_modules{{#if monorepo=vite-plus}}
+node_modules/.vite/task-cache{{/if}}
 
 # build
 dist
@@ -155,6 +156,20 @@ export const turboJsonContents = `{
     }
   }
 }
+`;
+
+// -- vite+ ------------------------------------------------------------------
+
+export const vitePlusConfigContents = `import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  run: {
+    cache: {
+      scripts: true,
+      tasks: true,
+    },
+  },
+});
 `;
 
 // -- biome ------------------------------------------------------------------

--- a/packages/catalog/src/registry/moduleRegistry.test.ts
+++ b/packages/catalog/src/registry/moduleRegistry.test.ts
@@ -103,6 +103,19 @@ describe("moduleRegistry", () => {
     expect(vitePlus?.conflictsWith).toEqual(["workspace-monorepo-turbo"]);
   });
 
+  it("should register Oxfmt as a formatter alternative when catalog modules are listed", () => {
+    const oxfmt = moduleRegistry.find(
+      (mod) => mod.id === "workspace-quality-oxfmt",
+    );
+
+    expect(oxfmt).toBeDefined();
+    expect(oxfmt?.categories).toContain("format");
+    expect(oxfmt?.conflictsWith).toEqual([
+      "workspace-quality-biome-format",
+      "workspace-quality-dprint",
+    ]);
+  });
+
   it("should explain the global executable requirement when Vite+ is selected", () => {
     const vitePlus = moduleRegistry.find(
       (mod) => mod.id === "workspace-monorepo-vite-plus",

--- a/packages/catalog/src/registry/moduleRegistry.test.ts
+++ b/packages/catalog/src/registry/moduleRegistry.test.ts
@@ -75,4 +75,41 @@ describe("moduleRegistry", () => {
 
     expect(missing).toEqual([]);
   });
+
+  it("should require symmetric references when modules declare conflicts", () => {
+    const invalid = moduleRegistry.flatMap((mod) =>
+      (mod.conflictsWith ?? []).flatMap((conflict) => {
+        const conflictingModule = moduleRegistry.find(
+          (candidate) => candidate.id === conflict,
+        );
+
+        return conflictingModule === undefined ||
+          !conflictingModule.conflictsWith?.includes(mod.id)
+          ? [{ module: mod.id, conflictsWith: conflict }]
+          : [];
+      }),
+    );
+
+    expect(invalid).toEqual([]);
+  });
+
+  it("should register Vite+ as a Turbo alternative when listing monorepo modules", () => {
+    const vitePlus = moduleRegistry.find(
+      (mod) => mod.id === "workspace-monorepo-vite-plus",
+    );
+
+    expect(vitePlus).toBeDefined();
+    expect(vitePlus?.categories).toContain("monorepo");
+    expect(vitePlus?.conflictsWith).toEqual(["workspace-monorepo-turbo"]);
+  });
+
+  it("should explain the global executable requirement when Vite+ is selected", () => {
+    const vitePlus = moduleRegistry.find(
+      (mod) => mod.id === "workspace-monorepo-vite-plus",
+    );
+
+    expect(vitePlus?.nextSteps).toEqual([
+      expect.stringContaining("https://viteplus.dev/guide/"),
+    ]);
+  });
 });

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -7,14 +7,16 @@ import {
 } from "@repo/domain/Catalog";
 import {
   biomeJsoncContents,
-  biomeVscodeSettingsContents,
   devcontainerJsonContents,
   dprintJsonContents,
   envrcContents,
   flakeNixContents,
+  oxfmtJsoncContents,
+  oxfmtVscodeExtensionsContents,
   turboJsonContents,
   vitePlusConfigContents,
   vitestConfigContents,
+  workspaceVscodeSettingsContents,
 } from "../content/init";
 
 const gitInitModule: typeof ModuleDefinition.Type = {
@@ -350,7 +352,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
       {
         _tag: "file",
         path: "{{targetPath}}/.vscode/settings.json",
-        contents: biomeVscodeSettingsContents,
+        contents: workspaceVscodeSettingsContents,
       },
       {
         _tag: "pkg-json-entry",
@@ -394,6 +396,10 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     description: "Fast formatter with recommended defaults",
     visibility: "internal",
     categories: [ModuleCategory.make("format")],
+    conflictsWith: [
+      ModuleId.make("workspace-quality-dprint"),
+      ModuleId.make("workspace-quality-oxfmt"),
+    ],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
     dependencies: [
       {
@@ -423,11 +429,74 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
   },
   {
+    id: ModuleId.make("workspace-quality-oxfmt"),
+    title: "Oxfmt",
+    description: "High-performance formatter for the JavaScript ecosystem",
+    visibility: "internal",
+    categories: [ModuleCategory.make("format")],
+    conflictsWith: [
+      ModuleId.make("workspace-quality-biome-format"),
+      ModuleId.make("workspace-quality-dprint"),
+    ],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/.oxfmtrc.jsonc",
+        contents: oxfmtJsoncContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/.vscode/settings.json",
+        contents: workspaceVscodeSettingsContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/.vscode/extensions.json",
+        contents: oxfmtVscodeExtensionsContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "oxfmt",
+        value: "^0.62.0",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "format",
+        value: "oxfmt",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "format:check",
+        value: "oxfmt --check",
+      },
+    ],
+  },
+  {
     id: ModuleId.make("workspace-quality-dprint"),
     title: "dprint",
     description: "Fast pluggable formatter used by the Effect team",
     visibility: "internal",
     categories: [ModuleCategory.make("format")],
+    conflictsWith: [
+      ModuleId.make("workspace-quality-biome-format"),
+      ModuleId.make("workspace-quality-oxfmt"),
+    ],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
     dependencies: [
       {

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -13,6 +13,7 @@ import {
   envrcContents,
   flakeNixContents,
   turboJsonContents,
+  vitePlusConfigContents,
   vitestConfigContents,
 } from "../content/init";
 
@@ -206,6 +207,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     description: "Monorepo build orchestration with caching",
     visibility: "internal",
     categories: [ModuleCategory.make("monorepo")],
+    conflictsWith: [ModuleId.make("workspace-monorepo-vite-plus")],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
     dependencies: [
       {
@@ -258,6 +260,70 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         value:
           "turbo run clean && git clean -xdf node_modules .cache .turbo dist tsconfig.tsbuildinfo",
       },
+    ],
+  },
+  {
+    id: ModuleId.make("workspace-monorepo-vite-plus"),
+    title: "Vite+",
+    description: "Monorepo task orchestration and caching with Vite+",
+    visibility: "internal",
+    categories: [ModuleCategory.make("monorepo")],
+    conflictsWith: [ModuleId.make("workspace-monorepo-turbo")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/vite.config.ts",
+        contents: vitePlusConfigContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "vite-plus",
+        value: "^0.2.8",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "build",
+        value: "vp run -r build",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "dev",
+        value: "vp run -r --parallel --no-cache dev",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "type-check",
+        value: "vp run -r type-check",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "clean",
+        value:
+          'vp cache clean && vp run --no-cache --filter "./apps/*" --filter "./packages/*" clean && git clean -xdf node_modules .cache dist tsconfig.tsbuildinfo',
+      },
+    ],
+    nextSteps: [
+      "Vite+: Install the separate global `vp` executable (https://viteplus.dev/guide/)",
     ],
   },
   {
@@ -475,7 +541,8 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "scripts",
         name: "test",
-        value: "turbo run test",
+        value:
+          "{{#if monorepo=turbo}}turbo run test{{/if}}{{#if monorepo=vite-plus}}vp run -r test{{/if}}",
       },
     ],
   },

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -310,6 +310,10 @@ export const ModuleDefinition = Schema.Struct({
     Schema.optionalKey,
     Schema.withConstructorDefault(Effect.succeed([])),
   ),
+  conflictsWith: Schema.Array(ModuleId).pipe(
+    Schema.optionalKey,
+    Schema.withConstructorDefault(Effect.succeed([])),
+  ),
   /**
    * Same-target child modules shown in nested selection UI.
    * Children must share at least one `supportedOn` rule with the parent.
@@ -407,6 +411,7 @@ export const CatalogTreeModule = Schema.Struct({
   ),
   provides: Schema.Array(ModuleCapability),
   implies: Schema.Array(ModuleImplication),
+  conflictsWith: Schema.Array(ModuleId),
 });
 
 /**

--- a/packages/domain/src/Scaffold.test.ts
+++ b/packages/domain/src/Scaffold.test.ts
@@ -292,6 +292,15 @@ describe("ContributionTokenContext.resolve", () => {
   });
 
   describe("equality conditionals", () => {
+    it("should resolve an equality conditional when its value contains a hyphen", () => {
+      const ctx = makeContext({ monorepo: "vite-plus" });
+      expect(
+        ctx.resolve(
+          "{{#if monorepo=vite-plus}}node_modules/.vite/task-cache{{/if}}",
+        ),
+      ).toBe("node_modules/.vite/task-cache");
+    });
+
     it("includes content when field equals value", () => {
       const ctx = makeContext({ lint: "biome" });
       expect(ctx.resolve("{{#if lint=biome}}is biome{{/if}}")).toBe("is biome");

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -84,7 +84,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
    * - `{{typescript}}` - TypeScript major version ("6" or "7"; defaults to "6")
    * - `{{workspaceDependency}}` - Package-manager-compatible local workspace range
    * - `{{lint}}` - Lint tool ("biome", "oxlint", or "")
-   * - `{{format}}` - Format tool ("biome", "dprint", or "")
+   * - `{{format}}` - Format tool ("biome", "dprint", "oxfmt", or "")
    * - `{{test}}` - Test framework ("vitest" or "")
    * - `{{monorepo}}` - Monorepo tool (for example, "turbo" or "vite-plus")
    * - `{{targetKind}}`, `{{targetName}}`, `{{targetPath}}`, `{{targetDir}}`, `{{packageName}}`

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -86,7 +86,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
    * - `{{lint}}` - Lint tool ("biome", "oxlint", or "")
    * - `{{format}}` - Format tool ("biome", "dprint", or "")
    * - `{{test}}` - Test framework ("vitest" or "")
-   * - `{{monorepo}}` - Monorepo tool ("turbo" or "")
+   * - `{{monorepo}}` - Monorepo tool (for example, "turbo" or "vite-plus")
    * - `{{targetKind}}`, `{{targetName}}`, `{{targetPath}}`, `{{targetDir}}`, `{{packageName}}`
    *
    * ## Conditionals
@@ -132,7 +132,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
 
     const resolveConditionals = (t: string): string => {
       const conditionalRegex =
-        /\{\{#if\s+(\w+)(?:=(\w+))?\}\}([\s\S]*?)\{\{\/if\}\}/g;
+        /\{\{#if\s+(\w+)(?:=([\w-]+))?\}\}([\s\S]*?)\{\{\/if\}\}/g;
       return t.replace(conditionalRegex, (_, field, value, content) => {
         const configValue = getConfigValue(field);
         if (value !== undefined) {

--- a/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
@@ -151,6 +151,75 @@ describe("BlueprintService", () => {
           });
         }),
       );
+
+      it.effect(
+        "should fail when incompatible modules resolve on one target",
+        () =>
+          Effect.gen(function* () {
+            const blueprintService = yield* BlueprintService;
+            const exit = yield* Effect.exit(
+              blueprintService.resolve({
+                targets: [
+                  {
+                    identity: new TargetIdentity({
+                      kind: TargetKind.make("workspace"),
+                      name: "root",
+                    }),
+                    modules: [
+                      { id: ModuleId.make("workspace-monorepo-turbo") },
+                      { id: ModuleId.make("workspace-monorepo-vite-plus") },
+                    ],
+                  },
+                ],
+              }),
+            );
+            const error = squashFailure(exit);
+
+            expect(error).toBeInstanceOf(BlueprintFailure);
+            expect(error).toMatchObject({
+              message:
+                "Incompatible modules on .: workspace-monorepo-turbo conflicts with workspace-monorepo-vite-plus",
+            });
+          }),
+      );
+
+      it.effect(
+        "should allow compatible modules when they share a presentation category",
+        () =>
+          Effect.gen(function* () {
+            const blueprintService = yield* BlueprintService;
+            const blueprint = yield* blueprintService.resolve({
+              targets: [
+                {
+                  identity: new TargetIdentity({
+                    kind: TargetKind.make("workspace"),
+                    name: "root",
+                  }),
+                  modules: [
+                    { id: ModuleId.make("workspace-quality-biome-format") },
+                    { id: ModuleId.make("workspace-quality-dprint") },
+                  ],
+                },
+              ],
+            });
+
+            expect(
+              blueprint.nodes.filter(
+                (node) =>
+                  node._tag === "attached-module" && node.targetId === ".",
+              ),
+            ).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  moduleId: "workspace-quality-biome-format",
+                }),
+                expect.objectContaining({
+                  moduleId: "workspace-quality-dprint",
+                }),
+              ]),
+            );
+          }),
+      );
     });
 
     describe("when resolving dependencies", () => {

--- a/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.test.ts
@@ -166,8 +166,8 @@ describe("BlueprintService", () => {
                       name: "root",
                     }),
                     modules: [
-                      { id: ModuleId.make("workspace-monorepo-turbo") },
-                      { id: ModuleId.make("workspace-monorepo-vite-plus") },
+                      { id: ModuleId.make("workspace-quality-biome-format") },
+                      { id: ModuleId.make("workspace-quality-oxfmt") },
                     ],
                   },
                 ],
@@ -178,7 +178,7 @@ describe("BlueprintService", () => {
             expect(error).toBeInstanceOf(BlueprintFailure);
             expect(error).toMatchObject({
               message:
-                "Incompatible modules on .: workspace-monorepo-turbo conflicts with workspace-monorepo-vite-plus",
+                "Incompatible modules on .: workspace-quality-biome-format conflicts with workspace-quality-oxfmt",
             });
           }),
       );
@@ -196,8 +196,8 @@ describe("BlueprintService", () => {
                     name: "root",
                   }),
                   modules: [
-                    { id: ModuleId.make("workspace-quality-biome-format") },
-                    { id: ModuleId.make("workspace-quality-dprint") },
+                    { id: ModuleId.make("workspace-devenv-nix-flake") },
+                    { id: ModuleId.make("workspace-devenv-devcontainer") },
                   ],
                 },
               ],
@@ -211,10 +211,10 @@ describe("BlueprintService", () => {
             ).toEqual(
               expect.arrayContaining([
                 expect.objectContaining({
-                  moduleId: "workspace-quality-biome-format",
+                  moduleId: "workspace-devenv-nix-flake",
                 }),
                 expect.objectContaining({
-                  moduleId: "workspace-quality-dprint",
+                  moduleId: "workspace-devenv-devcontainer",
                 }),
               ]),
             );

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -209,6 +209,29 @@ const resolveSelection = Effect.fn("BlueprintService.resolveSelection")(
         return current.value;
       }
 
+      const definition = yield* catalog.getModule(moduleId);
+      const attachedOnTarget = yield* Ref.get(stateRef).pipe(
+        Effect.map((state) =>
+          Arr.filter(
+            HashMap.values(state.attachedModules),
+            (attached) => attached.targetId === targetState.id,
+          ),
+        ),
+      );
+
+      for (const attached of attachedOnTarget) {
+        const attachedDefinition = yield* catalog.getModule(attached.moduleId);
+        const isIncompatible =
+          (definition.conflictsWith ?? []).includes(attached.moduleId) ||
+          (attachedDefinition.conflictsWith ?? []).includes(moduleId);
+
+        if (isIncompatible) {
+          throw new BlueprintFailure({
+            message: `Incompatible modules on ${targetState.id}: ${attached.moduleId} conflicts with ${moduleId}`,
+          });
+        }
+      }
+
       const next: typeof BlueprintAttachedModuleNode.Type = {
         _tag: "attached-module",
         id: attachedModuleNodeId,
@@ -231,8 +254,6 @@ const resolveSelection = Effect.fn("BlueprintService.resolveSelection")(
         to: attachedModuleNodeId,
         reason: "owns-module",
       });
-
-      const definition = yield* catalog.getModule(moduleId);
 
       for (const dependency of definition.dependencies) {
         yield* ModuleDependency.match(dependency, {

--- a/packages/scaffold/src/service/recipe/RecipePreviewService.test.ts
+++ b/packages/scaffold/src/service/recipe/RecipePreviewService.test.ts
@@ -3,8 +3,27 @@ import { StackConfig } from "@repo/domain/Scaffold";
 import { Effect, Schema } from "effect";
 import { RecipePreviewService } from "./RecipePreviewService";
 
+const previewQualityConfig = (
+  lint: "biome" | "oxlint",
+  format: "dprint" | "oxfmt",
+) =>
+  Effect.gen(function* () {
+    const previews = yield* RecipePreviewService;
+    return yield* previews.preview({
+      config: new StackConfig({
+        name: "quality-app" as typeof Schema.NonEmptyString.Type,
+        runtime: { _tag: "bun" },
+        monorepo: "turbo",
+        lint,
+        format,
+        test: "vitest",
+      }),
+      recipe: { targets: [] },
+    });
+  });
+
 it.effect(
-  "should generate Biome linting with dprint formatting when both are selected",
+  "should preserve Biome import organization when dprint formatting is selected",
   () =>
     Effect.gen(function* () {
       const previews = yield* RecipePreviewService;
@@ -36,6 +55,115 @@ it.effect(
       assert.include(
         fileContents(".vscode/settings.json"),
         '"editor.defaultFormatter": "dprint.dprint"',
+      );
+      assert.include(
+        fileContents(".vscode/settings.json"),
+        "source.organizeImports.biome",
+      );
+    }).pipe(Effect.provide(RecipePreviewService.layer)),
+);
+
+it.effect(
+  "should generate Oxfmt commands and dependency when Oxfmt formatting is selected",
+  () =>
+    Effect.gen(function* () {
+      const preview = yield* previewQualityConfig("biome", "oxfmt");
+      const fileContents = (path: string) =>
+        preview.files.find((file) => file.path === path)?.contents;
+      const packageJson = JSON.parse(fileContents("package.json") ?? "{}");
+
+      assert.strictEqual(packageJson.scripts.format, "oxfmt");
+      assert.strictEqual(packageJson.scripts["format:check"], "oxfmt --check");
+      assert.strictEqual(packageJson.devDependencies.oxfmt, "^0.62.0");
+      assert.isUndefined(fileContents("dprint.json"));
+    }).pipe(Effect.provide(RecipePreviewService.layer)),
+);
+
+it.effect(
+  "should emit the established Oxfmt policy when Oxfmt formatting is selected",
+  () =>
+    Effect.gen(function* () {
+      const preview = yield* previewQualityConfig("biome", "oxfmt");
+      const fileContents = (path: string) =>
+        preview.files.find((file) => file.path === path)?.contents;
+
+      assert.deepStrictEqual(
+        JSON.parse(fileContents(".oxfmtrc.jsonc") ?? "{}"),
+        {
+          $schema: "./node_modules/oxfmt/configuration_schema.json",
+          printWidth: 80,
+          tabWidth: 2,
+          useTabs: false,
+          semi: true,
+          singleQuote: false,
+          trailingComma: "all",
+          sortImports: false,
+          sortTailwindcss: false,
+          sortPackageJson: false,
+          ignorePatterns: [
+            "**/node_modules/**",
+            "**/dist/**",
+            "**/build/**",
+            "**/coverage/**",
+            "**/generated/**",
+            "**/.cache/**",
+            "**/.turbo/**",
+          ],
+        },
+      );
+    }).pipe(Effect.provide(RecipePreviewService.layer)),
+);
+
+it.effect(
+  "should configure the Oxc extension when Oxfmt formatting is selected",
+  () =>
+    Effect.gen(function* () {
+      const preview = yield* previewQualityConfig("biome", "oxfmt");
+      const fileContents = (path: string) =>
+        preview.files.find((file) => file.path === path)?.contents;
+
+      assert.include(
+        fileContents(".vscode/settings.json"),
+        '"editor.defaultFormatter": "oxc.oxc-vscode"',
+      );
+      assert.include(
+        fileContents(".vscode/extensions.json"),
+        '"recommendations": ["oxc.oxc-vscode"]',
+      );
+    }).pipe(Effect.provide(RecipePreviewService.layer)),
+);
+
+it.effect(
+  "should preserve Biome lint configuration when Oxfmt formatting is selected",
+  () =>
+    Effect.gen(function* () {
+      const preview = yield* previewQualityConfig("biome", "oxfmt");
+      const fileContents = (path: string) =>
+        preview.files.find((file) => file.path === path)?.contents;
+      const packageJson = JSON.parse(fileContents("package.json") ?? "{}");
+
+      assert.strictEqual(packageJson.scripts.lint, "biome lint .");
+      assert.isDefined(fileContents("biome.jsonc"));
+      assert.notInclude(fileContents("biome.jsonc"), '"formatter"');
+      assert.include(
+        fileContents(".vscode/settings.json"),
+        "source.organizeImports.biome",
+      );
+    }).pipe(Effect.provide(RecipePreviewService.layer)),
+);
+
+it.effect(
+  "should omit Biome editor actions when Oxlint and Oxfmt are selected",
+  () =>
+    Effect.gen(function* () {
+      const preview = yield* previewQualityConfig("oxlint", "oxfmt");
+      const fileContents = (path: string) =>
+        preview.files.find((file) => file.path === path)?.contents;
+
+      assert.isUndefined(fileContents("biome.jsonc"));
+      assert.notInclude(
+        fileContents(".vscode/settings.json"),
+        "source.organizeImports.biome",
       );
     }).pipe(Effect.provide(RecipePreviewService.layer)),
 );

--- a/packages/scaffold/src/service/recipe/WorkspaceModules.ts
+++ b/packages/scaffold/src/service/recipe/WorkspaceModules.ts
@@ -12,6 +12,7 @@ const workspaceLintModules = {
 
 const workspaceFormatModules = {
   biome: "workspace-quality-biome-format",
+  oxfmt: "workspace-quality-oxfmt",
 } as const;
 
 const moduleToolValues = Object.fromEntries(

--- a/packages/scaffold/src/service/recipe/WorkspaceModules.ts
+++ b/packages/scaffold/src/service/recipe/WorkspaceModules.ts
@@ -1,5 +1,6 @@
 const workspaceToolModules = {
   turbo: "workspace-monorepo-turbo",
+  "vite-plus": "workspace-monorepo-vite-plus",
   dprint: "workspace-quality-dprint",
   oxlint: "workspace-quality-oxlint",
   vitest: "workspace-test-vitest",


### PR DESCRIPTION
## Goals/Scope

Add `vite+` and `oxfmt` module

## Description

- Introduced `vite+` monorepo module
- Corrected the `dx` modules label styling gap
- Added `oxfmt` module

---

- [x] closes #198
- [x] closes #199