### PR TITLE
feat: add Nx monorepo support

### DIFF
--- a/.changeset/shaky-colts-shine.md
+++ b/.changeset/shaky-colts-shine.md
@@ -1,0 +1,11 @@
+---
+"stack-effect": minor
+---
+
+Generated workspaces can now use Nx for package-based task orchestration and caching with Bun, npm, or pnpm.
+
+For example:
+
+```bash
+bunx stack-effect@latest create my-app --monorepo nx
+```

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -106,12 +106,12 @@ interface ProjectContext {
     ...args: ReadonlyArray<string>
   ) => Effect.Effect<CommandResult>;
   readonly expectBuildSucceeds: (
-    packageManager?: "bun" | "pnpm",
+    packageManager?: "bun" | "npm" | "pnpm",
   ) => Effect.Effect<void>;
   readonly expectLintPasses: () => Effect.Effect<void>;
   readonly expectFormatPasses: () => Effect.Effect<void>;
   readonly expectTypeCheckPasses: (
-    packageManager?: "bun" | "pnpm",
+    packageManager?: "bun" | "npm" | "pnpm",
   ) => Effect.Effect<void>;
   readonly expectTestsPasses: () => Effect.Effect<void>;
   readonly expectCommandSucceeds: (

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -1,4 +1,4 @@
-import { describe, layer } from "@effect/vitest";
+import { assert, describe, layer } from "@effect/vitest";
 import { Effect } from "effect";
 import { CLI } from "./harness";
 
@@ -273,6 +273,239 @@ describe("init", () => {
           );
         }),
       { timeout: 120_000 },
+    );
+
+    it.effect(
+      "should run a generated Bun workspace through Nx without caching ignored environment changes",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "create",
+            "nx-bun-app",
+            "--target",
+            "client-react/web:client-react-http-api",
+            "--target",
+            "server/api:server-http-api",
+            "--yes",
+            "--no-git",
+            "--monorepo",
+            "nx",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.expectFileExists("nx-bun-app/nx.json");
+          yield* cli.expectFileExists("nx-bun-app/scripts/hash-env.mjs");
+          yield* cli.expectFileNotExists("nx-bun-app/turbo.json");
+          yield* cli.expectFileNotExists("nx-bun-app/vite.config.ts");
+          yield* cli.expectJsonFile(
+            "nx-bun-app/package.json",
+            "devDependencies.nx",
+            "^23.1.1",
+          );
+          yield* cli.expectJsonFile(
+            "nx-bun-app/package.json",
+            "scripts.build",
+            "nx run-many -t build",
+          );
+          yield* cli.expectJsonFile(
+            "nx-bun-app/package.json",
+            "scripts.dev",
+            "nx run-many -t dev",
+          );
+          yield* cli.expectJsonFile(
+            "nx-bun-app/package.json",
+            "scripts.type-check",
+            "nx run-many -t type-check",
+          );
+          yield* cli.expectJsonFile(
+            "nx-bun-app/package.json",
+            "scripts.test",
+            "nx run-many -t test",
+          );
+          yield* cli.expectJsonFile(
+            "nx-bun-app/package.json",
+            "scripts.clean",
+            "nx reset && nx run-many -t clean && git clean -xdf node_modules .cache .nx/cache .nx/workspace-data dist tsconfig.tsbuildinfo",
+          );
+          yield* cli.expectJsonFile(
+            "nx-bun-app/nx.json",
+            "pluginsConfig.@nx/js.analyzeLockfile",
+            false,
+          );
+          yield* cli.expectFileContaining(
+            "nx-bun-app/.gitignore",
+            ".nx/workspace-data",
+          );
+          yield* cli.expectFileContaining(
+            "nx-bun-app/package.json",
+            /^(?![\s\S]*"turbo"\s*:)(?![\s\S]*"nx"\s*:\s*\{)[\s\S]*$/,
+          );
+          yield* cli.expectFileContaining(
+            "nx-bun-app/nx.json",
+            '"{workspaceRoot}/bun.lock"',
+          );
+
+          yield* cli.withinProject("nx-bun-app", function* (project) {
+            const discovered = yield* project.exec(
+              "bunx",
+              "nx",
+              "show",
+              "projects",
+            );
+            assert.strictEqual(discovered.exitCode, 0);
+            assert.match(discovered.stdout, /client-react-web/);
+            assert.match(discovered.stdout, /server-api/);
+            assert.isFalse(/nx-bun-app/.test(discovered.stdout));
+
+            yield* project.expectTypeCheckPasses();
+            yield* project.expectBuildSucceeds();
+            yield* project.expectTestsPasses();
+
+            const cached = yield* project.exec("bun", "run", "build");
+            assert.strictEqual(cached.exitCode, 0);
+            assert.match(cached.stdout, /read the output from the cache/i);
+
+            yield* project.writeFile(
+              "apps/client-react-web/.env.local",
+              "NX_GAUNTLET_SECRET=must-not-appear-in-nx-output\n",
+            );
+            const digest = yield* project.exec("node", "scripts/hash-env.mjs");
+            assert.strictEqual(digest.exitCode, 0);
+            assert.match(digest.stdout, /^[a-f0-9]{64}$/);
+            assert.strictEqual(digest.stderr, "");
+
+            const invalidated = yield* project.exec("bun", "run", "build");
+            const invalidatedOutput = `${invalidated.stdout}\n${invalidated.stderr}`;
+            assert.strictEqual(invalidated.exitCode, 0);
+            assert.isFalse(
+              /read the output from the cache/i.test(invalidatedOutput),
+            );
+            assert.isFalse(
+              /must-not-appear-in-nx-output/.test(invalidatedOutput),
+            );
+
+            const projectEnvCached = yield* project.exec("bun", "run", "build");
+            assert.match(
+              projectEnvCached.stdout,
+              /read the output from the cache/i,
+            );
+            yield* project.writeFile(
+              ".env",
+              "NX_ROOT_GAUNTLET_SECRET=also-must-not-appear\n",
+            );
+            const rootEnvInvalidated = yield* project.exec(
+              "bun",
+              "run",
+              "build",
+            );
+            const rootEnvOutput = `${rootEnvInvalidated.stdout}\n${rootEnvInvalidated.stderr}`;
+            assert.strictEqual(rootEnvInvalidated.exitCode, 0);
+            assert.isFalse(
+              /read the output from the cache/i.test(rootEnvOutput),
+            );
+            assert.isFalse(/also-must-not-appear/.test(rootEnvOutput));
+          });
+        }),
+      { timeout: 180_000 },
+    );
+
+    it.effect(
+      "should install, discover, type-check, and build with Nx in a Node and npm workspace",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "create",
+            "nx-npm-app",
+            "--target",
+            "client-react/web:client-react-web-worker",
+            "--yes",
+            "--no-git",
+            "--runtime",
+            "node",
+            "--package-manager",
+            "npm",
+            "--monorepo",
+            "nx",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileContaining(
+            "nx-npm-app/nx.json",
+            /^(?![\s\S]*analyzeLockfile)[\s\S]*$/,
+          );
+
+          yield* cli.withinProject("nx-npm-app", function* (project) {
+            const discovered = yield* project.exec(
+              "npm",
+              "exec",
+              "nx",
+              "show",
+              "projects",
+            );
+            assert.strictEqual(discovered.exitCode, 0);
+            assert.match(discovered.stdout, /client-react-web/);
+            assert.isFalse(/nx-npm-app/.test(discovered.stdout));
+            yield* project.expectTypeCheckPasses("npm");
+            yield* project.expectBuildSucceeds("npm");
+          });
+        }),
+      { timeout: 180_000 },
+    );
+
+    it.effect(
+      "should install and discover projects with Nx in a Node and pnpm workspace",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "create",
+            "nx-pnpm-app",
+            "--target",
+            "package/domain:domain-api-contracts",
+            "--yes",
+            "--no-git",
+            "--runtime",
+            "node",
+            "--package-manager",
+            "pnpm",
+            "--monorepo",
+            "nx",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileContaining(
+            "nx-pnpm-app/pnpm-workspace.yaml",
+            /allowBuilds:[\s\S]*nx: true/,
+          );
+          yield* cli.expectFileContaining(
+            "nx-pnpm-app/nx.json",
+            /^(?![\s\S]*analyzeLockfile)[\s\S]*$/,
+          );
+
+          yield* cli.withinProject("nx-pnpm-app", function* (project) {
+            const discovered = yield* project.exec(
+              "pnpm",
+              "exec",
+              "nx",
+              "show",
+              "projects",
+            );
+            assert.strictEqual(discovered.exitCode, 0);
+            assert.match(discovered.stdout, /@repo\/domain/);
+            assert.isFalse(/nx-pnpm-app/.test(discovered.stdout));
+            yield* project.expectTypeCheckPasses("pnpm");
+          });
+        }),
+      { timeout: 180_000 },
     );
 
     it.effect(

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -130,6 +130,31 @@ describe("RecipeService", () => {
   });
 
   describe("resolve", () => {
+    it.effect("should select the Nx workspace module when configured", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const config = new StackConfig({
+          ...testConfig,
+          monorepo: "nx",
+        });
+        const selection = yield* service.resolve(
+          { targets: [] },
+          {
+            config,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        assertTargetModules(selection, ".", [
+          ModuleId.make("workspace-typescript-6"),
+          ModuleId.make("workspace-monorepo-nx"),
+          ModuleId.make("workspace-quality-biome-lint"),
+          ModuleId.make("workspace-quality-biome-format"),
+          ModuleId.make("workspace-test-vitest"),
+        ]);
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect("should select the Vite+ workspace module when configured", () =>
       Effect.gen(function* () {
         const service = yield* RecipeService;
@@ -808,6 +833,30 @@ describe("RecipeService", () => {
   });
 
   describe("renderCreateCommand", () => {
+    it.effect(
+      "should render an explicit monorepo flag when Nx is configured",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* RecipeService;
+          const config = new StackConfig({
+            ...testConfig,
+            monorepo: "nx",
+          });
+          const selection = yield* service.resolve(
+            { targets: [] },
+            {
+              config,
+              providerStrategy: { _tag: "fail-on-ambiguous" },
+            },
+          );
+
+          assert.strictEqual(
+            service.renderCreateCommand({ config, selection }),
+            "bunx stack-effect@latest create recipe-app --monorepo nx --no-git",
+          );
+        }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect(
       "should render an explicit monorepo flag when Vite+ is configured",
       () =>

--- a/packages/catalog/src/CatalogService.test.ts
+++ b/packages/catalog/src/CatalogService.test.ts
@@ -15,9 +15,17 @@ layer(CatalogService.layer)("CatalogService", (it) => {
         const vitePlus = workspace?.modules.find(
           (module) => module.id === "workspace-monorepo-vite-plus",
         );
+        const nx = workspace?.modules.find(
+          (module) => module.id === "workspace-monorepo-nx",
+        );
 
         assert.deepStrictEqual(vitePlus?.conflictsWith, [
           ModuleId.make("workspace-monorepo-turbo"),
+          ModuleId.make("workspace-monorepo-nx"),
+        ]);
+        assert.deepStrictEqual(nx?.conflictsWith, [
+          ModuleId.make("workspace-monorepo-turbo"),
+          ModuleId.make("workspace-monorepo-vite-plus"),
         ]);
       }),
   );

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -8,8 +8,11 @@ node_modules/.vite/task-cache{{/if}}
 dist
 build
 .cache
-.turbo
-tsconfig.tsbuildinfo
+{{#if monorepo=turbo}}.turbo
+{{/if}}{{#if monorepo=vite-plus}}.turbo
+{{/if}}{{#if monorepo=nx}}.nx/cache
+.nx/workspace-data
+{{/if}}tsconfig.tsbuildinfo
 
 # env
 .env
@@ -65,7 +68,8 @@ export const pnpmWorkspaceContents = `packages:
 
 allowBuilds:
   esbuild: true
-  msgpackr-extract: true
+  msgpackr-extract: true{{#if monorepo=nx}}
+  nx: true{{/if}}
 `;
 
 export const configTypescriptBaseContents = `{
@@ -156,6 +160,124 @@ export const turboJsonContents = `{
     }
   }
 }
+`;
+
+// -- nx ---------------------------------------------------------------------
+
+// HACK: Nx 23.1.1 cannot parse Bun 1.4's lockfile version 2. Bun recipes hash
+// the lockfile through sharedGlobals instead; remove when Nx accepts version 2.
+export const nxJsonContents = `{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",{{#if runtime=bun}}
+  "pluginsConfig": {
+    "@nx/js": {
+      "analyzeLockfile": false
+    }
+  },{{/if}}
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/bun.lock",
+      "{workspaceRoot}/bun.lockb",
+      "{workspaceRoot}/package-lock.json",
+      "{workspaceRoot}/npm-shrinkwrap.json",
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/pnpm-lock.yml",
+      "{workspaceRoot}/pnpm-workspace.yaml",
+      "{workspaceRoot}/scripts/hash-env.mjs",
+      { "runtime": "node ./scripts/hash-env.mjs" }
+    ]
+  },
+  "targetDefaults": {
+    "build": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^default"],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "dev": {
+      "cache": false,
+      "continuous": true
+    },
+    "type-check": {
+      "cache": true,
+      "dependsOn": ["^type-check"],
+      "inputs": ["default", "^default"]
+    },
+    "test": {
+      "cache": true,
+      "dependsOn": ["^test"],
+      "inputs": ["default", "^default"]
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}
+`;
+
+export const nxHashEnvContents = `import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+const workspaceRoot = process.cwd();
+const workspaceDirectories = ["apps", "packages"];
+
+const isEnvironmentFile = (name) =>
+  name === ".env" || name.startsWith(".env.") || name.endsWith(".env");
+
+const readDirectoryIfPresent = (path) =>
+  readdir(path, { withFileTypes: true }).catch((error) => {
+    if (
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw error;
+  });
+
+const childDirectories = async (path) =>
+  (await readDirectoryIfPresent(path))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+const projectRoots = (
+  await Promise.all(
+    workspaceDirectories.map(async (directory) =>
+      (await childDirectories(join(workspaceRoot, directory))).map((name) =>
+        join(workspaceRoot, directory, name),
+      ),
+    ),
+  )
+).flat();
+
+const environmentFiles = (
+  await Promise.all(
+    [workspaceRoot, ...projectRoots].map(async (projectRoot) =>
+      (await readDirectoryIfPresent(projectRoot))
+        .filter((entry) => entry.isFile() && isEnvironmentFile(entry.name))
+        .map((entry) => join(projectRoot, entry.name)),
+    ),
+  )
+).flat();
+
+const hash = createHash("sha256");
+
+const environmentFileContents = await Promise.all(
+  environmentFiles.sort().map(async (path) => [path, await readFile(path)]),
+);
+
+environmentFileContents.forEach(([path, contents]) => {
+  hash.update(relative(workspaceRoot, path));
+  hash.update("\\0");
+  hash.update(contents);
+  hash.update("\\0");
+});
+
+process.stdout.write(hash.digest("hex"));
 `;
 
 // -- vite+ ------------------------------------------------------------------

--- a/packages/catalog/src/registry/moduleRegistry.test.ts
+++ b/packages/catalog/src/registry/moduleRegistry.test.ts
@@ -93,14 +93,31 @@ describe("moduleRegistry", () => {
     expect(invalid).toEqual([]);
   });
 
-  it("should register Vite+ as a Turbo alternative when listing monorepo modules", () => {
+  it("should register Nx and Vite+ as mutually exclusive Turbo alternatives", () => {
+    const turbo = moduleRegistry.find(
+      (mod) => mod.id === "workspace-monorepo-turbo",
+    );
+    const nx = moduleRegistry.find((mod) => mod.id === "workspace-monorepo-nx");
     const vitePlus = moduleRegistry.find(
       (mod) => mod.id === "workspace-monorepo-vite-plus",
     );
 
+    expect(nx).toBeDefined();
     expect(vitePlus).toBeDefined();
+    expect(nx?.categories).toContain("monorepo");
     expect(vitePlus?.categories).toContain("monorepo");
-    expect(vitePlus?.conflictsWith).toEqual(["workspace-monorepo-turbo"]);
+    expect(turbo?.conflictsWith).toEqual([
+      "workspace-monorepo-vite-plus",
+      "workspace-monorepo-nx",
+    ]);
+    expect(nx?.conflictsWith).toEqual([
+      "workspace-monorepo-turbo",
+      "workspace-monorepo-vite-plus",
+    ]);
+    expect(vitePlus?.conflictsWith).toEqual([
+      "workspace-monorepo-turbo",
+      "workspace-monorepo-nx",
+    ]);
   });
 
   it("should register Oxfmt as a formatter alternative when catalog modules are listed", () => {

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -11,6 +11,8 @@ import {
   dprintJsonContents,
   envrcContents,
   flakeNixContents,
+  nxHashEnvContents,
+  nxJsonContents,
   oxfmtJsoncContents,
   oxfmtVscodeExtensionsContents,
   turboJsonContents,
@@ -209,7 +211,10 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     description: "Monorepo build orchestration with caching",
     visibility: "internal",
     categories: [ModuleCategory.make("monorepo")],
-    conflictsWith: [ModuleId.make("workspace-monorepo-vite-plus")],
+    conflictsWith: [
+      ModuleId.make("workspace-monorepo-vite-plus"),
+      ModuleId.make("workspace-monorepo-nx"),
+    ],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
     dependencies: [
       {
@@ -265,12 +270,85 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
     ],
   },
   {
+    id: ModuleId.make("workspace-monorepo-nx"),
+    title: "Nx",
+    description:
+      "Package-based monorepo task orchestration and caching with Nx",
+    visibility: "internal",
+    categories: [ModuleCategory.make("monorepo")],
+    conflictsWith: [
+      ModuleId.make("workspace-monorepo-turbo"),
+      ModuleId.make("workspace-monorepo-vite-plus"),
+    ],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [
+      {
+        _tag: "required-target",
+        identity: new TargetIdentity({
+          kind: TargetKind.make("workspace"),
+          name: "root",
+        }),
+      },
+    ],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/nx.json",
+        contents: nxJsonContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/scripts/hash-env.mjs",
+        contents: nxHashEnvContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "nx",
+        value: "^23.1.1",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "build",
+        value: "nx run-many -t build",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "dev",
+        value: "nx run-many -t dev",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "type-check",
+        value: "nx run-many -t type-check",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "clean",
+        value:
+          "nx reset && nx run-many -t clean && git clean -xdf node_modules .cache .nx/cache .nx/workspace-data dist tsconfig.tsbuildinfo",
+      },
+    ],
+  },
+  {
     id: ModuleId.make("workspace-monorepo-vite-plus"),
     title: "Vite+",
     description: "Monorepo task orchestration and caching with Vite+",
     visibility: "internal",
     categories: [ModuleCategory.make("monorepo")],
-    conflictsWith: [ModuleId.make("workspace-monorepo-turbo")],
+    conflictsWith: [
+      ModuleId.make("workspace-monorepo-turbo"),
+      ModuleId.make("workspace-monorepo-nx"),
+    ],
     supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
     dependencies: [
       {
@@ -611,7 +689,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         field: "scripts",
         name: "test",
         value:
-          "{{#if monorepo=turbo}}turbo run test{{/if}}{{#if monorepo=vite-plus}}vp run -r test{{/if}}",
+          "{{#if monorepo=turbo}}turbo run test{{/if}}{{#if monorepo=vite-plus}}vp run -r test{{/if}}{{#if monorepo=nx}}nx run-many -t test{{/if}}",
       },
     ],
   },

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -86,7 +86,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
    * - `{{lint}}` - Lint tool ("biome", "oxlint", or "")
    * - `{{format}}` - Format tool ("biome", "dprint", "oxfmt", or "")
    * - `{{test}}` - Test framework ("vitest" or "")
-   * - `{{monorepo}}` - Monorepo tool (for example, "turbo" or "vite-plus")
+   * - `{{monorepo}}` - Monorepo tool (for example, "turbo", "vite-plus", or "nx")
    * - `{{targetKind}}`, `{{targetName}}`, `{{targetPath}}`, `{{targetDir}}`, `{{packageName}}`
    *
    * ## Conditionals

--- a/packages/scaffold/src/service/recipe/WorkspaceModules.ts
+++ b/packages/scaffold/src/service/recipe/WorkspaceModules.ts
@@ -1,4 +1,5 @@
 const workspaceToolModules = {
+  nx: "workspace-monorepo-nx",
   turbo: "workspace-monorepo-turbo",
   "vite-plus": "workspace-monorepo-vite-plus",
   dprint: "workspace-quality-dprint",


### PR DESCRIPTION
## Goals/Scope

Add support for Nx monorepos by enabling integration/configuration for projects organized as Nx workspaces.

## Description

- Introduces Nx monorepo support.
- Enables handling/configuration for Nx workspace project structures.

---

- [x] closes #216