### PR TITLE
feat: add url sharing to builder

### DIFF
--- a/.changeset/social-pigs-add.md
+++ b/.changeset/social-pigs-add.md
@@ -1,0 +1,5 @@
+---
+"@stack-effect/docs": minor
+---
+
+The Recipe Builder can now keep valid selections in the URL and copy a shareable recipe link.

--- a/apps/docs/app/components/molecules/command-dock.tsx
+++ b/apps/docs/app/components/molecules/command-dock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Clipboard } from "lucide-react";
+import { Check, Clipboard, Share2 } from "lucide-react";
 import { type ReactNode, useEffect, useId } from "react";
 import { Button } from "~/components/ui/button";
 import { useCopyToClipboard } from "~/hooks/use-copy-to-clipboard";
@@ -10,6 +10,7 @@ type CommandDockProps = {
   readonly command: string;
   readonly summary: ReactNode;
   readonly disabled?: boolean;
+  readonly shareUrl?: string;
   readonly sticky?: boolean;
   readonly onCopySuccess?: () => void;
 };
@@ -18,15 +19,22 @@ export function CommandDock({
   command,
   summary,
   disabled = false,
+  shareUrl,
   sticky = true,
   onCopySuccess,
 }: CommandDockProps) {
   const { status, copy, reset } = useCopyToClipboard();
+  const {
+    status: shareStatus,
+    copy: copyShareUrl,
+    reset: resetShareStatus,
+  } = useCopyToClipboard();
   const titleId = useId();
 
   useEffect(() => {
     reset();
-  }, [command, reset]);
+    resetShareStatus();
+  }, [command, reset, resetShareStatus, shareUrl]);
 
   const copyLabel =
     status === "copied"
@@ -43,6 +51,17 @@ export function CommandDock({
   const copyCommand = async () => {
     if (await copy(command)) onCopySuccess?.();
   };
+  const shareRecipe = async () => {
+    if (shareUrl)
+      await copyShareUrl(new URL(shareUrl, window.location.origin).toString());
+  };
+  const activeStatus = shareStatus === "idle" ? status : shareStatus;
+  const activeStatusMessage =
+    shareStatus === "copied"
+      ? "Recipe link copied — share it with your team."
+      : shareStatus === "error"
+        ? "Could not access the clipboard. Copy the URL from your browser instead."
+        : statusMessage;
 
   return (
     <aside
@@ -85,32 +104,53 @@ export function CommandDock({
           <p
             className={cn(
               "mt-1.5 hidden min-h-4 text-xs sm:block",
-              status === "copied" && "text-muted-foreground",
-              status === "error" && "text-destructive",
-              status === "idle" && "invisible",
+              activeStatus === "copied" && "text-muted-foreground",
+              activeStatus === "error" && "text-destructive",
+              activeStatus === "idle" && "invisible",
             )}
             aria-hidden="true"
           >
-            {statusMessage}
+            {activeStatusMessage}
           </p>
           <p className="sr-only" aria-live="polite" aria-atomic="true">
-            {statusMessage}
+            {activeStatusMessage}
           </p>
         </div>
-        <Button
-          className="h-11 w-11 p-0 text-center has-data-[icon=inline-start]:pl-0 sm:w-auto sm:px-4 sm:has-data-[icon=inline-start]:pl-4 lg:h-11"
-          type="button"
-          onClick={copyCommand}
-          disabled={disabled}
-        >
-          {status === "copied" ? (
-            <Check data-icon="inline-start" />
-          ) : (
-            <Clipboard data-icon="inline-start" />
-          )}
-          <span className="hidden sm:inline">{copyLabel}</span>
-          <span className="sr-only sm:hidden">{copyLabel}</span>
-        </Button>
+        <div className="flex gap-2">
+          {shareUrl ? (
+            <Button
+              variant="outline"
+              className="h-11 w-11 p-0 text-center sm:w-auto sm:px-4 sm:has-data-[icon=inline-start]:pl-4 lg:h-11"
+              type="button"
+              onClick={shareRecipe}
+              disabled={disabled}
+            >
+              {shareStatus === "copied" ? (
+                <Check data-icon="inline-start" />
+              ) : (
+                <Share2 data-icon="inline-start" />
+              )}
+              <span className="hidden sm:inline">
+                {shareStatus === "copied" ? "Copied" : "Share"}
+              </span>
+              <span className="sr-only sm:hidden">Share recipe</span>
+            </Button>
+          ) : null}
+          <Button
+            className="h-11 w-11 p-0 text-center has-data-[icon=inline-start]:pl-0 sm:w-auto sm:px-4 sm:has-data-[icon=inline-start]:pl-4 lg:h-11"
+            type="button"
+            onClick={copyCommand}
+            disabled={disabled}
+          >
+            {status === "copied" ? (
+              <Check data-icon="inline-start" />
+            ) : (
+              <Clipboard data-icon="inline-start" />
+            )}
+            <span className="hidden sm:inline">{copyLabel}</span>
+            <span className="sr-only sm:hidden">{copyLabel}</span>
+          </Button>
+        </div>
       </div>
     </aside>
   );

--- a/apps/docs/app/components/recipe-builder/form.ts
+++ b/apps/docs/app/components/recipe-builder/form.ts
@@ -125,9 +125,11 @@ export const initialRecipeBuilderValues: RecipeBuilderFormValues = {
   supportSelections: [],
 };
 
-export function useRecipeBuilderForm() {
+export function useRecipeBuilderForm(
+  initialValues: RecipeBuilderFormValues = initialRecipeBuilderValues,
+) {
   return useForm({
-    defaultValues: initialRecipeBuilderValues,
+    defaultValues: initialValues,
     validators: { onChange: recipeBuilderFormValidator },
   });
 }

--- a/apps/docs/app/components/recipe-builder/recipe-builder-context.tsx
+++ b/apps/docs/app/components/recipe-builder/recipe-builder-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, type ReactNode, use, useMemo } from "react";
-import { type RecipeBuilderFormApi, useRecipeBuilderForm } from "./form";
+import { type RecipeBuilderFormApi } from "./form";
+import { useRecipeBuilderUrlState } from "./use-recipe-builder-url-state";
 import {
   type RecipeBuilderWorkerModel,
   useRecipeBuilderWorker,
@@ -19,6 +20,10 @@ type RecipeBuilderPreviewModel = Pick<
   "canPreview" | "previewResult"
 >;
 
+type RecipeBuilderUrlModel = {
+  readonly urlIssue: string | undefined;
+};
+
 const RecipeBuilderCatalogContext = createContext<
   RecipeBuilderCatalogModel | undefined
 >(undefined);
@@ -27,13 +32,17 @@ const RecipeBuilderPreviewContext = createContext<
   RecipeBuilderPreviewModel | undefined
 >(undefined);
 
+const RecipeBuilderUrlContext = createContext<
+  RecipeBuilderUrlModel | undefined
+>(undefined);
+
 export function RecipeBuilderProvider({
   children,
 }: {
   readonly children: ReactNode;
 }) {
-  const form = useRecipeBuilderForm();
-  const worker = useRecipeBuilderWorker(form);
+  const urlState = useRecipeBuilderUrlState();
+  const worker = useRecipeBuilderWorker(urlState.form, urlState.workerEnabled);
   const catalog = useMemo<RecipeBuilderCatalogModel>(
     () => ({
       catalog: worker.catalog,
@@ -55,12 +64,18 @@ export function RecipeBuilderProvider({
     }),
     [worker.canPreview, worker.previewResult],
   );
+  const url = useMemo<RecipeBuilderUrlModel>(
+    () => ({ urlIssue: urlState.urlIssue }),
+    [urlState.urlIssue],
+  );
 
   return (
-    <RecipeBuilderFormContext value={form}>
+    <RecipeBuilderFormContext value={urlState.form}>
       <RecipeBuilderCatalogContext value={catalog}>
         <RecipeBuilderPreviewContext value={preview}>
-          {children}
+          <RecipeBuilderUrlContext value={url}>
+            {children}
+          </RecipeBuilderUrlContext>
         </RecipeBuilderPreviewContext>
       </RecipeBuilderCatalogContext>
     </RecipeBuilderFormContext>
@@ -95,4 +110,14 @@ export function useRecipeBuilderPreview() {
     );
   }
   return preview;
+}
+
+export function useRecipeBuilderUrl() {
+  const url = use(RecipeBuilderUrlContext);
+  if (url === undefined) {
+    throw new Error(
+      "useRecipeBuilderUrl must be used inside RecipeBuilderProvider",
+    );
+  }
+  return url;
 }

--- a/apps/docs/app/components/recipe-builder/recipe-builder-url.ts
+++ b/apps/docs/app/components/recipe-builder/recipe-builder-url.ts
@@ -1,0 +1,216 @@
+import { encodeRecipeTargetSpecs, RecipeTargetString } from "@repo/scaffold";
+import { Array as Arr, Option, Schema } from "effect";
+import {
+  initialRecipeBuilderValues,
+  RecipeBuilderFormSchema,
+  type RecipeBuilderFormValues,
+  type TargetInstance,
+  toRecipePreviewInput,
+} from "./form";
+
+const defaults = initialRecipeBuilderValues.config;
+
+const RecipeUrlSchema = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  target: Schema.Array(RecipeTargetString),
+  runtime: Schema.optional(Schema.Literals(["bun", "node"])),
+  packageManager: Schema.optional(Schema.Literals(["bun", "pnpm", "npm"])),
+  typescript: Schema.optional(Schema.Literals(["6", "7"])),
+  monorepo: Schema.optional(Schema.String),
+  lint: Schema.optional(Schema.String),
+  format: Schema.optional(Schema.String),
+  test: Schema.optional(Schema.String),
+  noGit: Schema.Boolean,
+}).check(
+  Schema.makeFilter(({ runtime, packageManager }) =>
+    (runtime === "bun" &&
+      packageManager !== undefined &&
+      packageManager !== "bun") ||
+    (runtime === "node" && packageManager === "bun")
+      ? "Runtime and package manager conflict."
+      : undefined,
+  ),
+);
+
+const scalarRecipeParameters = [
+  "name",
+  "runtime",
+  "package-manager",
+  "typescript",
+  "monorepo",
+  "lint",
+  "format",
+  "test",
+  "no-git",
+] as const;
+
+const knownRecipeParameters = new Set([...scalarRecipeParameters, "target"]);
+
+const decodeUrl = Schema.decodeUnknownOption(RecipeUrlSchema);
+
+const invalidRecipeUrl = {
+  issue:
+    "This shared recipe URL is invalid. Fix its query parameters before using it.",
+} as const;
+
+type ValidRecipeUrl = {
+  readonly initialValues: RecipeBuilderFormValues;
+  readonly issue: undefined;
+};
+
+type InvalidRecipeUrl = {
+  readonly initialValues: RecipeBuilderFormValues;
+  readonly issue: string;
+};
+
+export type DecodedRecipeUrl = ValidRecipeUrl | InvalidRecipeUrl;
+
+const mergeTargets = (targets: ReadonlyArray<typeof RecipeTargetString.Type>) =>
+  Arr.fromIterable(
+    targets
+      .reduce((merged, spec) => {
+        const key = spec.target.toKey();
+        const existing = merged.get(key);
+        merged.set(key, {
+          target: spec.target,
+          modules: Arr.dedupe([...(existing?.modules ?? []), ...spec.modules]),
+        });
+        return merged;
+      }, new Map<string, typeof RecipeTargetString.Type>())
+      .values(),
+  );
+
+const toInitialValues = (
+  recipe: typeof RecipeUrlSchema.Type,
+): RecipeBuilderFormValues | undefined => {
+  const packageManager = recipe.packageManager ?? "bun";
+  const runtime = recipe.runtime ?? (packageManager === "bun" ? "bun" : "node");
+  const config = {
+    name: recipe.name ?? defaults.name,
+    runtime:
+      runtime === "bun"
+        ? ({ _tag: "bun" } as const)
+        : ({
+            _tag: "node" as const,
+            packageManager: packageManager === "npm" ? "npm" : "pnpm",
+          } as const),
+    typescript: recipe.typescript ?? defaults.typescript,
+    monorepo: recipe.monorepo ?? defaults.monorepo,
+    lint: recipe.lint ?? defaults.lint,
+    format: recipe.format ?? defaults.format,
+    test: recipe.test ?? defaults.test,
+  };
+  const targets = mergeTargets(recipe.target);
+  const workspaceTargets = targets.filter(
+    (target) => target.target.kind === "workspace",
+  );
+  if (workspaceTargets.some((target) => target.target.name !== config.name)) {
+    return undefined;
+  }
+  const workspaceModules = Arr.dedupe(
+    workspaceTargets.flatMap((target) => target.modules.map(String)),
+  );
+  if (recipe.noGit && workspaceModules.includes("workspace-devenv-git")) {
+    return undefined;
+  }
+  const formTargets: ReadonlyArray<TargetInstance> = targets
+    .filter((target) => target.target.kind !== "workspace")
+    .map((target, index) => ({
+      id: `url-${target.target.kind}-${target.target.name || "default"}-${index + 1}`,
+      kind: target.target.kind,
+      name: target.target.name,
+      modules: target.modules.map(String),
+    }));
+  const decoded = Schema.decodeOption(RecipeBuilderFormSchema)({
+    config,
+    gitEnabled: !recipe.noGit,
+    developerExperienceModules: workspaceModules.filter(
+      (module) => module !== "workspace-devenv-git",
+    ),
+    targets: formTargets,
+    supportSelections: [],
+  });
+
+  return Option.getOrUndefined(decoded);
+};
+
+const hasDuplicateModules = (
+  targets: ReadonlyArray<typeof RecipeTargetString.Type>,
+) =>
+  targets.some(
+    (target) =>
+      new Set(target.modules.map(String)).size !== target.modules.length,
+  );
+
+export const decodeRecipeBuilderUrl = (
+  searchParams: URLSearchParams,
+): DecodedRecipeUrl => {
+  if ([...searchParams.keys()].some((key) => !knownRecipeParameters.has(key))) {
+    return { ...invalidRecipeUrl, initialValues: initialRecipeBuilderValues };
+  }
+  if (
+    scalarRecipeParameters.some((key) => searchParams.getAll(key).length > 1)
+  ) {
+    return { ...invalidRecipeUrl, initialValues: initialRecipeBuilderValues };
+  }
+  const decoded = decodeUrl({
+    name: searchParams.get("name") ?? undefined,
+    target: searchParams.getAll("target"),
+    runtime: searchParams.get("runtime") ?? undefined,
+    packageManager: searchParams.get("package-manager") ?? undefined,
+    typescript: searchParams.get("typescript") ?? undefined,
+    monorepo: searchParams.get("monorepo") ?? undefined,
+    lint: searchParams.get("lint") ?? undefined,
+    format: searchParams.get("format") ?? undefined,
+    test: searchParams.get("test") ?? undefined,
+    noGit: searchParams.has("no-git"),
+  });
+  if (Option.isNone(decoded)) {
+    return { ...invalidRecipeUrl, initialValues: initialRecipeBuilderValues };
+  }
+  if (hasDuplicateModules(decoded.value.target)) {
+    return { ...invalidRecipeUrl, initialValues: initialRecipeBuilderValues };
+  }
+  const initialValues = toInitialValues(decoded.value);
+  return initialValues === undefined
+    ? { ...invalidRecipeUrl, initialValues: initialRecipeBuilderValues }
+    : { initialValues, issue: undefined };
+};
+
+export const encodeRecipeBuilderUrl = (
+  values: RecipeBuilderFormValues,
+): URLSearchParams => {
+  const params = new URLSearchParams();
+  const previewInput = toRecipePreviewInput(values);
+  const targets = previewInput.recipe.targets.flatMap((target) =>
+    target.target.kind === "workspace"
+      ? [
+          {
+            target: target.target,
+            modules: target.modules.filter(
+              (module) => module !== "workspace-devenv-git",
+            ),
+          },
+        ].filter((target) => target.modules.length > 0)
+      : [{ target: target.target, modules: target.modules }],
+  );
+
+  params.set("name", values.config.name);
+  encodeRecipeTargetSpecs(targets)
+    .sort()
+    .forEach((target) => params.append("target", target));
+  if (values.config.runtime._tag === "node") {
+    params.set("runtime", "node");
+    params.set("package-manager", values.config.runtime.packageManager);
+  }
+  if (values.config.typescript !== defaults.typescript) {
+    params.set("typescript", values.config.typescript ?? "6");
+  }
+  (["monorepo", "lint", "format", "test"] as const).forEach((field) => {
+    const value = values.config[field];
+    if (value !== undefined && value !== defaults[field])
+      params.set(field, value);
+  });
+  if (!values.gitEnabled) params.set("no-git", "");
+  return params;
+};

--- a/apps/docs/app/components/recipe-builder/recipe-builder.tsx
+++ b/apps/docs/app/components/recipe-builder/recipe-builder.tsx
@@ -14,6 +14,7 @@ import {
   useRecipeBuilderCatalog,
   useRecipeBuilderFormContext,
   useRecipeBuilderPreview,
+  useRecipeBuilderUrl,
 } from "./recipe-builder-context";
 import { RepositoryExplorer } from "./repository-explorer";
 import { StackConfigurator } from "./stack-configurator";
@@ -31,6 +32,7 @@ function RecipeBuilderContent() {
   const form = useRecipeBuilderFormContext();
   const { compatibilityNotice } = useRecipeBuilderCatalog();
   const { canPreview, previewResult } = useRecipeBuilderPreview();
+  const { urlIssue } = useRecipeBuilderUrl();
   const preview = Option.getOrUndefined(AsyncResult.value(previewResult));
 
   const commandReady =
@@ -98,6 +100,14 @@ function RecipeBuilderContent() {
           <AlertCircle />
           <AlertTitle>Selection adjusted</AlertTitle>
           <AlertDescription>{compatibilityNotice}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {urlIssue ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>Shared recipe could not be restored</AlertTitle>
+          <AlertDescription>{urlIssue}</AlertDescription>
         </Alert>
       ) : null}
 

--- a/apps/docs/app/components/recipe-builder/recipe-builder.tsx
+++ b/apps/docs/app/components/recipe-builder/recipe-builder.tsx
@@ -3,6 +3,7 @@
 import { Option } from "effect";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { AlertCircle } from "lucide-react";
+import { useLocation } from "react-router";
 import { CommandDock } from "~/components/molecules/command-dock";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
@@ -33,6 +34,7 @@ function RecipeBuilderContent() {
   const { compatibilityNotice } = useRecipeBuilderCatalog();
   const { canPreview, previewResult } = useRecipeBuilderPreview();
   const { urlIssue } = useRecipeBuilderUrl();
+  const location = useLocation();
   const preview = Option.getOrUndefined(AsyncResult.value(previewResult));
 
   const commandReady =
@@ -144,6 +146,7 @@ function RecipeBuilderContent() {
         }
         command={command}
         disabled={!commandReady}
+        shareUrl={`${location.pathname}${location.search}`}
         onCopySuccess={trackCommandCopy}
       />
     </article>

--- a/apps/docs/app/components/recipe-builder/use-recipe-builder-url-state.ts
+++ b/apps/docs/app/components/recipe-builder/use-recipe-builder-url-state.ts
@@ -1,0 +1,74 @@
+import { useSelector } from "@tanstack/react-form";
+import { useEffect, useMemo, useRef } from "react";
+import { useSearchParams } from "react-router";
+import { useRecipeBuilderForm } from "./form";
+import {
+  decodeRecipeBuilderUrl,
+  encodeRecipeBuilderUrl,
+} from "./recipe-builder-url";
+
+export function useRecipeBuilderUrlState() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.toString();
+  const decoded = useMemo(() => decodeRecipeBuilderUrl(searchParams), [search]);
+  const initialValuesRef = useRef(decoded.initialValues);
+  const form = useRecipeBuilderForm(initialValuesRef.current);
+  const values = useSelector(form.store, (state) => state.values);
+  const formValid = useSelector(form.store, (state) => state.isValid);
+  const formDirty = useSelector(form.store, (state) => state.isDirty);
+  const hasRecipeParams = search.length > 0;
+  const lastSearchRef = useRef(search);
+  const externalNavigationPendingRef = useRef(false);
+  const decodedSearch = decoded.issue
+    ? undefined
+    : encodeRecipeBuilderUrl(decoded.initialValues).toString();
+  const formSearch = formValid
+    ? encodeRecipeBuilderUrl(values).toString()
+    : undefined;
+
+  useEffect(() => {
+    if (search === lastSearchRef.current) return;
+    lastSearchRef.current = search;
+    if (
+      decodedSearch !== undefined &&
+      (formSearch === undefined || decodedSearch !== formSearch)
+    ) {
+      externalNavigationPendingRef.current = true;
+      initialValuesRef.current = decoded.initialValues;
+      form.reset(decoded.initialValues);
+    }
+  }, [decoded.initialValues, decodedSearch, form, formSearch, search]);
+
+  useEffect(() => {
+    if (externalNavigationPendingRef.current) {
+      externalNavigationPendingRef.current = false;
+      return;
+    }
+    if (
+      decoded.issue !== undefined ||
+      formSearch === undefined ||
+      (!hasRecipeParams && !formDirty)
+    ) {
+      return;
+    }
+    if (searchParams.toString() !== formSearch) {
+      setSearchParams(new URLSearchParams(formSearch), {
+        preventScrollReset: true,
+        replace: true,
+      });
+    }
+  }, [
+    decoded.issue,
+    formSearch,
+    formDirty,
+    hasRecipeParams,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  return {
+    form,
+    urlIssue: decoded.issue,
+    workerEnabled: decoded.issue === undefined,
+  };
+}

--- a/apps/docs/app/components/recipe-builder/use-recipe-builder-worker.ts
+++ b/apps/docs/app/components/recipe-builder/use-recipe-builder-worker.ts
@@ -62,7 +62,10 @@ const reconcileTargetsWithCatalog = (
   };
 };
 
-export function useRecipeBuilderWorker(form: RecipeBuilderFormApi) {
+export function useRecipeBuilderWorker(
+  form: RecipeBuilderFormApi,
+  enabled = true,
+) {
   const values = useSelector(form.store, (state) => state.values);
   const formValid = useSelector(form.store, (state) => state.isValid);
   const [catalogRequestResult, requestCatalog] = useAtom(catalogAtom);
@@ -83,12 +86,13 @@ export function useRecipeBuilderWorker(form: RecipeBuilderFormApi) {
     [previewRequestResult],
   );
   const retryCatalog = useCallback(() => {
-    if (lastCatalogRequestRef.current !== undefined) {
+    if (enabled && lastCatalogRequestRef.current !== undefined) {
       requestCatalog(lastCatalogRequestRef.current);
     }
-  }, [requestCatalog]);
+  }, [enabled, requestCatalog]);
 
   useEffect(() => {
+    if (!enabled) return;
     const request = {
       targetIdentityKey,
       owners: targets.map(
@@ -100,7 +104,7 @@ export function useRecipeBuilderWorker(form: RecipeBuilderFormApi) {
     requestCatalog(request);
     // Module selection deliberately does not invalidate catalog metadata.
     // biome-ignore lint/correctness/useExhaustiveDependencies: targetIdentityKey captures the identity fields used by this effect.
-  }, [requestCatalog, targetIdentityKey]);
+  }, [enabled, requestCatalog, targetIdentityKey]);
 
   const reconcileCatalog = useEffectEvent(
     (result: typeof catalogRequestResult) => {
@@ -120,12 +124,15 @@ export function useRecipeBuilderWorker(form: RecipeBuilderFormApi) {
     },
   );
 
-  useEffect(
-    () => reconcileCatalog(catalogRequestResult),
-    [catalogRequestResult],
-  );
+  useEffect(() => {
+    if (enabled) reconcileCatalog(catalogRequestResult);
+  }, [catalogRequestResult, enabled]);
 
   useEffect(() => {
+    if (!enabled) {
+      requestPreview(Atom.Interrupt);
+      return;
+    }
     if (!formValid) {
       requestPreview(Atom.Interrupt);
       return;
@@ -134,10 +141,10 @@ export function useRecipeBuilderWorker(form: RecipeBuilderFormApi) {
       targetIdentityKey,
       input: toRecipePreviewInput(values),
     });
-  }, [formValid, requestPreview, targetIdentityKey, values]);
+  }, [enabled, formValid, requestPreview, targetIdentityKey, values]);
 
   return {
-    canPreview: formValid,
+    canPreview: enabled && formValid,
     catalog,
     catalogResult,
     compatibilityNotice,

--- a/apps/docs/app/content/reference/cli/index.mdx
+++ b/apps/docs/app/content/reference/cli/index.mdx
@@ -2,7 +2,7 @@
 
 # CLI reference
 
-Commands, arguments, options, and examples for `stack-effect v0.12.0`. These pages are generated from the current Effect CLI command tree.
+Commands, arguments, options, and examples for `stack-effect v0.12.1`. These pages are generated from the current Effect CLI command tree.
 
 ## Commands
 

--- a/apps/docs/app/entry.server.tsx
+++ b/apps/docs/app/entry.server.tsx
@@ -1,0 +1,45 @@
+import { isbot } from "isbot";
+import { renderToReadableStream } from "react-dom/server";
+import type { EntryContext, RouterContextProvider } from "react-router";
+import { ServerRouter } from "react-router";
+
+const streamTimeout = 5_000;
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: RouterContextProvider,
+) {
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    });
+  }
+
+  let shellRendered = false;
+  const userAgent = request.headers.get("user-agent");
+  const body = await renderToReadableStream(
+    <ServerRouter context={routerContext} url={request.url} />,
+    {
+      signal: AbortSignal.timeout(streamTimeout + 1_000),
+      onError(error: unknown) {
+        responseStatusCode = 500;
+        if (shellRendered) console.error(error);
+      },
+    },
+  );
+  shellRendered = true;
+
+  if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
+    await body.allReady;
+  }
+
+  responseHeaders.set("Content-Type", "text/html");
+  return new Response(body, {
+    headers: responseHeaders,
+    status: responseStatusCode,
+  });
+}

--- a/apps/docs/react-router.config.ts
+++ b/apps/docs/react-router.config.ts
@@ -2,5 +2,5 @@ import type { Config } from "@react-router/dev/config";
 
 export default {
   ssr: false,
-  prerender: true,
+  prerender: false,
 } satisfies Config;

--- a/apps/docs/test/components/recipe-builder/recipe-builder-url.unit.test.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-builder-url.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeRecipeBuilderUrl,
+  encodeRecipeBuilderUrl,
+} from "../../../app/components/recipe-builder/recipe-builder-url";
+import { fullStackRecipeFixture } from "./recipe-fixtures";
+
+describe("recipe builder URL", () => {
+  it("round trips a create-compatible recipe without form bookkeeping", () => {
+    const encoded = encodeRecipeBuilderUrl(fullStackRecipeFixture);
+    const decoded = decodeRecipeBuilderUrl(encoded);
+
+    expect(decoded.issue).toBeUndefined();
+    expect(decoded.initialValues.config).toEqual(fullStackRecipeFixture.config);
+    expect(decoded.initialValues.gitEnabled).toBe(
+      fullStackRecipeFixture.gitEnabled,
+    );
+    expect(encodeRecipeBuilderUrl(decoded.initialValues).toString()).toBe(
+      encoded.toString(),
+    );
+    expect(decoded.initialValues.supportSelections).toEqual([]);
+  });
+
+  it("rejects malformed, unknown, and conflicting shared links without a partial restore", () => {
+    [
+      "?target=server/api:",
+      "?runtime=bun&package-manager=pnpm",
+      "?runtime=node&runtime=bun&package-manager=pnpm",
+      "?target=server/api:server-http-api,server-http-api",
+      "?name=demo&utm_source=newsletter",
+    ].forEach((search) => {
+      const decoded = decodeRecipeBuilderUrl(new URLSearchParams(search));
+
+      expect(decoded.issue).toBeDefined();
+      expect(decoded.initialValues.targets).toEqual([]);
+    });
+  });
+
+  it("uses create flag names and omits default configuration flags", () => {
+    const params = encodeRecipeBuilderUrl({
+      ...fullStackRecipeFixture,
+      config: {
+        ...fullStackRecipeFixture.config,
+        runtime: { _tag: "bun" },
+        typescript: "6",
+        monorepo: "turbo",
+        lint: "biome",
+        format: "biome",
+        test: "vitest",
+      },
+      gitEnabled: false,
+    });
+
+    expect(params.get("name")).toBe(fullStackRecipeFixture.config.name);
+    expect(params.getAll("target")).not.toHaveLength(0);
+    expect(params.has("runtime")).toBe(false);
+    expect(params.has("package-manager")).toBe(false);
+    expect(params.has("no-git")).toBe(true);
+  });
+
+  it("hydrates a valid project-name-only URL", () => {
+    const decoded = decodeRecipeBuilderUrl(
+      new URLSearchParams("?name=shared-recipe"),
+    );
+
+    expect(decoded.issue).toBeUndefined();
+    expect(decoded.initialValues.config.name).toBe("shared-recipe");
+  });
+});

--- a/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
+++ b/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
@@ -1,3 +1,4 @@
+import { MemoryRouter, useLocation, useNavigate } from "react-router";
 import { beforeEach, expect, test, vi } from "vitest";
 import { page } from "vitest/browser";
 import { render } from "vitest-browser-react";
@@ -124,8 +125,72 @@ beforeEach(() => {
   workerCalls.pendingPreviews = [];
 });
 
+const renderRecipeBuilder = (initialEntry = "/builder") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <RecipeBuilder />
+      <RecipeBuilderLocationProbe />
+    </MemoryRouter>,
+  );
+
+function RecipeBuilderLocationProbe() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => navigate("/builder?name=shared-recipe")}
+      >
+        Load shared recipe
+      </button>
+      <button type="button" onClick={() => navigate("/builder")}>
+        Clear shared recipe
+      </button>
+      <output aria-label="Recipe URL search">{location.search}</output>
+    </>
+  );
+}
+
+test("should leave an invalid shared recipe URL visible without previewing a fallback", async () => {
+  await renderRecipeBuilder("/builder?target=server/api:");
+
+  await expect
+    .element(page.getByText("Shared recipe could not be restored"))
+    .toBeVisible();
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .toHaveTextContent("?target=server/api:");
+  await expect
+    .element(page.getByRole("button", { name: "Copy command" }))
+    .toBeDisabled();
+});
+
+test("should replace valid URL edits and reset the existing form for external navigation", async () => {
+  await renderRecipeBuilder();
+
+  await page.getByLabelText("Project name").fill("local-recipe");
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .toHaveTextContent("?name=local-recipe");
+  await expect
+    .element(page.getByLabelText("Project name"))
+    .toHaveValue("local-recipe");
+
+  await page.getByRole("button", { name: "Load shared recipe" }).click();
+  await expect
+    .element(page.getByLabelText("Project name"))
+    .toHaveValue("shared-recipe");
+
+  await page.getByRole("button", { name: "Clear shared recipe" }).click();
+  await expect
+    .element(page.getByLabelText("Project name"))
+    .toHaveValue("my-effect-app");
+});
+
 test("should generate a usable preview when the user completes a valid Selection", async () => {
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await page.getByRole("button", { name: "Client React Application" }).click();
   await page.getByText("HTTP API Client", { exact: true }).click();
@@ -145,7 +210,7 @@ test("should generate a usable preview when the user completes a valid Selection
 });
 
 test("should remove unsupported modules when a renamed target resolves a different catalog", async () => {
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await page.getByRole("button", { name: "Client React Application" }).click();
   await page.getByText("HTTP API Client", { exact: true }).click();
@@ -161,10 +226,13 @@ test("should remove unsupported modules when a renamed target resolves a differe
   await expect
     .element(page.getByText("HTTP API Client", { exact: true }))
     .not.toBeInTheDocument();
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .not.toHaveTextContent("client-react-http-api");
 });
 
 test("should reconcile a rename after its delayed catalog request completes", async () => {
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await page.getByRole("button", { name: "Client React Application" }).click();
   await page.getByText("HTTP API Client", { exact: true }).click();
@@ -190,7 +258,7 @@ test("should reconcile a rename after its delayed catalog request completes", as
 });
 
 test("should generate a usable preview when the selected target has no modules", async () => {
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await page.getByRole("button", { name: "MCP Server Application" }).click();
 
@@ -207,7 +275,7 @@ test("should generate a usable preview when the selected target has no modules",
 
 test("should preserve a valid preview when catalog loading is retried", async () => {
   workerCalls.failCatalogOnce = true;
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await expect
     .element(page.getByText(/Live in-memory pipeline/u))
@@ -234,7 +302,7 @@ test("should preserve a valid preview when catalog loading is retried", async ()
 });
 
 test("should retain the last valid preview when the current Selection becomes invalid", async () => {
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await expect
     .element(page.getByText(/Live in-memory pipeline/u))
@@ -263,7 +331,7 @@ test("should retain the last valid preview when the current Selection becomes in
 });
 
 test("should show the newest preview when an older request completes after it is superseded", async () => {
-  await render(<RecipeBuilder />);
+  await renderRecipeBuilder();
 
   await expect
     .element(page.getByText(/Live in-memory pipeline/u))

--- a/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
+++ b/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
@@ -165,6 +165,9 @@ test("should leave an invalid shared recipe URL visible without previewing a fal
   await expect
     .element(page.getByRole("button", { name: "Copy command" }))
     .toBeDisabled();
+  await expect
+    .element(page.getByRole("button", { name: "Share recipe" }))
+    .toBeDisabled();
 });
 
 test("should replace valid URL edits and reset the existing form for external navigation", async () => {


### PR DESCRIPTION
## Goal/Scope

Enable saving a recipe to a shareable URL generated by the builder and add a “share” button to the builder UI for easier sharing.