### PR TITLE
feat: add web worker module

### DIFF
--- a/.changeset/bright-workers-stream.md
+++ b/.changeset/bright-workers-stream.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+React projects can now scaffold a streaming browser Worker with Effect RPC, Atom RPC, schema validation, and scheduled progress updates.

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -58,5 +58,6 @@ jobs:
         run: |
           nix develop --command bash -lc '
             cd apps/cli
-            bunx vitest run --config vitest.e2e.config.ts e2e/init.test.ts e2e/add.test.ts
+            bunx vitest run --config vitest.e2e.config.ts e2e/init.test.ts
+            bunx vitest run --config vitest.e2e.config.ts e2e/add.test.ts
           '

--- a/apps/cli/e2e/matrix.test.ts
+++ b/apps/cli/e2e/matrix.test.ts
@@ -15,6 +15,15 @@ interface MatrixEntry {
   readonly label: string;
 }
 
+interface GeneratedModuleExpectation {
+  readonly files: ReadonlyArray<string>;
+  readonly standaloneMissingFiles?: ReadonlyArray<string>;
+  readonly contents?: ReadonlyArray<{
+    readonly path: string;
+    readonly pattern: string | RegExp;
+  }>;
+}
+
 /**
  * Entry for testing modules with their optional children.
  * Tracks parent module and all optional children to add separately.
@@ -122,11 +131,54 @@ const matrix = Effect.runSync(
   buildMatrix.pipe(Effect.provide(CatalogService.layer)),
 );
 
-const singleTargetEntries = matrix.filter(
-  (e) =>
-    !e.target.startsWith("client-react") &&
-    !e.target.startsWith("client-foldkit"),
+const individualModuleEntries = matrix.filter(
+  (entry) => entry.modules.length === 1,
 );
+const maximalTargetEntries = matrix.filter((entry) => entry.modules.length > 1);
+
+const generatedModuleExpectations: Readonly<
+  Record<string, GeneratedModuleExpectation>
+> = {
+  "client-react-web-worker": {
+    files: [
+      "apps/client-react-web/src/workers/import-validation/domain.ts",
+      "apps/client-react-web/src/workers/import-validation/import-validation.worker.ts",
+      "apps/client-react-web/src/lib/import-validation-worker.ts",
+      "apps/client-react-web/src/components/import-validation-card.tsx",
+    ],
+    standaloneMissingFiles: [
+      "apps/server-api/package.json",
+      "packages/domain/package.json",
+    ],
+    contents: [
+      {
+        path: "apps/client-react-web/src/workers/import-validation/domain.ts",
+        pattern: 'Rpc.make("validate"',
+      },
+      {
+        path: "apps/client-react-web/src/workers/import-validation/import-validation.worker.ts",
+        pattern: 'Schedule.spaced("250 millis")',
+      },
+      {
+        path: "apps/client-react-web/src/workers/import-validation/import-validation.worker.ts",
+        pattern:
+          /const records = content[\s\S]*lineNumber: index \+ 1[\s\S]*\.filter\(/,
+      },
+      {
+        path: "apps/client-react-web/src/lib/import-validation-worker.ts",
+        pattern: "RpcClient.layerProtocolWorker",
+      },
+      {
+        path: "apps/client-react-web/src/app.tsx",
+        pattern: "<ImportValidationCard />",
+      },
+      {
+        path: "apps/client-react-web/package.json",
+        pattern: '"@effect/platform-browser": "4.0.0-rc.108"',
+      },
+    ],
+  },
+};
 
 function getModuleTarget(mod: {
   supportedOn: ReadonlyArray<
@@ -271,6 +323,33 @@ const fullStackMatrix = Effect.runSync(
   buildFullStackMatrix.pipe(Effect.provide(CatalogService.layer)),
 );
 
+const buildMaximalClientMatrix = Effect.gen(function* () {
+  const catalog = yield* CatalogService;
+
+  return yield* Effect.forEach(
+    [TargetKind.make("client-react"), TargetKind.make("client-foldkit")],
+    (kind) =>
+      Effect.gen(function* () {
+        const modules = yield* catalog.getSupportedModules(kind);
+        const serverModules = modules.flatMap((module) =>
+          (module.implies ?? [])
+            .filter((implication) => implication.targetKind === "server")
+            .map((implication) => implication.moduleId),
+        );
+
+        return {
+          clientTarget: `${kind}/${defaultTargetNames.get(kind)}`,
+          clientModules: modules.map((module) => module.id),
+          serverModules: [...new Set(serverModules)],
+        };
+      }),
+  );
+});
+
+const maximalClientMatrix = Effect.runSync(
+  buildMaximalClientMatrix.pipe(Effect.provide(CatalogService.layer)),
+);
+
 const expectInstallPasses = (project: {
   install: () => Effect.Effect<{
     readonly exitCode: number;
@@ -292,17 +371,56 @@ const expectInstallPasses = (project: {
       ),
     );
 
+const assertGeneratedModuleExpectations = (
+  project: {
+    expectFileExists: (path: string) => Effect.Effect<void>;
+    expectFileNotExists: (path: string) => Effect.Effect<void>;
+    expectFileContaining: (
+      path: string,
+      pattern: string | RegExp,
+    ) => Effect.Effect<void>;
+  },
+  modules: ReadonlyArray<string>,
+  standalone: boolean,
+) =>
+  Effect.forEach(
+    modules,
+    (moduleId) => {
+      const expectation = generatedModuleExpectations[moduleId];
+      if (!expectation) return Effect.void;
+
+      return Effect.all([
+        Effect.forEach(
+          expectation.files,
+          (path) => project.expectFileExists(path),
+          {
+            discard: true,
+          },
+        ),
+        Effect.forEach(
+          standalone ? (expectation.standaloneMissingFiles ?? []) : [],
+          (path) => project.expectFileNotExists(path),
+          { discard: true },
+        ),
+        Effect.forEach(
+          expectation.contents ?? [],
+          ({ path, pattern }) => project.expectFileContaining(path, pattern),
+          { discard: true },
+        ),
+      ]).pipe(Effect.asVoid);
+    },
+    { discard: true },
+  );
+
 /**
  * Acceptance tests for various module combinations in the matrix.
  *
- * The matrix is generated dynamically from the CatalogService, ensuring that
- * all supported module combinations are tested. Each test scaffolds a project,
- * adds the specified modules, and verifies that the resulting project is valid
- * (e.g., type checks successfully).
+ * The matrix is generated dynamically from the CatalogService. It proves each
+ * module alone, each target's maximal bundle, and each declared relationship.
  */
 describe("matrix", () => {
-  layer(CLI.layer)("single-target modules", (it) => {
-    for (const entry of singleTargetEntries) {
+  layer(CLI.layer)("every public module", (it) => {
+    for (const entry of individualModuleEntries) {
       it.effect(
         entry.label,
         () =>
@@ -325,11 +443,57 @@ describe("matrix", () => {
             yield* cli.expectExitCode(0);
 
             yield* cli.withinProject(name, function* (project) {
+              yield* assertGeneratedModuleExpectations(
+                project,
+                entry.modules,
+                true,
+              );
               yield* expectInstallPasses(project);
               yield* project.expectTypeCheckPasses();
             });
           }).pipe(Effect.provide(CLI.layer)),
         { timeout: 120_000 },
+      );
+    }
+  });
+
+  layer(CLI.layer)("maximal target bundles", (it) => {
+    for (const entry of maximalTargetEntries) {
+      it.effect(
+        entry.label,
+        () =>
+          Effect.gen(function* () {
+            const cli = yield* CLI;
+            const name = `matrix-maximal-${entry.target.replace("/", "-")}`;
+            const root = `${cli.workdir}/${name}`;
+
+            yield* cli.run("init", name, "--yes", "--root", cli.workdir);
+            yield* cli.expectExitCode(0);
+
+            yield* cli.run(
+              "add",
+              "--yes",
+              "--root",
+              root,
+              "--target",
+              `${entry.target}:${entry.modules.join(",")}`,
+            );
+            yield* cli.expectExitCode(0);
+
+            yield* cli.withinProject(name, function* (project) {
+              yield* assertGeneratedModuleExpectations(
+                project,
+                entry.modules,
+                false,
+              );
+              yield* expectInstallPasses(project);
+              yield* project.expectFormatPasses();
+              yield* project.expectLintPasses();
+              yield* project.expectTypeCheckPasses();
+              yield* project.expectBuildSucceeds();
+            });
+          }).pipe(Effect.provide(CLI.layer)),
+        { timeout: 180_000 },
       );
     }
   });
@@ -377,28 +541,12 @@ describe("matrix", () => {
     }
   });
 
-  layer(CLI.layer)("full-stack all client modules together", (it) => {
-    const byClientKind = new Map<
-      string,
-      { serverModules: Set<string>; clientModules: Set<string> }
-    >();
-    for (const entry of fullStackMatrix) {
-      const kind = entry.clientTarget;
-      if (!byClientKind.has(kind)) {
-        byClientKind.set(kind, {
-          serverModules: new Set(),
-          clientModules: new Set(),
-        });
-      }
-      const group = byClientKind.get(kind)!;
-      for (const m of entry.serverModules) group.serverModules.add(m);
-      for (const m of entry.clientModules) group.clientModules.add(m);
-    }
-
-    for (const [clientTarget, group] of byClientKind) {
+  layer(CLI.layer)("maximal client bundles", (it) => {
+    for (const entry of maximalClientMatrix) {
+      const { clientTarget, clientModules, serverModules } = entry;
       const kindSlug = clientTarget.replace("/", "-");
       it.effect(
-        `all ${clientTarget} modules with server dependencies`,
+        `all ${clientTarget} modules with required server dependencies`,
         () =>
           Effect.gen(function* () {
             const cli = yield* CLI;
@@ -408,15 +556,17 @@ describe("matrix", () => {
             yield* cli.run("init", name, "--yes", "--root", cli.workdir);
             yield* cli.expectExitCode(0);
 
-            yield* cli.run(
-              "add",
-              "--yes",
-              "--root",
-              root,
-              "--target",
-              `server/${defaultTargetNames.get("server")}:${[...group.serverModules].join(",")}`,
-            );
-            yield* cli.expectExitCode(0);
+            if (serverModules.length > 0) {
+              yield* cli.run(
+                "add",
+                "--yes",
+                "--root",
+                root,
+                "--target",
+                `server/${defaultTargetNames.get("server")}:${serverModules.join(",")}`,
+              );
+              yield* cli.expectExitCode(0);
+            }
 
             yield* cli.run(
               "add",
@@ -424,13 +574,21 @@ describe("matrix", () => {
               "--root",
               root,
               "--target",
-              `${clientTarget}:${[...group.clientModules].join(",")}`,
+              `${clientTarget}:${clientModules.join(",")}`,
             );
             yield* cli.expectExitCode(0);
 
             yield* cli.withinProject(name, function* (project) {
+              yield* assertGeneratedModuleExpectations(
+                project,
+                clientModules,
+                false,
+              );
               yield* expectInstallPasses(project);
+              yield* project.expectFormatPasses();
+              yield* project.expectLintPasses();
               yield* project.expectTypeCheckPasses();
+              yield* project.expectBuildSucceeds();
             });
           }).pipe(Effect.provide(CLI.layer)),
         { timeout: 180_000 },

--- a/packages/catalog/src/registry/content/client-worker.ts
+++ b/packages/catalog/src/registry/content/client-worker.ts
@@ -1,0 +1,297 @@
+export const clientImportValidationDomainContents = `import { Effect, Option, Schema } from "effect";
+import { Rpc, RpcGroup } from "effect/unstable/rpc";
+
+export const ImportRecord = Schema.Struct({
+  email: Schema.String.check(
+    Schema.isPattern(/^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/),
+  ),
+  name: Schema.String.check(Schema.isMinLength(1)),
+});
+
+export const ImportIssue = Schema.Struct({
+  line: Schema.Number,
+  message: Schema.String,
+});
+
+export const ImportValidationEvent = Schema.TaggedUnion({
+  started: { total: Schema.Number },
+  row: {
+    accepted: Schema.Boolean,
+    line: Schema.Number,
+    issue: Schema.optional(ImportIssue),
+  },
+  completed: {
+    total: Schema.Number,
+  },
+});
+
+export class ImportValidationFailure extends Schema.TaggedError<ImportValidationFailure>()(
+  "ImportValidationFailure",
+  { message: Schema.String },
+) {}
+
+export class ImportValidationRpc extends RpcGroup.make(
+  Rpc.make("validate", {
+    payload: { content: Schema.String },
+    success: ImportValidationEvent,
+    error: ImportValidationFailure,
+    stream: true,
+  }),
+) {}
+
+export const parseImportRecord = (line: string, lineNumber: number) =>
+  Effect.gen(function* () {
+    const parsed = yield* Effect.try({
+      try: () => JSON.parse(line),
+      catch: () => undefined,
+    }).pipe(Effect.option);
+    return Option.match(parsed, {
+      onNone: () => ({
+        accepted: false,
+        line: lineNumber,
+        issue: {
+          line: lineNumber,
+          message: "Expected a JSON object with a name and email address.",
+        },
+      }),
+      onSome: (value) =>
+        Schema.decodeUnknownOption(ImportRecord)(value).pipe(
+          Option.match({
+            onNone: () => ({
+              accepted: false,
+              line: lineNumber,
+              issue: {
+                line: lineNumber,
+                message:
+                  "Expected a JSON object with a name and email address.",
+              },
+            }),
+            onSome: () => ({ accepted: true, line: lineNumber }),
+          }),
+        ),
+    });
+  });
+`;
+
+export const clientImportValidationWorkerContents = `/// <reference lib="webworker" />
+
+import * as BrowserWorkerRunner from "@effect/platform-browser/BrowserWorkerRunner";
+import { Effect, Layer, Schedule, Stream } from "effect";
+import { RpcServer } from "effect/unstable/rpc";
+import { ImportValidationRpc, parseImportRecord } from "./domain";
+
+const ImportValidationHandlersLive = ImportValidationRpc.toLayer(
+  Effect.gen(function* () {
+    return ImportValidationRpc.of({
+      validate: ({ content }) => {
+        const records = content
+          .split("\\n")
+          .map((line, index) => ({ line, lineNumber: index + 1 }))
+          .filter(({ line }) => line.trim() !== "");
+        const rows = Stream.fromIterable(records).pipe(
+          Stream.mapEffect(({ line, lineNumber }) =>
+            parseImportRecord(line, lineNumber),
+          ),
+          Stream.map((row) => ({ _tag: "row" as const, ...row })),
+          // The demo intentionally paces rows so the Worker/RPC stream is visible.
+          // Production code can tune or remove this schedule for its workload.
+          Stream.schedule(Schedule.spaced("250 millis")),
+        );
+
+        // Seam: this Stream is the capability boundary. The UI only receives
+        // serializable events, while validation work and pacing stay in the worker.
+        return Stream.concat(
+          Stream.succeed({ _tag: "started" as const, total: records.length }),
+          Stream.concat(
+            rows,
+            Stream.succeed({ _tag: "completed" as const, total: records.length }),
+          ),
+        );
+      },
+    });
+  }),
+);
+
+const WorkerLive = RpcServer.layer(ImportValidationRpc).pipe(
+  Layer.provide(ImportValidationHandlersLive),
+  Layer.provide(RpcServer.layerProtocolWorkerRunner),
+  Layer.provide(BrowserWorkerRunner.layer),
+);
+
+Effect.runFork(Layer.launch(WorkerLive));
+`;
+
+export const clientImportValidationAtomContents = `import * as BrowserWorker from "@effect/platform-browser/BrowserWorker";
+import { Effect, Layer, Stream } from "effect";
+import { type Atom, AtomRpc } from "effect/unstable/reactivity";
+import { RpcClient } from "effect/unstable/rpc";
+import {
+  ImportValidationRpc,
+  type ImportValidationEvent,
+} from "../workers/import-validation/domain";
+
+class ImportValidationClient extends AtomRpc.Service<ImportValidationClient>()(
+  "ImportValidationClient",
+  {
+    group: ImportValidationRpc,
+    protocol: RpcClient.layerProtocolWorker({ size: 1, concurrency: 1 }).pipe(
+      Layer.provide(
+        BrowserWorker.layer(
+          () =>
+            new Worker(
+              new URL(
+                "../workers/import-validation/import-validation.worker.ts",
+                import.meta.url,
+              ),
+              { type: "module" },
+            ),
+        ),
+      ),
+    ),
+  },
+) {}
+
+// Seam: the React app asks for a stream through an Atom. It never owns the
+// Worker, protocol, validation loop, or scheduled batch cadence directly.
+export const importValidationAtom: Atom.AtomResultFn<
+  string,
+  typeof ImportValidationEvent.Type,
+  unknown
+> = ImportValidationClient.runtime.fn((content: string) =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const client = yield* ImportValidationClient;
+      return client("validate", { content });
+    }),
+  ),
+);
+`;
+
+export const clientImportValidationCardContents = `import { useAtom } from "@effect/atom-react";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { useEffect, useMemo, useState } from "react";
+import { importValidationAtom } from "@/lib/import-validation-worker";
+import type { ImportValidationEvent } from "@/workers/import-validation/domain";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const sample = \`{"name":"Ada Lovelace","email":"ada@example.com"}
+{"name":"Grace Hopper","email":"grace@example.com"}
+{"name":"Edsger Dijkstra","email":"edsger@example.com"}
+{"name":"Missing email"}
+{"name":"Barbara Liskov","email":"barbara@example.com"}
+{"name":"Invalid address","email":"not-an-email"}
+{"name":"Margaret Hamilton","email":"margaret@example.com"}
+{"name":"Donald Knuth","email":"donald@example.com"}
+{"name":"Alan Kay","email":"alan@example.com"}
+{"name":"Bad JSON"
+{"name":"Radia Perlman","email":"radia@example.com"}
+{"name":"Ken Thompson","email":"ken@example.com"}
+{"name":"No Email"}
+{"name":"Frances Allen","email":"frances@example.com"}\`;
+
+export function ImportValidationCard() {
+  const [content, setContent] = useState(sample);
+  const [result, validate] = useAtom(importValidationAtom);
+  const event = AsyncResult.getOrElse(result, () => undefined);
+  const [events, setEvents] = useState<
+    readonly (typeof ImportValidationEvent.Type)[]
+  >([]);
+
+  useEffect(() => {
+    if (event === undefined) return;
+    setEvents((current) =>
+      event._tag === "started" ? [event] : [...current, event],
+    );
+  }, [event]);
+  const summary = useMemo(
+    () => events.findLast((event) => event._tag === "completed"),
+    [events],
+  );
+  const rows = useMemo(
+    () => events.flatMap((event) => (event._tag === "row" ? [event] : [])),
+    [events],
+  );
+  const total = useMemo(
+    () => events.find((event) => event._tag === "started")?.total,
+    [events],
+  );
+  const accepted = useMemo(
+    () => rows.filter((row) => row.accepted).length,
+    [rows],
+  );
+  const recentRows = useMemo(() => rows.slice(-5).reverse(), [rows]);
+  const issues = useMemo(
+    () => rows.flatMap((row) => (row.issue === undefined ? [] : [row.issue])),
+    [rows],
+  );
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader>
+        <CardTitle>Streaming import validation</CardTitle>
+        <p className="text-muted-foreground text-sm">
+          JSONL rows are validated in a Worker and streamed back as progress.
+        </p>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3">
+        <textarea
+          aria-label="JSONL import rows"
+          className="min-h-28 w-full resize-none rounded-md border bg-background p-3 font-mono text-sm"
+          onChange={(event) => setContent(event.target.value)}
+          value={content}
+        />
+        <div className="flex gap-2">
+          <Button
+            onClick={() => {
+              setEvents([]);
+              validate(content);
+            }}
+          >
+            Validate import
+          </Button>
+          <Button onClick={() => validate(Atom.Interrupt)} variant="outline">
+            Cancel
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border bg-muted/40 p-3 text-sm">
+          {summary ? (
+            <p>Completed: {summary.total} rows processed.</p>
+          ) : total === undefined ? (
+            <p className="text-muted-foreground">
+              Run validation to receive rolling Worker RPC events.
+            </p>
+          ) : (
+            <p>
+              Processing {rows.length} of {total} rows…
+            </p>
+          )}
+          {total !== undefined && (
+            <p className="mt-2 text-muted-foreground">
+              {accepted} accepted, {issues.length} rejected
+            </p>
+          )}
+          {recentRows.length > 0 && (
+            <ol className="mt-2 space-y-1 font-mono text-xs">
+              {recentRows.map((row) => (
+                <li key={row.line}>
+                  Line {row.line}: {row.accepted ? "accepted" : "rejected"}
+                </li>
+              ))}
+            </ol>
+          )}
+          {issues.length > 0 && (
+            <ul className="mt-2 list-inside list-disc text-destructive">
+              {issues.map((issue) => (
+                <li key={issue.line}>
+                  Line {issue.line}: {issue.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+`;

--- a/packages/catalog/src/registry/modules/client.ts
+++ b/packages/catalog/src/registry/modules/client.ts
@@ -23,6 +23,12 @@ import {
   clientPresencePanelContents,
   clientWebSocketClientContents,
 } from "../content/client-websocket";
+import {
+  clientImportValidationAtomContents,
+  clientImportValidationCardContents,
+  clientImportValidationDomainContents,
+  clientImportValidationWorkerContents,
+} from "../content/client-worker";
 
 const clientReactKind = TargetKind.make("client-react");
 const serverKind = TargetKind.make("server");
@@ -32,6 +38,53 @@ const domainTarget = new TargetIdentity({
 });
 
 export const clientModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
+  {
+    id: ModuleId.make("client-react-web-worker"),
+    title: "Streaming Import Worker",
+    description:
+      "Browser Worker RPC with Effect Schema, Stream, Schedule, and Atom RPC",
+    supportedOn: [{ _tag: "kind", kind: clientReactKind }],
+    dependencies: [],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/workers/import-validation/domain.ts",
+        contents: clientImportValidationDomainContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/workers/import-validation/import-validation.worker.ts",
+        contents: clientImportValidationWorkerContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/lib/import-validation-worker.ts",
+        contents: clientImportValidationAtomContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/src/components/import-validation-card.tsx",
+        contents: clientImportValidationCardContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "dependencies",
+        name: "@effect/platform-browser",
+        value: "4.0.0-rc.108",
+      },
+      {
+        _tag: "jsx-slot",
+        path: "{{targetPath}}/src/app.tsx",
+        slotId: "components",
+        content: "<ImportValidationCard />",
+        import: {
+          moduleSpecifier: "./components/import-validation-card",
+          namedImports: ["ImportValidationCard"],
+        },
+      },
+    ],
+  },
   {
     id: ModuleId.make("client-react-http-api"),
     title: "HTTP API Client",


### PR DESCRIPTION
## Goals/Scope

Add a new **streaming React Worker module** to the catalog.

## Description

- Introduced streaming support via a dedicated React Worker module in the catalog.
- Expanded E2E tests to validate all catalog modules and maximal bundle configurations.
- Updated test setup to isolate tool state, enabling safe parallel execution.

---

- [x] closes #197