### PR TITLE
feat: add local-first Alchemy Cloudflare infrastructure

### DIFF
--- a/.changeset/cloudflare-react-infrastructure.md
+++ b/.changeset/cloudflare-react-infrastructure.md
@@ -1,0 +1,7 @@
+---
+"stack-effect": minor
+---
+
+Add opt-in Alchemy and Cloudflare deployment generation for a selected static React application, with matching CLI and Recipe Builder configuration.
+
+Local development uses Alchemy local state, while remote Cloudflare deployment remains an explicit infrastructure lifecycle.

--- a/apps/cli/src/commands/catalog.test.ts
+++ b/apps/cli/src/commands/catalog.test.ts
@@ -1,0 +1,99 @@
+import {
+  Contribution,
+  GenerationDomainAdapterId,
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  TargetKey,
+} from "@repo/domain/Catalog";
+import {
+  NormalizedContributions,
+  TargetContribution,
+} from "@repo/domain/Scaffold";
+import { describe, expect, it } from "vitest";
+import { buildManifestFiles } from "./catalog";
+
+const targetKey = TargetKey.make("apps/client-react-web");
+const domainId = GenerationDomainId.make("infrastructure");
+const optionId = GenerationDomainOptionId.make("cloudflare");
+const adapterId = GenerationDomainAdapterId.make("cloudflare-website-vite");
+
+describe("catalog workspace manifest", () => {
+  it("preserves generation-domain option and adapter provenance", () => {
+    const files = buildManifestFiles(
+      NormalizedContributions.make({
+        targets: [
+          TargetContribution.make({
+            targetKey,
+            contributions: [
+              Contribution.cases.file.make({
+                path: "base.ts",
+                contents: "base",
+              }),
+            ],
+          }),
+          TargetContribution.make({
+            targetKey,
+            generationDomain: { domainId, optionId },
+            contributions: [
+              Contribution.cases["pkg-json-entry"].make({
+                path: "package.json",
+                field: "dependencies",
+                name: "alchemy",
+                value: "2.0.0-beta.73",
+              }),
+            ],
+          }),
+          TargetContribution.make({
+            targetKey,
+            generationDomain: { domainId, optionId, adapterId },
+            contributions: [
+              Contribution.cases.file.make({
+                path: "alchemy.run.ts",
+                contents: "export default {};",
+              }),
+            ],
+          }),
+        ],
+        modules: [],
+      }),
+    );
+
+    expect(files).toEqual([
+      {
+        path: "alchemy.run.ts",
+        contributors: [
+          {
+            origin: "generation-domain",
+            targetKey: "apps/client-react-web",
+            domainId: "infrastructure",
+            optionId: "cloudflare",
+            adapterId: "cloudflare-website-vite",
+            contributionTag: "file",
+          },
+        ],
+      },
+      {
+        path: "base.ts",
+        contributors: [
+          {
+            origin: "target",
+            targetKey: "apps/client-react-web",
+            contributionTag: "file",
+          },
+        ],
+      },
+      {
+        path: "package.json",
+        contributors: [
+          {
+            origin: "generation-domain",
+            targetKey: "apps/client-react-web",
+            domainId: "infrastructure",
+            optionId: "cloudflare",
+            contributionTag: "pkg-json-entry",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/cli/src/commands/catalog.test.ts
+++ b/apps/cli/src/commands/catalog.test.ts
@@ -1,4 +1,14 @@
 import {
+  mkdir,
+  mkdtemp,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
   Contribution,
   GenerationDomainAdapterId,
   GenerationDomainId,
@@ -9,13 +19,40 @@ import {
   NormalizedContributions,
   TargetContribution,
 } from "@repo/domain/Scaffold";
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { buildManifestFiles } from "./catalog";
+import { buildManifestFiles, ensureWorkspaceLink } from "./catalog";
 
 const targetKey = TargetKey.make("apps/client-react-web");
 const domainId = GenerationDomainId.make("infrastructure");
 const optionId = GenerationDomainOptionId.make("cloudflare");
 const adapterId = GenerationDomainAdapterId.make("cloudflare-website-vite");
+
+describe("catalog workspace links", () => {
+  it("is idempotent for correct links and rejects conflicts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "catalog-links-"));
+    const source = join(root, "source");
+    const target = join(root, "target");
+    try {
+      await mkdir(source);
+      await symlink(source, target, "dir");
+      await Effect.runPromise(ensureWorkspaceLink(source, target, "ai"));
+      expect(resolve(root, await readlink(target))).toBe(source);
+
+      const missing = join(root, "missing");
+      await Effect.runPromise(ensureWorkspaceLink(source, missing, "domain"));
+      expect(resolve(root, await readlink(missing))).toBe(source);
+
+      const conflict = join(root, "conflict");
+      await writeFile(conflict, "not a link");
+      await expect(
+        Effect.runPromise(ensureWorkspaceLink(source, conflict, "bad")),
+      ).rejects.toThrow("link @repo/bad");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("catalog workspace manifest", () => {
   it("preserves generation-domain option and adapter provenance", () => {

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -42,6 +42,7 @@ import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import {
   formatFlag,
+  infrastructureFlag,
   monorepoFlag,
   recipeTargetFlag,
   rootFlag,
@@ -49,16 +50,6 @@ import {
 } from "../flags";
 
 const defaultWorkspaceRoot = "workspace/catalog-built";
-
-const infrastructureFlag = Flag.choice("infrastructure", [
-  "none",
-  "cloudflare",
-]).pipe(
-  Flag.optional,
-  Flag.withDescription(
-    "Catalog maintenance intent used to materialize provider-specific output",
-  ),
-);
 
 const defaultTargetNames = new Map<string, string>([
   ["server", "api"],
@@ -520,6 +511,31 @@ const runValidationCommand = Effect.fn(
   }
 });
 
+export const ensureWorkspaceLink = (
+  source: string,
+  target: string,
+  packageName: string,
+) =>
+  Effect.tryPromise({
+    try: async () => {
+      try {
+        await nodeFs.symlink(source, target, "dir");
+      } catch (error) {
+        if (
+          (error as NodeJS.ErrnoException).code !== "EEXIST" ||
+          (await nodeFs.realpath(target)) !== (await nodeFs.realpath(source))
+        ) {
+          throw error;
+        }
+      }
+    },
+    catch: (error) =>
+      new WorkspaceCommandFailed({
+        command: `link @repo/${packageName}`,
+        cause: error,
+      }),
+  });
+
 const linkWorkspacePackages = Effect.fn("catalog.workspace.linkPackages")(
   function* (repoRoot: string) {
     const fs = yield* FileSystem.FileSystem;
@@ -534,19 +550,11 @@ const linkWorkspacePackages = Effect.fn("catalog.workspace.linkPackages")(
     yield* Effect.forEach(
       packageNames,
       (packageName) =>
-        Effect.tryPromise({
-          try: () =>
-            nodeFs.symlink(
-              path.join(packagesRoot, packageName),
-              path.join(scopeRoot, packageName),
-              "dir",
-            ),
-          catch: (error) =>
-            new WorkspaceCommandFailed({
-              command: `link @repo/${packageName}`,
-              cause: error,
-            }),
-        }),
+        ensureWorkspaceLink(
+          path.join(packagesRoot, packageName),
+          path.join(scopeRoot, packageName),
+          packageName,
+        ),
       { concurrency: 1 },
     );
   },

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -10,7 +10,7 @@ import {
   TargetKind,
 } from "@repo/domain/Catalog";
 import type { RecipeTargetSpec } from "@repo/domain/Recipe";
-import { StackConfig } from "@repo/domain/Scaffold";
+import { NormalizedContributions, StackConfig } from "@repo/domain/Scaffold";
 import {
   ApplyService,
   BlueprintService,
@@ -37,7 +37,7 @@ import {
   Schema,
   Stream,
 } from "effect";
-import { Command } from "effect/unstable/cli";
+import { Command, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import {
@@ -50,6 +50,16 @@ import {
 
 const defaultWorkspaceRoot = "workspace/catalog-built";
 
+const infrastructureFlag = Flag.choice("infrastructure", [
+  "none",
+  "cloudflare",
+]).pipe(
+  Flag.optional,
+  Flag.withDescription(
+    "Catalog maintenance intent used to materialize provider-specific output",
+  ),
+);
+
 const defaultTargetNames = new Map<string, string>([
   ["server", "api"],
   ["client-react", "web"],
@@ -60,9 +70,12 @@ const defaultTargetNames = new Map<string, string>([
 ]);
 
 const ManifestContribution = Schema.Struct({
-  origin: Schema.Literals(["target", "module"]),
+  origin: Schema.Literals(["target", "module", "generation-domain"]),
   targetKey: Schema.String,
   moduleId: Schema.optional(Schema.String),
+  domainId: Schema.optional(Schema.String),
+  optionId: Schema.optional(Schema.String),
+  adapterId: Schema.optional(Schema.String),
   contributionTag: Schema.String,
 });
 
@@ -242,15 +255,9 @@ const buildWorkspaceSelection = Effect.fn("catalog.workspace.buildSelection")(
   },
 );
 
-const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
-  blueprint,
-  config,
-}: {
-  blueprint: typeof import("@repo/domain/Blueprint").Blueprint.Type;
-  config: typeof StackConfig.Type;
-}) {
-  const resolver = yield* ContributionResolver;
-  const normalized = yield* resolver.resolve(blueprint, config);
+export const buildManifestFiles = (
+  normalized: typeof NormalizedContributions.Type,
+): Array<typeof ManifestFile.Type> => {
   const contributorsByPath = new Map<string, Array<ManifestContributor>>();
 
   const appendContributor = (
@@ -265,11 +272,26 @@ const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
 
   for (const target of normalized.targets) {
     for (const contribution of target.contributions) {
-      appendContributor(contributionPath(contribution), {
-        origin: "target",
-        targetKey: target.targetKey,
-        contributionTag: contribution._tag,
-      });
+      const generationDomain = target.generationDomain;
+      appendContributor(
+        contributionPath(contribution),
+        generationDomain === undefined
+          ? {
+              origin: "target",
+              targetKey: target.targetKey,
+              contributionTag: contribution._tag,
+            }
+          : {
+              origin: "generation-domain",
+              targetKey: target.targetKey,
+              domainId: generationDomain.domainId,
+              optionId: generationDomain.optionId,
+              ...(generationDomain.adapterId === undefined
+                ? {}
+                : { adapterId: generationDomain.adapterId }),
+              contributionTag: contribution._tag,
+            },
+      );
     }
   }
 
@@ -284,9 +306,7 @@ const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
     }
   }
 
-  const manifestFiles: Array<typeof ManifestFile.Type> = Array.from(
-    contributorsByPath.entries(),
-  )
+  return Array.from(contributorsByPath.entries())
     .map(([path, contributors]) =>
       ManifestFile.make({
         path,
@@ -294,6 +314,18 @@ const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
       }),
     )
     .sort((a, b) => a.path.localeCompare(b.path));
+};
+
+const buildManifest = Effect.fn("catalog.workspace.buildManifest")(function* ({
+  blueprint,
+  config,
+}: {
+  blueprint: typeof import("@repo/domain/Blueprint").Blueprint.Type;
+  config: typeof StackConfig.Type;
+}) {
+  const resolver = yield* ContributionResolver;
+  const normalized = yield* resolver.resolve(blueprint, config);
+  const manifestFiles = buildManifestFiles(normalized);
 
   const now = yield* DateTime.now;
 
@@ -569,6 +601,7 @@ const reset = Command.make(
     target: recipeTargetFlag,
     typescript: typescriptFlag,
     monorepo: monorepoFlag,
+    infrastructure: infrastructureFlag,
   },
   (flags) =>
     Effect.gen(function* () {
@@ -599,6 +632,12 @@ const reset = Command.make(
         format: Option.getOrElse(flags.format, () => defaults.format),
         test: defaults.test,
         monorepo: Option.getOrElse(flags.monorepo, () => defaults.monorepo),
+        infrastructure: Option.getOrUndefined(
+          Option.filter(
+            flags.infrastructure,
+            (value) => value === "cloudflare",
+          ),
+        ),
       });
 
       const selection = yield* buildWorkspaceSelection(config, flags.target);

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -7,6 +7,7 @@ import { Command } from "effect/unstable/cli";
 import {
   dryRunFlag,
   formatFlag,
+  infrastructureFlag,
   lintFlag,
   monorepoFlag,
   noGitFlag,
@@ -67,6 +68,7 @@ const buildConfig = ({
   lint,
   format,
   test,
+  infrastructure,
   defaults,
 }: {
   readonly projectName: string;
@@ -77,6 +79,7 @@ const buildConfig = ({
   readonly lint: Option.Option<string>;
   readonly format: Option.Option<string>;
   readonly test: Option.Option<string>;
+  readonly infrastructure: Option.Option<"none" | "cloudflare">;
   readonly defaults: StackConfig;
 }): typeof StackConfig.Type => {
   const packageManagerName = Option.getOrElse(
@@ -104,6 +107,9 @@ const buildConfig = ({
     lint: Option.getOrElse(lint, () => defaults.lint),
     format: Option.getOrElse(format, () => defaults.format),
     test: Option.getOrElse(test, () => defaults.test),
+    infrastructure: Option.getOrUndefined(
+      Option.filter(infrastructure, (value) => value === "cloudflare"),
+    ),
   });
 };
 
@@ -140,6 +146,7 @@ export const create = Command.make(
     lint: lintFlag,
     format: formatFlag,
     test: testFlag,
+    infrastructure: infrastructureFlag,
     noGit: noGitFlag,
     yes: yesFlag,
     trust: trustFlag,
@@ -184,6 +191,7 @@ export const create = Command.make(
         lint: flags.lint,
         format: flags.format,
         test: flags.test,
+        infrastructure: flags.infrastructure,
         defaults,
       });
       const recipeSpec = buildRecipeSpec(flags.target.value, !flags.noGit);

--- a/apps/cli/src/commands/init.test.ts
+++ b/apps/cli/src/commands/init.test.ts
@@ -1,0 +1,68 @@
+import { assert, describe, it } from "@effect/vitest";
+import { RecipeTargetString } from "@repo/scaffold";
+import { Effect, Option, Schema } from "effect";
+import { resolveInfrastructureTargets } from "./init";
+
+const baseReactTarget =
+  Schema.decodeUnknownSync(RecipeTargetString)("client-react/web");
+
+describe("resolveInfrastructureTargets", () => {
+  it.effect(
+    "collects one React target for an interactive Cloudflare init",
+    () =>
+      Effect.gen(function* () {
+        let prompts = 0;
+        const targets = yield* resolveInfrastructureTargets({
+          infrastructure: "cloudflare",
+          yes: false,
+          targets: Option.none(),
+          promptTarget: Effect.sync(() => {
+            prompts += 1;
+            return baseReactTarget;
+          }),
+        });
+
+        assert.strictEqual(prompts, 1);
+        assert.deepStrictEqual(targets, Option.some([baseReactTarget]));
+      }),
+  );
+
+  it.effect(
+    "preserves an explicitly supplied Cloudflare target without prompting",
+    () =>
+      Effect.gen(function* () {
+        let prompts = 0;
+        const supplied = Option.some([baseReactTarget]);
+        const targets = yield* resolveInfrastructureTargets({
+          infrastructure: "cloudflare",
+          yes: false,
+          targets: supplied,
+          promptTarget: Effect.sync(() => {
+            prompts += 1;
+            return baseReactTarget;
+          }),
+        });
+
+        assert.strictEqual(prompts, 0);
+        assert.deepStrictEqual(targets, supplied);
+      }),
+  );
+
+  it.effect("keeps --yes Cloudflare target enforcement non-interactive", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.exit(
+        resolveInfrastructureTargets({
+          infrastructure: "cloudflare",
+          yes: true,
+          targets: Option.none(),
+          promptTarget: Effect.succeed(baseReactTarget),
+        }),
+      );
+
+      if (result._tag !== "Failure") {
+        return assert.fail("expected missing --yes target to fail");
+      }
+      assert.match(String(result.cause), /requires an explicit React target/);
+    }),
+  );
+});

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -7,6 +7,7 @@ import {
 } from "@repo/domain/Catalog";
 import {
   RecipeService,
+  RecipeTargetString,
   StackConfigDefaults,
   toWorkspaceToolValue,
 } from "@repo/scaffold";
@@ -16,8 +17,10 @@ import { Command } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import {
   dryRunFlag,
+  infrastructureFlag,
   noGitFlag,
   projectNameArg,
+  recipeTargetFlag,
   rootFlag,
   runtimeFlag,
   showFilesFlag,
@@ -79,6 +82,30 @@ const chooseOptionalTool = <A extends string>(
     ? Effect.succeed(Option.some(fallback))
     : optionalSelect(message, choices);
 
+export const resolveInfrastructureTargets = Effect.fn(
+  "resolveInfrastructureTargets",
+)(function* <A, E, R>({
+  infrastructure,
+  yes,
+  targets,
+  promptTarget,
+}: {
+  readonly infrastructure: "none" | "cloudflare";
+  readonly yes: boolean;
+  readonly targets: Option.Option<ReadonlyArray<A>>;
+  readonly promptTarget: Effect.Effect<A, E, R>;
+}) {
+  if (infrastructure !== "cloudflare" || Option.isSome(targets)) {
+    return targets;
+  }
+  if (yes) {
+    return yield* Effect.fail(
+      "Cloudflare infrastructure requires an explicit React target, for example --target client-react/web.",
+    );
+  }
+  return Option.some([yield* promptTarget]);
+});
+
 export const init = Command.make(
   "init",
   {
@@ -89,6 +116,8 @@ export const init = Command.make(
     showFiles: showFilesFlag,
     runtime: runtimeFlag,
     typescript: typescriptFlag,
+    infrastructure: infrastructureFlag,
+    target: recipeTargetFlag,
     noGit: noGitFlag,
     trust: trustFlag,
   },
@@ -230,6 +259,39 @@ export const init = Command.make(
         defaults.test ?? "",
       );
 
+      const infrastructure = Option.isSome(flags.infrastructure)
+        ? flags.infrastructure.value
+        : flags.yes
+          ? ("none" as const)
+          : yield* Select({
+              message: "Infrastructure as Effects",
+              choices: [
+                { title: "None", value: "none" as const },
+                {
+                  title: "Cloudflare",
+                  description: "Deploy an explicit React target with Alchemy",
+                  value: "cloudflare" as const,
+                },
+              ],
+            });
+
+      const targets = yield* resolveInfrastructureTargets({
+        infrastructure,
+        yes: flags.yes,
+        targets: flags.target,
+        promptTarget: TextInput({
+          message: "Which React target should Cloudflare deploy?",
+          validate: (value) =>
+            Schema.decodeEffect(RecipeTargetString)(value).pipe(
+              Effect.as(value),
+              Effect.mapError(
+                () =>
+                  "Enter exactly one React target, for example client-react/web.",
+              ),
+            ),
+        }).pipe(Effect.flatMap(Schema.decodeEffect(RecipeTargetString))),
+      });
+
       const git = flags.noGit
         ? false
         : flags.yes
@@ -272,6 +334,7 @@ export const init = Command.make(
           onNone: () => ({}),
           onSome: (v) => ({ monorepo: v }),
         }),
+        ...(infrastructure === "cloudflare" ? { infrastructure } : {}),
       });
 
       const dxExtrasDisplay =
@@ -351,8 +414,8 @@ export const init = Command.make(
       ];
       const selection = yield* recipe.resolve(
         {
-          targets:
-            explicitWorkspaceModules.length === 0
+          targets: [
+            ...(explicitWorkspaceModules.length === 0
               ? []
               : [
                   {
@@ -362,7 +425,9 @@ export const init = Command.make(
                     }),
                     modules: explicitWorkspaceModules,
                   },
-                ],
+                ]),
+            ...Option.getOrElse(targets, () => []),
+          ],
         },
         {
           config,

--- a/apps/cli/src/flags.test.ts
+++ b/apps/cli/src/flags.test.ts
@@ -3,13 +3,30 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 import { TestConsole } from "effect/testing";
 import { CliOutput, Command } from "effect/unstable/cli";
-import { showFilesFlag, validateShowFiles } from "./flags";
+import { infrastructureFlag, showFilesFlag, validateShowFiles } from "./flags";
 
 const helpLayer = Layer.mergeAll(
   NodeServices.layer,
   TestConsole.layer,
   CliOutput.layer(CliOutput.defaultFormatter({ colors: false })),
 );
+
+describe("infrastructure flag", () => {
+  it.effect("documents the canonical choices without aliases", () =>
+    Effect.gen(function* () {
+      const command = Command.make("scaffold", {
+        infrastructure: infrastructureFlag,
+      });
+      yield* Command.runWith(command, { version: "test" })(["--help"]);
+      const output = (yield* TestConsole.logLines).join("\n");
+
+      expect(output).toContain("--infrastructure <none|cloudflare>");
+      expect(output).toContain("Infrastructure as Effects");
+      expect(output).not.toContain("--IaC");
+      expect(output).not.toContain("--IaE");
+    }).pipe(Effect.provide(helpLayer)),
+  );
+});
 
 describe("show-files flag", () => {
   it.effect("documents the shared dry-run companion", () =>

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -62,6 +62,17 @@ export const trustFlag = Flag.boolean("trust").pipe(
   ),
 );
 
+export const infrastructureFlag = Flag.choice("infrastructure", [
+  "none",
+  "cloudflare",
+]).pipe(
+  Flag.optional,
+  Flag.withMetavar("<none|cloudflare>"),
+  Flag.withDescription(
+    "Infrastructure as Effects (None or Cloudflare via Alchemy)",
+  ),
+);
+
 export const runtimeFlag = Flag.choice("runtime", ["bun", "node"]).pipe(
   Flag.optional,
   Flag.withDescription("Runtime to use"),

--- a/apps/cli/src/lib/recipeTargets.test.ts
+++ b/apps/cli/src/lib/recipeTargets.test.ts
@@ -83,6 +83,26 @@ describe("RecipeTargetString", () => {
     assert.strictEqual(encoded, "server-mcp/");
   });
 
+  it("uses the canonical target-without-modules syntax for base React", () => {
+    const decoded =
+      Schema.decodeUnknownSync(RecipeTargetString)("client-react/web");
+
+    assert.deepStrictEqual(decoded, {
+      target: new TargetIdentity({
+        kind: TargetKind.make("client-react"),
+        name: "web",
+      }),
+      modules: [],
+    });
+    assert.strictEqual(
+      Schema.encodeUnknownSync(RecipeTargetString)(decoded),
+      "client-react/web",
+    );
+    assert.throws(() =>
+      Schema.decodeUnknownSync(RecipeTargetString)("client-react/web:"),
+    );
+  });
+
   it("rejects malformed target specs", () => {
     assert.throws(() =>
       Schema.decodeUnknownSync(RecipeTargetString)(":server-http-api"),

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -843,6 +843,55 @@ describe("RecipeService", () => {
   });
 
   describe("renderCreateCommand", () => {
+    it.effect("should omit none and render explicit Cloudflare intent", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const noneSelection = yield* service.resolve(
+          { targets: [] },
+          {
+            config: testConfig,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+        const cloudflareConfig = new StackConfig({
+          ...testConfig,
+          infrastructure: "cloudflare",
+        });
+        const cloudflareSelection = yield* service.resolve(
+          {
+            targets: [
+              {
+                target: new TargetIdentity({
+                  kind: TargetKind.make("client-react"),
+                  name: "web",
+                }),
+                modules: [ModuleId.make("client-react-web-worker")],
+              },
+            ],
+          },
+          {
+            config: cloudflareConfig,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        assert.notInclude(
+          service.renderCreateCommand({
+            config: testConfig,
+            selection: noneSelection,
+          }),
+          "--infrastructure",
+        );
+        assert.include(
+          service.renderCreateCommand({
+            config: cloudflareConfig,
+            selection: cloudflareSelection,
+          }),
+          "--infrastructure cloudflare",
+        );
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect(
       "should omit values supplied by an injected default StackConfig",
       () => {

--- a/apps/docs/app/components/recipe-builder/form.ts
+++ b/apps/docs/app/components/recipe-builder/form.ts
@@ -32,6 +32,7 @@ const StackConfigurationSchema = Schema.Struct({
   format: Schema.optional(Schema.String),
   test: Schema.optional(Schema.String),
   monorepo: Schema.optional(Schema.String),
+  infrastructure: Schema.Literals(["none", "cloudflare"]),
 });
 
 const TargetModuleRequirementSchema = Schema.Struct({
@@ -122,6 +123,7 @@ export const initialRecipeBuilderValues: RecipeBuilderFormValues = {
     lint: stackConfigDefaults.lint,
     format: stackConfigDefaults.format,
     test: stackConfigDefaults.test,
+    infrastructure: "none",
   },
   database: "none",
   gitEnabled: true,
@@ -184,7 +186,13 @@ export function toRecipePreviewInput(
   );
 
   return {
-    config: new StackConfig(values.config),
+    config: new StackConfig({
+      ...values.config,
+      infrastructure:
+        values.config.infrastructure === "cloudflare"
+          ? "cloudflare"
+          : undefined,
+    }),
     recipe: {
       targets: [
         ...(values.gitEnabled || values.developerExperienceModules.length > 0
@@ -210,7 +218,13 @@ export function toRecipePreviewInput(
             kind: TargetKind.make(target.kind),
             name: target.name,
           }),
-          modules: target.modules.map((id) => ModuleId.make(id)),
+          modules: target.modules
+            .filter(
+              (id) =>
+                values.config.infrastructure !== "cloudflare" ||
+                id !== "config-typescript-vite",
+            )
+            .map((id) => ModuleId.make(id)),
         })),
       ],
     },

--- a/apps/docs/app/components/recipe-builder/recipe-builder-url.ts
+++ b/apps/docs/app/components/recipe-builder/recipe-builder-url.ts
@@ -20,6 +20,7 @@ const RecipeUrlSchema = Schema.Struct({
   lint: Schema.optional(Schema.String),
   format: Schema.optional(Schema.String),
   test: Schema.optional(Schema.String),
+  infrastructure: Schema.optional(Schema.Literals(["none", "cloudflare"])),
   noGit: Schema.Boolean,
 }).check(
   Schema.makeFilter(({ runtime, packageManager }) =>
@@ -41,6 +42,7 @@ const scalarRecipeParameters = [
   "lint",
   "format",
   "test",
+  "infrastructure",
   "no-git",
 ] as const;
 
@@ -99,6 +101,7 @@ const toInitialValues = (
     lint: recipe.lint ?? defaults.lint,
     format: recipe.format ?? defaults.format,
     test: recipe.test ?? defaults.test,
+    infrastructure: recipe.infrastructure ?? defaults.infrastructure,
   };
   const targets = mergeTargets(recipe.target);
   const workspaceTargets = targets.filter(
@@ -197,6 +200,7 @@ export const decodeRecipeBuilderUrl = (
     lint: searchParams.get("lint") ?? undefined,
     format: searchParams.get("format") ?? undefined,
     test: searchParams.get("test") ?? undefined,
+    infrastructure: searchParams.get("infrastructure") ?? undefined,
     noGit: searchParams.has("no-git"),
   });
   if (Option.isNone(decoded)) {
@@ -245,6 +249,9 @@ export const encodeRecipeBuilderUrl = (
     if (value !== undefined && value !== defaults[field])
       params.set(field, value);
   });
+  if (values.config.infrastructure === "cloudflare") {
+    params.set("infrastructure", "cloudflare");
+  }
   if (!values.gitEnabled) params.set("no-git", "");
   return params;
 };

--- a/apps/docs/app/components/recipe-builder/stack-configurator.tsx
+++ b/apps/docs/app/components/recipe-builder/stack-configurator.tsx
@@ -169,6 +169,21 @@ export function StackConfigurator() {
         />
 
         <ConfigurationSelect
+          id="stack-infrastructure"
+          label="Infrastructure as Effects"
+          value={config.infrastructure}
+          options={[
+            { value: "none", label: "None" },
+            { value: "cloudflare", label: "Cloudflare" },
+          ]}
+          onChange={(value) =>
+            configure({
+              infrastructure: value === "cloudflare" ? "cloudflare" : "none",
+            })
+          }
+        />
+
+        <ConfigurationSelect
           id="stack-typescript"
           label="TypeScript"
           value={config.typescript ?? "6"}

--- a/apps/docs/app/components/recipe-builder/target-selector/index.tsx
+++ b/apps/docs/app/components/recipe-builder/target-selector/index.tsx
@@ -1,3 +1,4 @@
+import { useSelector } from "@tanstack/react-form";
 import { Plus } from "lucide-react";
 import { DisclosurePanel } from "~/components/molecules/disclosure-panel";
 import { Button } from "~/components/ui/button";
@@ -11,10 +12,17 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { cn } from "~/lib/utils";
 import { RecipeBuilderCatalog } from "../../../workers/recipe-builder/domain";
+import { useRecipeBuilderFormContext } from "../recipe-builder-context";
+import { infrastructureTargetDisabledReason } from "./state";
 import { TargetConfiguration } from "./target-configuration";
 import { newTargetTabId, useTargetEditor } from "./use-target-editor";
 
 export function TargetSelector() {
+  const form = useRecipeBuilderFormContext();
+  const infrastructure = useSelector(
+    form.store,
+    (state) => state.values.config.infrastructure,
+  );
   const {
     activeId,
     activeTarget,
@@ -96,6 +104,8 @@ export function TargetSelector() {
           <TargetOptions
             onAddTarget={addTarget}
             firstTarget={targets.length === 0}
+            infrastructure={infrastructure}
+            selectedTargets={targets}
             targets={availableTargets}
           />
         )}
@@ -107,12 +117,16 @@ export function TargetSelector() {
 type TargetOptionsProps = {
   readonly firstTarget: boolean;
   readonly onAddTarget: (kind: string) => void;
+  readonly infrastructure: "none" | "cloudflare";
+  readonly selectedTargets: ReadonlyArray<{ readonly kind: string }>;
   readonly targets: (typeof RecipeBuilderCatalog.Type)["targets"];
 };
 
 function TargetOptions({
   firstTarget,
   onAddTarget,
+  infrastructure,
+  selectedTargets,
   targets,
 }: TargetOptionsProps) {
   return (
@@ -137,40 +151,62 @@ function TargetOptions({
           )}
           aria-label="Available target types"
         >
-          {targets.map((target, index) => (
-            <button
-              key={target.kind}
-              type="button"
-              className={cn(
-                "@container group flex h-full w-full items-start gap-3 bg-background p-3.5 text-left transition-colors hover:bg-muted/35 focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none",
-                firstTarget && "bg-primary/3 hover:bg-primary/7",
-                index > 0 && "border-t",
-                "sm:nth-2:border-t-0 sm:even:border-l",
-              )}
-              onClick={() => onAddTarget(target.kind)}
-            >
-              <span className="min-w-0 flex-1">
-                <span className="flex flex-wrap @2xs:flex-row flex-col items-baseline gap-x-2 gap-y-1">
-                  <span className="font-heading text-sm font-semibold text-foreground">
-                    {target.title}
+          {targets.map((target, index) => {
+            const disabledReason = infrastructureTargetDisabledReason(
+              infrastructure,
+              target.kind,
+              selectedTargets,
+            );
+            return (
+              <div key={target.kind} className="contents">
+                <button
+                  type="button"
+                  className={cn(
+                    "@container group flex h-full w-full items-start gap-3 bg-background p-3.5 text-left transition-colors hover:bg-muted/35 focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none",
+                    firstTarget && "bg-primary/3 hover:bg-primary/7",
+                    index > 0 && "border-t",
+                    "sm:nth-2:border-t-0 sm:even:border-l",
+                  )}
+                  disabled={disabledReason !== undefined}
+                  aria-describedby={
+                    disabledReason
+                      ? `target-${target.kind}-disabled-reason`
+                      : undefined
+                  }
+                  onClick={() => onAddTarget(target.kind)}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="flex flex-wrap @2xs:flex-row flex-col items-baseline gap-x-2 gap-y-1">
+                      <span className="font-heading text-sm font-semibold text-foreground">
+                        {target.title}
+                      </span>
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {target.kind}
+                      </span>
+                    </span>
+                    <span className="@2xs:block mt-1.5 hidden text-sm leading-5 text-muted-foreground">
+                      {target.description}
+                    </span>
                   </span>
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {target.kind}
-                  </span>
-                </span>
-                <span className="@2xs:block mt-1.5 hidden text-sm leading-5 text-muted-foreground">
-                  {target.description}
-                </span>
-              </span>
-              <Plus
-                className={cn(
-                  "mt-0.5 size-4 shrink-0 transition-colors group-hover:text-primary",
-                  firstTarget ? "text-primary" : "text-muted-foreground",
-                )}
-                aria-hidden="true"
-              />
-            </button>
-          ))}
+                  <Plus
+                    className={cn(
+                      "mt-0.5 size-4 shrink-0 transition-colors group-hover:text-primary",
+                      firstTarget ? "text-primary" : "text-muted-foreground",
+                    )}
+                    aria-hidden="true"
+                  />
+                </button>
+                {disabledReason ? (
+                  <p
+                    id={`target-${target.kind}-disabled-reason`}
+                    className="px-3.5 py-2 text-sm text-muted-foreground sm:col-span-2"
+                  >
+                    {disabledReason}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
       ) : (
         <div

--- a/apps/docs/app/components/recipe-builder/target-selector/state.ts
+++ b/apps/docs/app/components/recipe-builder/target-selector/state.ts
@@ -12,6 +12,39 @@ import {
 
 type Owner = SupportConfiguration["owner"];
 
+export type InfrastructureSelection = "none" | "cloudflare";
+
+const cloudflareTargetReason =
+  "This first Alchemy/Cloudflare slice supports only Client React and requires exactly one target.";
+const cloudflareAdditionalReactTargetReason =
+  "This first Alchemy/Cloudflare slice supports exactly one Client React target; remove the selected React target before adding another.";
+const cloudflareModuleReason =
+  "This backend-dependent module is not supported by the first Alchemy/Cloudflare static React slice.";
+
+export function infrastructureTargetDisabledReason(
+  infrastructure: InfrastructureSelection,
+  targetKind: string,
+  selectedTargets: ReadonlyArray<Pick<TargetInstance, "kind">> = [],
+): string | undefined {
+  if (infrastructure !== "cloudflare") return undefined;
+  if (targetKind !== "client-react") return cloudflareTargetReason;
+  return selectedTargets.some((target) => target.kind === "client-react")
+    ? cloudflareAdditionalReactTargetReason
+    : undefined;
+}
+
+export function infrastructureModuleDisabledReason(
+  infrastructure: InfrastructureSelection,
+  moduleId: string,
+): string | undefined {
+  if (infrastructure !== "cloudflare") return undefined;
+  return moduleId === "config-typescript-vite" ||
+    moduleId === "client-react-web-worker" ||
+    moduleId === "client-react-devtools"
+    ? undefined
+    : cloudflareModuleReason;
+}
+
 const moduleKey = (owner: Owner, moduleId: string) =>
   `${ownerKey(owner)}#${moduleId}`;
 

--- a/apps/docs/app/components/recipe-builder/target-selector/target-configuration.tsx
+++ b/apps/docs/app/components/recipe-builder/target-selector/target-configuration.tsx
@@ -34,6 +34,7 @@ import { ModuleBranch } from "./module-branch";
 import {
   buildModuleRelationshipNodes,
   dependencySourceNames,
+  infrastructureModuleDisabledReason,
   moduleRequiresCapability,
 } from "./state";
 
@@ -67,6 +68,10 @@ export function TargetConfiguration({
 }: TargetConfigurationProps) {
   const form = useRecipeBuilderFormContext();
   const database = useSelector(form.store, (state) => state.values.database);
+  const infrastructure = useSelector(
+    form.store,
+    (state) => state.values.config.infrastructure,
+  );
   const modules =
     catalog?.targetModules.find(
       (entry) => ownerKey(entry.owner) === ownerKey(catalogOwner ?? target),
@@ -94,10 +99,11 @@ export function TargetConfiguration({
     name: target.name,
   };
   const getDisabledReason = (module: typeof CatalogModule.Type) =>
-    database === "none" &&
+    infrastructureModuleDisabledReason(infrastructure, module.id) ??
+    (database === "none" &&
     moduleRequiresCapability(module, moduleOwner, "db-sql", catalog)
       ? "Select a database to enable this module."
-      : undefined;
+      : undefined);
   return (
     <section className="p-4 md:p-5">
       <div className="border-b pb-5">

--- a/apps/docs/app/content/reference/cli/catalog.mdx
+++ b/apps/docs/app/content/reference/cli/catalog.mdx
@@ -53,6 +53,7 @@ stack-effect catalog workspace reset [flags]
 | `--target <targetKind>/<targetName>:<moduleId>[,...]` | Target spec as &lt;targetKind&gt;/&lt;targetName&gt;:&lt;moduleId&gt;[,&lt;moduleId&gt;...] |
 | `--typescript choice` | TypeScript major version to configure (choices: 6, 7) |
 | `--monorepo string` | Override the default monorepo tool |
+| `--infrastructure <none\|cloudflare>` | Infrastructure as Effects (None or Cloudflare via Alchemy) (choices: none, cloudflare) |
 
 ## stack-effect catalog workspace diff
 

--- a/apps/docs/app/content/reference/cli/create.mdx
+++ b/apps/docs/app/content/reference/cli/create.mdx
@@ -29,6 +29,7 @@ stack-effect create [flags] [<project-name>]
 | `--lint string` | Override the default lint tool |
 | `--format string` | Override the default format tool |
 | `--test string` | Override the default test framework |
+| `--infrastructure <none\|cloudflare>` | Infrastructure as Effects (None or Cloudflare via Alchemy) (choices: none, cloudflare) |
 | `--no-git` | Skip git repository initialization |
 | `--yes, -y` | Skip confirmation prompts (uses defaults where available) |
 | `--trust` | Skip finalize script approval prompt and run all scripts |

--- a/apps/docs/app/content/reference/cli/index.mdx
+++ b/apps/docs/app/content/reference/cli/index.mdx
@@ -2,7 +2,7 @@
 
 # CLI reference
 
-Commands, arguments, options, and examples for `stack-effect v0.12.1`. These pages are generated from the current Effect CLI command tree.
+Commands, arguments, options, and examples for `stack-effect v0.13.1`. These pages are generated from the current Effect CLI command tree.
 
 ## Commands
 

--- a/apps/docs/app/content/reference/cli/init.mdx
+++ b/apps/docs/app/content/reference/cli/init.mdx
@@ -26,6 +26,8 @@ stack-effect init [flags] [<project-name>]
 | `--show-files` | Include generated file contents in a dry-run preview |
 | `--runtime choice` | Runtime to use (choices: bun, node) |
 | `--typescript choice` | TypeScript major version to configure (choices: 6, 7) |
+| `--infrastructure <none\|cloudflare>` | Infrastructure as Effects (None or Cloudflare via Alchemy) (choices: none, cloudflare) |
+| `--target <targetKind>/<targetName>:<moduleId>[,...]` | Target spec as &lt;targetKind&gt;/&lt;targetName&gt;:&lt;moduleId&gt;[,&lt;moduleId&gt;...] |
 | `--no-git` | Skip git repository initialization |
 | `--trust` | Skip finalize script approval prompt and run all scripts |
 

--- a/apps/docs/test/components/recipe-builder/recipe-builder-form.unit.test.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-builder-form.unit.test.ts
@@ -3,11 +3,28 @@ import { describe, expect, it } from "vitest";
 import {
   initialRecipeBuilderValues,
   RecipeBuilderFormSchema,
+  toRecipePreviewInput,
 } from "../../../app/components/recipe-builder/form";
 
 const decodeForm = Schema.decodeUnknownOption(RecipeBuilderFormSchema);
 
 describe("recipe builder form", () => {
+  it("defaults infrastructure to none and carries Cloudflare intent only when selected", () => {
+    expect(initialRecipeBuilderValues.config.infrastructure).toBe("none");
+    expect(
+      toRecipePreviewInput(initialRecipeBuilderValues).config.infrastructure,
+    ).toBeUndefined();
+    expect(
+      toRecipePreviewInput({
+        ...initialRecipeBuilderValues,
+        config: {
+          ...initialRecipeBuilderValues.config,
+          infrastructure: "cloudflare",
+        },
+      }).config.infrastructure,
+    ).toBe("cloudflare");
+  });
+
   it("should reject a target name when it is outside the canonical path format", () => {
     const result = decodeForm({
       ...initialRecipeBuilderValues,

--- a/apps/docs/test/components/recipe-builder/recipe-builder-url.unit.test.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-builder-url.unit.test.ts
@@ -6,6 +6,37 @@ import {
 import { fullStackRecipeFixture } from "./recipe-fixtures";
 
 describe("recipe builder URL", () => {
+  it("omits default infrastructure and round trips Cloudflare canonically", () => {
+    expect(
+      encodeRecipeBuilderUrl(fullStackRecipeFixture).has("infrastructure"),
+    ).toBe(false);
+    const encoded = encodeRecipeBuilderUrl({
+      ...fullStackRecipeFixture,
+      config: {
+        ...fullStackRecipeFixture.config,
+        infrastructure: "cloudflare",
+      },
+    });
+    expect(encoded.get("infrastructure")).toBe("cloudflare");
+    const decoded = decodeRecipeBuilderUrl(encoded);
+    expect(decoded.issue).toBeUndefined();
+    expect(decoded.initialValues.config.infrastructure).toBe("cloudflare");
+    expect(encodeRecipeBuilderUrl(decoded.initialValues).toString()).toBe(
+      encoded.toString(),
+    );
+  });
+
+  it("rejects unknown and duplicate infrastructure parameters", () => {
+    [
+      "?infrastructure=aws",
+      "?infrastructure=none&infrastructure=cloudflare",
+    ].forEach((search) =>
+      expect(
+        decodeRecipeBuilderUrl(new URLSearchParams(search)).issue,
+      ).toBeDefined(),
+    );
+  });
+
   it("round trips a create-compatible recipe without form bookkeeping", () => {
     const encoded = encodeRecipeBuilderUrl(fullStackRecipeFixture);
     const decoded = decodeRecipeBuilderUrl(encoded);

--- a/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
+++ b/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
@@ -57,7 +57,11 @@ vi.mock("../../../app/atom/recipe-builder-atom", async () => {
       identity,
     }));
     return {
-      command: `bunx stack-effect create ${input.config.name}`,
+      command: `bunx stack-effect create ${input.config.name}${
+        input.config.infrastructure === "cloudflare"
+          ? " --infrastructure cloudflare"
+          : ""
+      }`,
       selection: { targets },
       blueprint: { nodes: blueprintTargets, edges: [] },
       files: [
@@ -225,6 +229,120 @@ test("should replace valid URL edits and reset the existing form for external na
   await expect
     .element(page.getByLabelText("Project name"))
     .toHaveValue("my-effect-app");
+});
+
+test("should preserve selections while Cloudflare advisory policy is toggled", async () => {
+  await renderRecipeBuilder();
+
+  await page.getByRole("button", { name: "Client React Application" }).click();
+  await page.getByText("HTTP API Client", { exact: true }).click();
+  await page.getByLabelText("Infrastructure as Effects").click();
+  await page.getByRole("option", { name: "Cloudflare" }).click();
+
+  await expect
+    .element(page.getByRole("checkbox", { name: /HTTP API Client/u }))
+    .toBeChecked();
+  await expect
+    .element(
+      page.getByText(/backend-dependent module is not supported/i).first(),
+    )
+    .toBeVisible();
+  await page.getByRole("button", { name: "Add target" }).click();
+  await expect
+    .element(page.getByRole("button", { name: "Server Application" }).first())
+    .toBeDisabled();
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .toHaveTextContent("infrastructure=cloudflare");
+
+  await page.getByLabelText("Infrastructure as Effects").click();
+  await page.getByRole("option", { name: "None" }).click();
+  await page.getByRole("tab", { name: /web · client-react/u }).click();
+  await expect
+    .element(page.getByRole("checkbox", { name: /HTTP API Client/u }))
+    .toBeChecked();
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .not.toHaveTextContent("infrastructure");
+
+  await page.getByLabelText("Infrastructure as Effects").click();
+  await page.getByRole("option", { name: "Cloudflare" }).click();
+  await expect
+    .element(page.getByRole("tab", { name: /web · client-react/u }))
+    .toBeVisible();
+  await expect.element(page.getByLabelText("Target name")).toHaveValue("web");
+  await expect
+    .element(page.getByRole("checkbox", { name: /HTTP API Client/u }))
+    .toBeChecked();
+});
+
+test("should allow the first React target but disable a second under Cloudflare", async () => {
+  await renderRecipeBuilder();
+
+  await page.getByLabelText("Infrastructure as Effects").click();
+  await page.getByRole("option", { name: "Cloudflare" }).click();
+
+  await expect
+    .element(page.getByRole("button", { name: "Client React Application" }))
+    .toBeEnabled();
+  const server = page
+    .getByRole("button", { name: "Server Application" })
+    .first();
+  await expect.element(server).toBeDisabled();
+  await expect
+    .element(
+      page
+        .getByText(
+          "This first Alchemy/Cloudflare slice supports only Client React and requires exactly one target.",
+        )
+        .first(),
+    )
+    .toBeVisible();
+
+  await page.getByRole("button", { name: "Client React Application" }).click();
+  await expect
+    .element(page.getByRole("tab", { name: /web · client-react/u }))
+    .toBeVisible();
+  await page.getByRole("button", { name: "Add target" }).click();
+
+  await expect
+    .element(page.getByRole("button", { name: "Client React Application" }))
+    .toBeDisabled();
+  await expect
+    .element(
+      page.getByText(
+        "This first Alchemy/Cloudflare slice supports exactly one Client React target; remove the selected React target before adding another.",
+      ),
+    )
+    .toBeVisible();
+});
+
+test("should render a visible reason referenced by every disabled Cloudflare target", async () => {
+  await renderRecipeBuilder();
+
+  await page.getByLabelText("Infrastructure as Effects").click();
+  await page.getByRole("option", { name: "Cloudflare" }).click();
+
+  const targetButtons = await page
+    .getByLabelText("Available target types")
+    .getByRole("button")
+    .all();
+  const disabledButtons = [];
+  for (const button of targetButtons) {
+    const element = button.element();
+    if (element instanceof HTMLButtonElement && element.disabled) {
+      disabledButtons.push(button);
+    }
+  }
+  expect(disabledButtons.length).toBeGreaterThan(0);
+  for (const button of disabledButtons) {
+    const reasonId = button.element().getAttribute("aria-describedby");
+    expect(reasonId).toBeTruthy();
+    const reason = document.getElementById(reasonId ?? "");
+    expect(reason).not.toBeNull();
+    expect(reason?.hidden).toBe(false);
+    expect(reason?.textContent?.trim().length).toBeGreaterThan(0);
+  }
 });
 
 test("should generate a usable preview when the user completes a valid Selection", async () => {

--- a/apps/docs/test/components/recipe-builder/recipe-fixtures.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-fixtures.ts
@@ -240,6 +240,7 @@ export const fullStackRecipeFixture: RecipeBuilderFormValues = {
     lint: "biome",
     format: "biome",
     test: "vitest",
+    infrastructure: "none",
   },
   gitEnabled: true,
   database: "none",

--- a/apps/docs/test/components/recipe-builder/target-selector/state.unit.test.ts
+++ b/apps/docs/test/components/recipe-builder/target-selector/state.unit.test.ts
@@ -3,6 +3,8 @@ import { assert, describe, expect, it } from "vitest";
 import type { SupportSelection } from "../../../../app/components/recipe-builder/form";
 import {
   buildModuleRelationshipNodes,
+  infrastructureModuleDisabledReason,
+  infrastructureTargetDisabledReason,
   makeTargetInstance,
   moduleRequiresCapability,
   removeModuleSupportSelections,
@@ -64,6 +66,37 @@ const unrelatedModuleFixture = makeCatalogModule({
 });
 
 describe("recipe builder state", () => {
+  it("projects the Cloudflare first-slice target and module policy without changing selections", () => {
+    expect(
+      infrastructureTargetDisabledReason("cloudflare", "client-react"),
+    ).toBeUndefined();
+    expect(infrastructureTargetDisabledReason("cloudflare", "server")).toBe(
+      "This first Alchemy/Cloudflare slice supports only Client React and requires exactly one target.",
+    );
+    expect(
+      infrastructureTargetDisabledReason("cloudflare", "client-react", [
+        { kind: "client-react" },
+      ]),
+    ).toBe(
+      "This first Alchemy/Cloudflare slice supports exactly one Client React target; remove the selected React target before adding another.",
+    );
+    expect(
+      infrastructureModuleDisabledReason(
+        "cloudflare",
+        "client-react-web-worker",
+      ),
+    ).toBeUndefined();
+    expect(
+      infrastructureModuleDisabledReason("cloudflare", "client-react-devtools"),
+    ).toBeUndefined();
+    expect(
+      infrastructureModuleDisabledReason("cloudflare", "client-react-http-api"),
+    ).toMatch(/backend/i);
+    expect(
+      infrastructureTargetDisabledReason("none", "server"),
+    ).toBeUndefined();
+  });
+
   it("should find a required capability through module dependencies", () => {
     const repository = makeCatalogModule({
       id: "package-db-todo-repository",

--- a/apps/docs/test/workers/recipe-builder.browser.test.ts
+++ b/apps/docs/test/workers/recipe-builder.browser.test.ts
@@ -45,6 +45,44 @@ it.live(
 );
 
 it.live(
+  "should preserve Cloudflare intent across the browser Worker preview boundary",
+  () =>
+    Effect.gen(function* () {
+      const input = toRecipePreviewInput({
+        ...fullStackRecipeFixture,
+        config: {
+          ...fullStackRecipeFixture.config,
+          infrastructure: "cloudflare",
+        },
+        targets: [
+          {
+            id: "client-1",
+            kind: "client-react",
+            name: "web",
+            modules: ["config-typescript-vite", "client-react-web-worker"],
+          },
+        ],
+        database: "none",
+      });
+      const preview = yield* runAtom(previewAtom, {
+        targetIdentityKey: "cloudflare-react",
+        input,
+      });
+
+      assert.strictEqual(input.config.infrastructure, "cloudflare");
+      assert.include(preview.preview.command, "--infrastructure cloudflare");
+      assert.strictEqual(
+        preview.preview.selection.domains?.[0]?.option,
+        "cloudflare",
+      );
+      assert.strictEqual(
+        preview.preview.blueprint.domainBindings?.[0]?.targetId,
+        "apps/client-react-web",
+      );
+    }),
+);
+
+it.live(
   "should return flattened catalog relationships when catalog data crosses the browser Worker boundary",
   () =>
     Effect.gen(function* () {

--- a/packages/catalog/src/CatalogService.ts
+++ b/packages/catalog/src/CatalogService.ts
@@ -1,6 +1,8 @@
 import type {
   CatalogGraph,
   CatalogTree,
+  GenerationDomainId,
+  GenerationDomainOptionId,
   ModuleCapability,
   ModuleCategory,
   ModuleChild,
@@ -20,6 +22,10 @@ import {
   Match,
   Result,
 } from "effect";
+import {
+  generationDomainRegistry,
+  generationDomainTargetAdapterRegistry,
+} from "./registry/generationDomainRegistry";
 import { moduleRegistry } from "./registry/moduleRegistry";
 import { targetRegistry } from "./registry/targetRegistry";
 
@@ -107,6 +113,30 @@ export class CatalogService extends Context.Service<CatalogService>()(
     make: Effect.gen(function* () {
       const targetIndex = new Map(targetRegistry.map((t) => [t.kind, t]));
       const moduleIndex = new Map(moduleRegistry.map((m) => [m.id, m]));
+      const generationDomainOptionIndex = new Map<
+        string,
+        (typeof generationDomainRegistry)[number]["options"][number]
+      >(
+        Arr.flatMap(generationDomainRegistry, (domain) =>
+          Arr.map(
+            domain.options,
+            (option) => [`${domain.id}/${option.id}`, option] as const,
+          ),
+        ),
+      );
+      const generationDomainAdapterIndex = new Map<
+        string,
+        (typeof generationDomainTargetAdapterRegistry)[number]
+      >(
+        Arr.map(
+          generationDomainTargetAdapterRegistry,
+          (adapter) =>
+            [
+              `${adapter.domainId}/${adapter.optionId}/${adapter.targetKind}`,
+              adapter,
+            ] as const,
+        ),
+      );
 
       const capabilityProviderIndex = Arr.reduce(
         moduleRegistry,
@@ -442,7 +472,52 @@ export class CatalogService extends Context.Service<CatalogService>()(
         })),
       };
 
+      const getGenerationDomainOption = Effect.fn(
+        "CatalogService.getGenerationDomainOption",
+      )(function* (
+        domainId: typeof GenerationDomainId.Type,
+        optionId: typeof GenerationDomainOptionId.Type,
+      ) {
+        const key = `${domainId}/${optionId}`;
+        return yield* Effect.fromNullishOr(
+          generationDomainOptionIndex.get(key),
+        ).pipe(
+          Effect.mapError(
+            () =>
+              new CatalogNotFound({
+                catalog: "generation-domain",
+                entity: "generation-domain-option",
+                id: key,
+              }),
+          ),
+        );
+      });
+
+      const getGenerationDomainTargetAdapter = Effect.fn(
+        "CatalogService.getGenerationDomainTargetAdapter",
+      )(function* (
+        domainId: typeof GenerationDomainId.Type,
+        optionId: typeof GenerationDomainOptionId.Type,
+        targetKind: typeof TargetKind.Type,
+      ) {
+        const key = `${domainId}/${optionId}/${targetKind}`;
+        return yield* Effect.fromNullishOr(
+          generationDomainAdapterIndex.get(key),
+        ).pipe(
+          Effect.mapError(
+            () =>
+              new CatalogNotFound({
+                catalog: "generation-domain",
+                entity: "generation-domain-adapter",
+                id: key,
+              }),
+          ),
+        );
+      });
+
       return {
+        getGenerationDomainOption,
+        getGenerationDomainTargetAdapter,
         getImplications,
         getCapabilityProviders,
         getModules,

--- a/packages/catalog/src/GenerationDomainRegistry.test.ts
+++ b/packages/catalog/src/GenerationDomainRegistry.test.ts
@@ -259,6 +259,27 @@ describe("generation domain registry", () => {
               }),
               expect.objectContaining({
                 _tag: "pkg-json-entry",
+                path: "package.json",
+                field: "dependencies",
+                name: "effect",
+                value: "4.0.0-rc.111",
+              }),
+              expect.objectContaining({
+                _tag: "pkg-json-entry",
+                path: "package.json",
+                field: "dependencies",
+                name: "@effect/platform-node",
+                value: "4.0.0-rc.111",
+              }),
+              expect.objectContaining({
+                _tag: "pkg-json-entry",
+                path: "package.json",
+                field: "dependencies",
+                name: "@effect/platform-bun",
+                value: "4.0.0-rc.111",
+              }),
+              expect.objectContaining({
+                _tag: "pkg-json-entry",
                 field: "scripts",
                 name: "infra:deploy",
                 value: "alchemy deploy",
@@ -279,6 +300,13 @@ describe("generation domain registry", () => {
             ["infra:destroy", "alchemy destroy"],
           ]);
           expect(entries.some((entry) => entry.name === "dev")).toBe(false);
+          expect(option.nextSteps).toEqual([
+            "Run infra:dev for credential-free local Alchemy startup; it must not contact Cloudflare.",
+            "Before infra:plan, infra:deploy, or infra:destroy, supply credentials through Alchemy and Cloudflare's documented external configuration.",
+            "Those remote commands may inspect, create, mutate, or delete real provider state and are not covered by local acceptance.",
+            "Local acceptance does not prove workers.dev, edge upload, TLS, global routing, provider authentication, or remote destroy.",
+            "Never place secrets in generated source or public Vite configuration.",
+          ]);
           expect(adapter.contributions).toHaveLength(1);
           const stackContribution = adapter.contributions[0];
           expect(stackContribution).toMatchObject({
@@ -292,6 +320,12 @@ describe("generation domain registry", () => {
           );
           expect(stackContribution.contents).toContain(
             'notFoundHandling: "single-page-application"',
+          );
+          expect(stackContribution.contents).toContain(
+            "state: Alchemy.localState()",
+          );
+          expect(stackContribution.contents).not.toContain(
+            "Cloudflare.state()",
           );
           expect(stackContribution.contents).toContain("yield* Alchemy.Stage");
           expect(stackContribution.contents).toContain("url: website.url");

--- a/packages/catalog/src/GenerationDomainRegistry.test.ts
+++ b/packages/catalog/src/GenerationDomainRegistry.test.ts
@@ -1,14 +1,233 @@
 import { layer } from "@effect/vitest";
 import {
+  GenerationDomainAdapterId,
   GenerationDomainId,
   GenerationDomainOptionId,
+  TargetIdentity,
   TargetKind,
 } from "@repo/domain/Catalog";
+import { ContributionTokenContext, StackConfig } from "@repo/domain/Scaffold";
 import { Effect } from "effect";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { CatalogService } from "./CatalogService";
+import { alchemyRunContents } from "./registry/content/infrastructure";
 
 describe("generation domain registry", () => {
+  const generateAlchemySource = (projectName: string, targetName = "web") => {
+    const identity = new TargetIdentity({
+      kind: TargetKind.make("client-react"),
+      name: targetName,
+    });
+    return new ContributionTokenContext({
+      targetKey: identity.toKey(),
+      identity,
+      config: new StackConfig({
+        name: projectName,
+        runtime: { _tag: "bun" },
+        infrastructure: "cloudflare",
+      }),
+      generationDomainAdapterId: GenerationDomainAdapterId.make(
+        "cloudflare-website-vite",
+      ),
+    }).resolve(alchemyRunContents);
+  };
+
+  const generatedIdentities = (source: string) => ({
+    stackName: source.match(/Alchemy\.Stack\(\n  "([^"]+)"/)?.[1],
+    resourceId: source.match(/const resourceId = "([^"]+)"/)?.[1],
+    targetId: source.match(/const targetId = "([^"]+)"/)?.[1],
+    rootDir: source.match(/rootDir: "([^"]+)"/)?.[1],
+  });
+
+  const expectGeneratedSourceToParse = (source: string) => {
+    const scriptBody = source
+      .replaceAll(/^import .*;$/gm, "")
+      .replace("export default", "return");
+    expect(() => Function(scriptBody)).not.toThrow();
+  };
+
+  it("keeps all reproduced colliding project names distinct and repeatable", () => {
+    const projectNames = ["acme$?(", "acme$\\+", "acme?)", "acme}+"];
+    const identities = projectNames.map((projectName) =>
+      generatedIdentities(generateAlchemySource(projectName)),
+    );
+
+    expect(
+      projectNames.map((projectName) =>
+        generatedIdentities(generateAlchemySource(projectName)),
+      ),
+    ).toEqual(identities);
+    expect(new Set(identities.map(({ stackName }) => stackName)).size).toBe(4);
+    expect(new Set(identities.map(({ resourceId }) => resourceId)).size).toBe(
+      4,
+    );
+    for (const { stackName, resourceId } of identities) {
+      expect(stackName).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      expect(resourceId).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("keeps sanitized-equivalent target names distinct without changing canonical paths", () => {
+    const targetNames = ["web$?(", "web$\\+", "web?)", "web}+"];
+    const identities = targetNames.map((targetName) =>
+      generatedIdentities(generateAlchemySource("acme", targetName)),
+    );
+
+    expect(
+      targetNames.map((targetName) =>
+        generatedIdentities(generateAlchemySource("acme", targetName)),
+      ),
+    ).toEqual(identities);
+    expect(new Set(identities.map(({ resourceId }) => resourceId)).size).toBe(
+      4,
+    );
+    expect(identities.map(({ targetId }) => targetId)).toEqual(
+      Array.from({ length: 4 }, () => "apps/client-react-web"),
+    );
+    expect(identities.map(({ rootDir }) => rootDir)).toEqual(
+      Array.from({ length: 4 }, () => "apps/client-react-web"),
+    );
+    for (const { stackName, resourceId } of identities) {
+      expect(stackName).toBe("acme");
+      expect(resourceId).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("keeps provider identities distinct when accepted project names share a slug", () => {
+    const first = generatedIdentities(generateAlchemySource("acme@$"));
+    const second = generatedIdentities(generateAlchemySource("acme!%"));
+
+    expect(first).toMatchObject({
+      stackName: "se-encoded-acme-x61636d654024",
+      resourceId:
+        "se-encoded-acme-x61636d654024-cloudflare-website-vite-web-e3e1cb13",
+    });
+    expect(second).toMatchObject({
+      stackName: "se-encoded-acme-x61636d652125",
+      resourceId:
+        "se-encoded-acme-x61636d652125-cloudflare-website-vite-web-e3e1cb13",
+    });
+    expect(first.stackName).not.toBe(second.stackName);
+    expect(first.resourceId).not.toBe(second.resourceId);
+  });
+
+  it("keeps encoded, canonical, reserved, and whitespace identities distinct", () => {
+    const projectNames = [
+      "!",
+      "se-encoded-project-x21",
+      "project-x-21",
+      "A",
+      "a-x-41",
+    ];
+    const projectSources = projectNames.map((projectName) =>
+      generateAlchemySource(projectName),
+    );
+    const projectIdentities = projectSources.map(generatedIdentities);
+
+    expect(projectIdentities.map(({ stackName }) => stackName)).toEqual([
+      "se-encoded-project-x21",
+      "se-encoded-se-encoded-project-x-21-x73652d656e636f6465642d70726f6a6563742d783231",
+      "project-x-21",
+      "se-encoded-a-x41",
+      "a-x-41",
+    ]);
+    expect(
+      new Set(projectIdentities.map(({ stackName }) => stackName)),
+    ).toHaveLength(projectNames.length);
+
+    const targetNames = [
+      "!",
+      "project-x-21",
+      "A",
+      "a-x-41",
+      "se-encoded-client-react-x21",
+      "",
+      " ",
+      "\t",
+    ];
+    const targetSources = targetNames.map((targetName) =>
+      generateAlchemySource("stack-effect", targetName),
+    );
+    const targetIdentities = targetSources.map(generatedIdentities);
+
+    expect(
+      new Set(targetIdentities.map(({ resourceId }) => resourceId)),
+    ).toHaveLength(targetNames.length);
+    expect(
+      targetIdentities.slice(-3).map(({ targetId, rootDir }) => ({
+        targetId,
+        rootDir,
+      })),
+    ).toEqual(
+      Array.from({ length: 3 }, () => ({
+        targetId: "apps/client-react",
+        rootDir: "apps/client-react",
+      })),
+    );
+    expect(
+      new Set(
+        targetIdentities
+          .slice(-3)
+          .map(({ resourceId }) => resourceId?.slice(-8)),
+      ),
+    ).toHaveLength(1);
+
+    for (const source of [...projectSources, ...targetSources]) {
+      expectGeneratedSourceToParse(source);
+    }
+  });
+
+  it("repeats identities and preserves canonical simple-name bytes", () => {
+    const first = generatedIdentities(generateAlchemySource("catalog-built"));
+    const repeated = generatedIdentities(
+      generateAlchemySource("catalog-built"),
+    );
+    const stackEffect = generatedIdentities(
+      generateAlchemySource("stack-effect"),
+    );
+
+    expect(first).toEqual(repeated);
+    expect(first).toMatchObject({
+      stackName: "catalog-built",
+      resourceId: "catalog-built-cloudflare-website-vite-web-e0de8a05",
+    });
+    expect(stackEffect).toMatchObject({
+      stackName: "stack-effect",
+      resourceId: "stack-effect-cloudflare-website-vite-web-28b6f049",
+    });
+  });
+
+  it("generates provider-safe Alchemy identifiers for accepted quoted names", () => {
+    const identity = new TargetIdentity({
+      kind: TargetKind.make("client-react"),
+      name: 'Admin "UI"',
+    });
+    const source = new ContributionTokenContext({
+      targetKey: identity.toKey(),
+      identity,
+      config: new StackConfig({
+        name: 'Acme "Cloud"',
+        runtime: { _tag: "bun" },
+        infrastructure: "cloudflare",
+      }),
+      generationDomainAdapterId: GenerationDomainAdapterId.make(
+        "cloudflare-website-vite",
+      ),
+    }).resolve(alchemyRunContents);
+
+    expect(source).toContain('const targetId = "apps/client-react-admin-ui";');
+    expect(source).toContain(
+      'const resourceId = "se-encoded-acme-cloud-x41636d652022436c6f756422-cloudflare-website-vite-se-encoded-admin-ui-x41646d696e2022554922-',
+    );
+    expect(source).toContain('rootDir: "apps/client-react-admin-ui"');
+    expect(source).toContain(
+      'Alchemy.Stack(\n  "se-encoded-acme-cloud-x41636d652022436c6f756422",',
+    );
+    expectGeneratedSourceToParse(source);
+    expect(source).not.toContain('Admin "UI"');
+    expect(source).not.toContain('Acme "Cloud"');
+  });
+
   layer(CatalogService.layer)("lookup", (it) => {
     it.effect(
       "looks up an option and exact target-kind adapter generically",
@@ -29,6 +248,60 @@ describe("generation domain registry", () => {
             maximumBindings: 1,
           });
           expect(adapter.adapterId).toBe("cloudflare-website-vite");
+          expect(option.rootContributions).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                _tag: "pkg-json-entry",
+                path: "package.json",
+                field: "dependencies",
+                name: "alchemy",
+                value: "2.0.0-beta.73",
+              }),
+              expect.objectContaining({
+                _tag: "pkg-json-entry",
+                field: "scripts",
+                name: "infra:deploy",
+                value: "alchemy deploy",
+              }),
+            ]),
+          );
+          const entries = option.rootContributions.filter(
+            (contribution) => contribution._tag === "pkg-json-entry",
+          );
+          expect(
+            entries
+              .filter((entry) => entry.field === "scripts")
+              .map(({ name, value }) => [name, value]),
+          ).toEqual([
+            ["infra:plan", "alchemy plan"],
+            ["infra:dev", "alchemy dev"],
+            ["infra:deploy", "alchemy deploy"],
+            ["infra:destroy", "alchemy destroy"],
+          ]);
+          expect(entries.some((entry) => entry.name === "dev")).toBe(false);
+          expect(adapter.contributions).toHaveLength(1);
+          const stackContribution = adapter.contributions[0];
+          expect(stackContribution).toMatchObject({
+            _tag: "file",
+            path: "alchemy.run.ts",
+          });
+          expect(stackContribution?._tag).toBe("file");
+          if (stackContribution?._tag !== "file") return;
+          expect(stackContribution.contents).toContain(
+            'rootDir: "{{targetPath}}"',
+          );
+          expect(stackContribution.contents).toContain(
+            'notFoundHandling: "single-page-application"',
+          );
+          expect(stackContribution.contents).toContain("yield* Alchemy.Stage");
+          expect(stackContribution.contents).toContain("url: website.url");
+          expect(stackContribution.contents).toContain("urls: website.urls");
+          expect(
+            stackContribution.contents.match(/Alchemy\.Stack\(/g),
+          ).toHaveLength(1);
+          expect(
+            stackContribution.contents.match(/Cloudflare\.Website\.Vite\(/g),
+          ).toHaveLength(1);
         }),
     );
   });

--- a/packages/catalog/src/GenerationDomainRegistry.test.ts
+++ b/packages/catalog/src/GenerationDomainRegistry.test.ts
@@ -1,0 +1,35 @@
+import { layer } from "@effect/vitest";
+import {
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  TargetKind,
+} from "@repo/domain/Catalog";
+import { Effect } from "effect";
+import { describe, expect } from "vitest";
+import { CatalogService } from "./CatalogService";
+
+describe("generation domain registry", () => {
+  layer(CatalogService.layer)("lookup", (it) => {
+    it.effect(
+      "looks up an option and exact target-kind adapter generically",
+      () =>
+        Effect.gen(function* () {
+          const catalog = yield* CatalogService;
+          const option = yield* catalog.getGenerationDomainOption(
+            GenerationDomainId.make("infrastructure"),
+            GenerationDomainOptionId.make("cloudflare"),
+          );
+          const adapter = yield* catalog.getGenerationDomainTargetAdapter(
+            GenerationDomainId.make("infrastructure"),
+            GenerationDomainOptionId.make("cloudflare"),
+            TargetKind.make("client-react"),
+          );
+          expect(option).toMatchObject({
+            minimumBindings: 1,
+            maximumBindings: 1,
+          });
+          expect(adapter.adapterId).toBe("cloudflare-website-vite");
+        }),
+    );
+  });
+});

--- a/packages/catalog/src/registry/content/infrastructure.ts
+++ b/packages/catalog/src/registry/content/infrastructure.ts
@@ -9,7 +9,7 @@ export default Alchemy.Stack(
   "{{providerSafeProjectName}}",
   {
     providers: Cloudflare.providers(),
-    state: Cloudflare.state(),
+    state: Alchemy.localState(),
   },
   Effect.gen(function* () {
     const stage = yield* Alchemy.Stage;

--- a/packages/catalog/src/registry/content/infrastructure.ts
+++ b/packages/catalog/src/registry/content/infrastructure.ts
@@ -1,0 +1,32 @@
+export const alchemyRunContents = `import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+const targetId = "{{targetKey}}";
+const resourceId = "{{providerSafeProjectName}}-{{generationDomainAdapterId}}-{{providerSafeTargetName}}-{{stableIdentityHash}}";
+
+export default Alchemy.Stack(
+  "{{providerSafeProjectName}}",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const stage = yield* Alchemy.Stage;
+    const website = yield* Cloudflare.Website.Vite(resourceId, {
+      rootDir: "{{targetPath}}",
+      assets: {
+        notFoundHandling: "single-page-application",
+      },
+    });
+
+    return {
+      stage,
+      targetId,
+      resourceId,
+      url: website.url,
+      urls: website.urls,
+    };
+  }),
+);
+`;

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -4,7 +4,10 @@ export const gitignoreContents = `# dependencies
 node_modules{{#if monorepo=vite-plus}}
 node_modules/.vite/task-cache{{/if}}
 
-# build
+{{#if infrastructure=cloudflare}}# infrastructure
+.alchemy/
+
+{{/if}}# build
 dist
 build
 .cache

--- a/packages/catalog/src/registry/generationDomainRegistry.ts
+++ b/packages/catalog/src/registry/generationDomainRegistry.ts
@@ -1,0 +1,49 @@
+import {
+  GenerationDomainAdapterId,
+  type GenerationDomainDefinition,
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  type GenerationDomainTargetAdapter,
+  ModuleId,
+  TargetKind,
+} from "@repo/domain/Catalog";
+
+export const generationDomainRegistry: ReadonlyArray<
+  typeof GenerationDomainDefinition.Type
+> = [
+  {
+    id: GenerationDomainId.make("infrastructure"),
+    title: "Infrastructure",
+    options: [
+      {
+        id: GenerationDomainOptionId.make("cloudflare"),
+        title: "Cloudflare",
+        minimumBindings: 1,
+        maximumBindings: 1,
+        rootContributions: [],
+        nextSteps: [],
+      },
+    ],
+  },
+];
+
+export const generationDomainTargetAdapterRegistry: ReadonlyArray<
+  typeof GenerationDomainTargetAdapter.Type
+> = [
+  {
+    domainId: GenerationDomainId.make("infrastructure"),
+    optionId: GenerationDomainOptionId.make("cloudflare"),
+    adapterId: GenerationDomainAdapterId.make("cloudflare-website-vite"),
+    targetKind: TargetKind.make("client-react"),
+    supportedSelectedModules: [
+      ModuleId.make("client-react-web-worker"),
+      ModuleId.make("client-react-devtools"),
+    ],
+    supportedResolvedModules: [
+      ModuleId.make("config-typescript-vite"),
+      ModuleId.make("client-react-web-worker"),
+      ModuleId.make("client-react-devtools"),
+    ],
+    contributions: [],
+  },
+];

--- a/packages/catalog/src/registry/generationDomainRegistry.ts
+++ b/packages/catalog/src/registry/generationDomainRegistry.ts
@@ -7,6 +7,7 @@ import {
   ModuleId,
   TargetKind,
 } from "@repo/domain/Catalog";
+import { alchemyRunContents } from "./content/infrastructure";
 
 export const generationDomainRegistry: ReadonlyArray<
   typeof GenerationDomainDefinition.Type
@@ -20,8 +21,36 @@ export const generationDomainRegistry: ReadonlyArray<
         title: "Cloudflare",
         minimumBindings: 1,
         maximumBindings: 1,
-        rootContributions: [],
-        nextSteps: [],
+        rootContributions: [
+          ...[
+            ["alchemy", "2.0.0-beta.73"],
+            ["effect", "4.0.0-rc.111"],
+            ["@effect/platform-node", "4.0.0-rc.111"],
+          ].map(([name, value]) => ({
+            _tag: "pkg-json-entry" as const,
+            path: "package.json",
+            field: "dependencies" as const,
+            name: name!,
+            value: value!,
+          })),
+          ...[
+            ["infra:plan", "alchemy plan"],
+            ["infra:dev", "alchemy dev"],
+            ["infra:deploy", "alchemy deploy"],
+            ["infra:destroy", "alchemy destroy"],
+          ].map(([name, value]) => ({
+            _tag: "pkg-json-entry" as const,
+            path: "package.json",
+            field: "scripts" as const,
+            name: name!,
+            value: value!,
+          })),
+        ],
+        nextSteps: [
+          "Configure Cloudflare credentials through Alchemy's documented environment conventions before running infrastructure commands.",
+          "Infrastructure commands may authenticate with Cloudflare and mutate real provider state; use infra:destroy for the same stage when finished.",
+          "The website URL is public. Never place secrets in generated source or public Vite configuration.",
+        ],
       },
     ],
   },
@@ -44,6 +73,12 @@ export const generationDomainTargetAdapterRegistry: ReadonlyArray<
       ModuleId.make("client-react-web-worker"),
       ModuleId.make("client-react-devtools"),
     ],
-    contributions: [],
+    contributions: [
+      {
+        _tag: "file",
+        path: "alchemy.run.ts",
+        contents: alchemyRunContents,
+      },
+    ],
   },
 ];

--- a/packages/catalog/src/registry/generationDomainRegistry.ts
+++ b/packages/catalog/src/registry/generationDomainRegistry.ts
@@ -26,6 +26,7 @@ export const generationDomainRegistry: ReadonlyArray<
             ["alchemy", "2.0.0-beta.73"],
             ["effect", "4.0.0-rc.111"],
             ["@effect/platform-node", "4.0.0-rc.111"],
+            ["@effect/platform-bun", "4.0.0-rc.111"],
           ].map(([name, value]) => ({
             _tag: "pkg-json-entry" as const,
             path: "package.json",
@@ -47,9 +48,11 @@ export const generationDomainRegistry: ReadonlyArray<
           })),
         ],
         nextSteps: [
-          "Configure Cloudflare credentials through Alchemy's documented environment conventions before running infrastructure commands.",
-          "Infrastructure commands may authenticate with Cloudflare and mutate real provider state; use infra:destroy for the same stage when finished.",
-          "The website URL is public. Never place secrets in generated source or public Vite configuration.",
+          "Run infra:dev for credential-free local Alchemy startup; it must not contact Cloudflare.",
+          "Before infra:plan, infra:deploy, or infra:destroy, supply credentials through Alchemy and Cloudflare's documented external configuration.",
+          "Those remote commands may inspect, create, mutate, or delete real provider state and are not covered by local acceptance.",
+          "Local acceptance does not prove workers.dev, edge upload, TLS, global routing, provider authentication, or remote destroy.",
+          "Never place secrets in generated source or public Vite configuration.",
         ],
       },
     ],

--- a/packages/domain/src/Blueprint.ts
+++ b/packages/domain/src/Blueprint.ts
@@ -1,6 +1,7 @@
 import { Array as Arr, Data, Order, Schema } from "effect";
 import {
   CatalogNotFound,
+  GenerationDomainBinding,
   ModuleId,
   TargetIdentity,
   TargetKey,
@@ -12,6 +13,17 @@ export { CatalogNotFound };
 export class BlueprintFailure extends Data.TaggedError("BlueprintFailure")<{
   message: string;
   cause?: unknown;
+  reason?:
+    | "binding-cardinality"
+    | "unsupported-target"
+    | "unsupported-module"
+    | "binding-target-missing";
+  domainId?: string;
+  optionId?: string;
+  targetId?: string;
+  targetIds?: ReadonlyArray<string>;
+  moduleId?: string;
+  moduleSource?: "selected" | "resolved";
 }> {}
 
 /**
@@ -65,6 +77,7 @@ const duplicates = (values: ReadonlyArray<string>): ReadonlyArray<string> =>
 
 const BlueprintFields = Schema.Struct({
   nodes: Schema.Array(BlueprintNode),
+  domainBindings: Schema.optional(Schema.Array(GenerationDomainBinding)),
   edges: Schema.Array(
     Schema.Struct({
       id: Schema.NonEmptyString,
@@ -172,6 +185,9 @@ export class Blueprint extends Schema.Class<Blueprint>("Blueprint")(
     return new Blueprint({
       nodes: [...this.nodes].sort(blueprintNodeOrd),
       edges: [...this.edges].sort(idOrd),
+      ...(this.domainBindings === undefined
+        ? {}
+        : { domainBindings: this.domainBindings }),
     });
   }
 

--- a/packages/domain/src/Catalog.ts
+++ b/packages/domain/src/Catalog.ts
@@ -1,8 +1,12 @@
 import { Data, Effect, type Graph, Schema, String as Str } from "effect";
 
 export class CatalogNotFound extends Data.TaggedError("CatalogNotFound")<{
-  catalog: "target" | "module";
-  entity: "target-kind" | "module";
+  catalog: "target" | "module" | "generation-domain";
+  entity:
+    | "target-kind"
+    | "module"
+    | "generation-domain-option"
+    | "generation-domain-adapter";
   id: string;
 }> {
   override get message(): string {
@@ -11,6 +15,57 @@ export class CatalogNotFound extends Data.TaggedError("CatalogNotFound")<{
 }
 
 export const ModuleId = Schema.String.pipe(Schema.brand("ModuleId"));
+
+export const GenerationDomainId = Schema.String.pipe(
+  Schema.brand("GenerationDomainId"),
+);
+export const GenerationDomainOptionId = Schema.String.pipe(
+  Schema.brand("GenerationDomainOptionId"),
+);
+export const GenerationDomainAdapterId = Schema.String.pipe(
+  Schema.brand("GenerationDomainAdapterId"),
+);
+
+export class GenerationDomainSelection extends Schema.Class<GenerationDomainSelection>(
+  "GenerationDomainSelection",
+)({
+  id: GenerationDomainId,
+  option: GenerationDomainOptionId,
+}) {}
+
+export class GenerationDomainBinding extends Schema.Class<GenerationDomainBinding>(
+  "GenerationDomainBinding",
+)({
+  domainId: GenerationDomainId,
+  optionId: GenerationDomainOptionId,
+  targetId: Schema.String.pipe(Schema.brand("TargetKey")),
+  adapterId: GenerationDomainAdapterId,
+}) {}
+
+export const GenerationDomainDefinition = Schema.Struct({
+  id: GenerationDomainId,
+  title: Schema.String,
+  options: Schema.Array(
+    Schema.Struct({
+      id: GenerationDomainOptionId,
+      title: Schema.String,
+      minimumBindings: Schema.Finite,
+      maximumBindings: Schema.Finite,
+      rootContributions: Schema.Array(Schema.suspend(() => Contribution)),
+      nextSteps: Schema.Array(Schema.String),
+    }),
+  ),
+});
+
+export const GenerationDomainTargetAdapter = Schema.Struct({
+  domainId: GenerationDomainId,
+  optionId: GenerationDomainOptionId,
+  adapterId: GenerationDomainAdapterId,
+  targetKind: Schema.suspend(() => TargetKind),
+  supportedSelectedModules: Schema.Array(ModuleId),
+  supportedResolvedModules: Schema.Array(ModuleId),
+  contributions: Schema.Array(Schema.suspend(() => Contribution)),
+});
 
 export const ModuleCapability = Schema.String.pipe(
   Schema.brand("ModuleCapability"),

--- a/packages/domain/src/GenerationDomain.test.ts
+++ b/packages/domain/src/GenerationDomain.test.ts
@@ -1,0 +1,72 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+import { Blueprint } from "./Blueprint";
+import {
+  GenerationDomainAdapterId,
+  GenerationDomainBinding,
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  GenerationDomainSelection,
+  ModuleId,
+  TargetKey,
+} from "./Catalog";
+import { Plan } from "./Plan";
+import { Selection } from "./Selection";
+
+const domain = new GenerationDomainSelection({
+  id: GenerationDomainId.make("deployment"),
+  option: GenerationDomainOptionId.make("fixture"),
+});
+const binding = new GenerationDomainBinding({
+  domainId: domain.id,
+  optionId: domain.option,
+  targetId: TargetKey.make("apps/client-react-web"),
+  adapterId: GenerationDomainAdapterId.make("fixture-react"),
+});
+
+describe("generation domain contracts", () => {
+  it("keeps domain intent optional for backward compatibility", () => {
+    expect(Schema.decodeSync(Selection)({ targets: [] })).toEqual({
+      targets: [],
+    });
+    expect(
+      Schema.decodeSync(Blueprint)({ nodes: [], edges: [] }).domainBindings,
+    ).toBeUndefined();
+    expect(
+      Schema.decodeSync(Plan)({ outcomes: [], conflicts: [] })
+        .generationDomains,
+    ).toBeUndefined();
+  });
+
+  it("round-trips provider-neutral selection, binding, and Plan metadata", () => {
+    expect(
+      Schema.decodeSync(Selection)({ targets: [], domains: [domain] }).domains,
+    ).toEqual([domain]);
+    expect(
+      Schema.decodeSync(Blueprint)({
+        nodes: [],
+        edges: [],
+        domainBindings: [binding],
+      }).domainBindings,
+    ).toEqual([binding]);
+    expect(
+      Schema.decodeSync(Plan)({
+        outcomes: [],
+        conflicts: [],
+        generationDomains: [{ selection: domain, bindings: [binding] }],
+      }).generationDomains,
+    ).toEqual([{ selection: domain, bindings: [binding] }]);
+  });
+
+  it("rejects duplicate generation-domain selections", () => {
+    expect(() =>
+      Schema.decodeSync(Selection)({ targets: [], domains: [domain, domain] }),
+    ).toThrow(/unique/);
+  });
+
+  it("retains module identities in adapter policy", () => {
+    expect(ModuleId.make("client-react-web-worker")).toBe(
+      "client-react-web-worker",
+    );
+  });
+});

--- a/packages/domain/src/InfrastructureConfig.test.ts
+++ b/packages/domain/src/InfrastructureConfig.test.ts
@@ -1,0 +1,42 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+import { StackConfig } from "./Scaffold";
+
+const base = { name: "demo", runtime: { _tag: "bun" as const } };
+
+describe("StackConfig infrastructure", () => {
+  it("defaults absent infrastructure to effective none and encodes it absent", () => {
+    const config = Schema.decodeSync(StackConfig)(base);
+    expect(config.effectiveInfrastructure).toBe("none");
+    expect(Schema.encodeSync(StackConfig)(config)).toEqual(base);
+  });
+
+  it("canonicalizes persisted explicit none to the exact absent/default bytes", () => {
+    const encodePersisted = Schema.encodeSync(
+      Schema.fromJsonString(StackConfig),
+    );
+    const absent = encodePersisted(Schema.decodeSync(StackConfig)(base));
+    const explicitNone = encodePersisted(
+      Schema.decodeSync(StackConfig)({ ...base, infrastructure: "none" }),
+    );
+
+    expect(explicitNone).toBe(absent);
+    expect(explicitNone).toBe('{"name":"demo","runtime":{"_tag":"bun"}}');
+  });
+
+  it("accepts explicit none and Cloudflare without accepting unknown providers", () => {
+    const explicitNone = Schema.decodeSync(StackConfig)({
+      ...base,
+      infrastructure: "none",
+    });
+    expect(explicitNone.effectiveInfrastructure).toBe("none");
+    expect(Schema.encodeSync(StackConfig)(explicitNone)).toEqual(base);
+    expect(
+      Schema.decodeSync(StackConfig)({ ...base, infrastructure: "cloudflare" })
+        .effectiveInfrastructure,
+    ).toBe("cloudflare");
+    expect(() =>
+      Schema.decodeUnknownSync(StackConfig)({ ...base, infrastructure: "aws" }),
+    ).toThrow(/none.*cloudflare|cloudflare.*none/);
+  });
+});

--- a/packages/domain/src/Plan.ts
+++ b/packages/domain/src/Plan.ts
@@ -1,4 +1,5 @@
 import { Array as Arr, Order, Schema } from "effect";
+import { GenerationDomainBinding, GenerationDomainSelection } from "./Catalog";
 import { pathOrd } from "./Order";
 import { StackConfig } from "./Scaffold";
 import { Selection } from "./Selection";
@@ -220,6 +221,14 @@ const duplicates = (values: ReadonlyArray<string>): ReadonlyArray<string> =>
 const PlanFields = Schema.Struct({
   outcomes: Schema.Array(PlanOutcome),
   conflicts: Schema.Array(PlanConflict),
+  generationDomains: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        selection: GenerationDomainSelection,
+        bindings: Schema.Array(GenerationDomainBinding),
+      }),
+    ),
+  ),
 }).check(
   Schema.makeFilter(({ conflicts, outcomes }) => {
     const outcomePaths = outcomes.map((outcome) => outcome.path);
@@ -276,6 +285,9 @@ export class Plan extends Schema.Class<Plan>("Plan")(PlanFields) {
       conflicts: [...this.conflicts].sort(
         Order.mapInput(Order.String, planConflictKey),
       ),
+      ...(this.generationDomains === undefined
+        ? {}
+        : { generationDomains: this.generationDomains }),
     });
   }
 }

--- a/packages/domain/src/Scaffold.test.ts
+++ b/packages/domain/src/Scaffold.test.ts
@@ -1,6 +1,11 @@
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
-import { TargetIdentity, TargetKey, TargetKind } from "./Catalog";
+import {
+  GenerationDomainAdapterId,
+  TargetIdentity,
+  TargetKey,
+  TargetKind,
+} from "./Catalog";
 import { ContributionTokenContext, StackConfig } from "./Scaffold";
 
 describe("@repo/domain Scaffold", () => {
@@ -374,5 +379,187 @@ line3{{/if}}`;
 line2
 line3`);
     });
+  });
+  it("resolves canonical deployment paths and deterministic distinct identity hashes", () => {
+    const makeContext = (projectName: string, targetName: string) => {
+      const identity = new TargetIdentity({
+        kind: TargetKind.make("client-react"),
+        name: targetName,
+      });
+      return new ContributionTokenContext({
+        targetKey: identity.toKey(),
+        identity,
+        config: new StackConfig({
+          name: projectName,
+          runtime: { _tag: "bun" },
+          infrastructure: "cloudflare",
+        }),
+        generationDomainAdapterId: GenerationDomainAdapterId.make(
+          "cloudflare-website-vite",
+        ),
+      });
+    };
+    const first = makeContext("acme", "web");
+    const repeated = makeContext("acme", "web");
+    const second = makeContext("acme", "admin");
+
+    expect(first.resolve("{{targetPath}}:{{stableIdentityHash}}")).toBe(
+      repeated.resolve("{{targetPath}}:{{stableIdentityHash}}"),
+    );
+    expect(first.resolve("{{targetPath}}")).toBe("apps/client-react-web");
+    expect(second.resolve("{{targetPath}}")).toBe("apps/client-react-admin");
+    expect(first.resolve("{{stableIdentityHash}}")).not.toBe(
+      second.resolve("{{stableIdentityHash}}"),
+    );
+  });
+
+  it("resolves provider-safe names without changing canonical identity tokens", () => {
+    const identity = new TargetIdentity({
+      kind: TargetKind.make("client-react"),
+      name: 'Admin "UI"',
+    });
+    const context = new ContributionTokenContext({
+      targetKey: identity.toKey(),
+      identity,
+      config: new StackConfig({
+        name: 'Acme "Cloud"',
+        runtime: { _tag: "bun" },
+        infrastructure: "cloudflare",
+      }),
+      generationDomainAdapterId: GenerationDomainAdapterId.make(
+        "cloudflare-website-vite",
+      ),
+    });
+
+    expect(
+      context.resolve("{{providerSafeProjectName}}:{{providerSafeTargetName}}"),
+    ).toBe(
+      "se-encoded-acme-cloud-x41636d652022436c6f756422:se-encoded-admin-ui-x41646d696e2022554922",
+    );
+    expect(context.resolve("{{targetKey}}:{{targetPath}}")).toBe(
+      "apps/client-react-admin-ui:apps/client-react-admin-ui",
+    );
+  });
+
+  it("encodes UTF-8 exactly while keeping Unicode names provider safe", () => {
+    const identity = new TargetIdentity({
+      kind: TargetKind.make("client-react"),
+      name: "管理 UI",
+    });
+    const context = new ContributionTokenContext({
+      targetKey: identity.toKey(),
+      identity,
+      config: new StackConfig({
+        name: "Café ☁",
+        runtime: { _tag: "bun" },
+        infrastructure: "cloudflare",
+      }),
+      generationDomainAdapterId: GenerationDomainAdapterId.make(
+        "cloudflare-website-vite",
+      ),
+    });
+    const resolved = context.resolve(
+      "{{providerSafeProjectName}}:{{providerSafeTargetName}}",
+    );
+
+    expect(resolved).toMatch(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*:[a-z0-9]+(?:-[a-z0-9]+)*$/,
+    );
+    expect(resolved).toContain("se-encoded-caf-x436166c3a920e29881");
+    expect(resolved).toContain("se-encoded-ui-xe7aea1e79086205549");
+  });
+
+  it("reserves an encoded namespace for exact project and target names", () => {
+    const resolveNames = (projectName: string, targetName: string) => {
+      const identity = new TargetIdentity({
+        kind: TargetKind.make("client-react"),
+        name: targetName,
+      });
+      const context = new ContributionTokenContext({
+        targetKey: identity.toKey(),
+        identity,
+        config: new StackConfig({
+          name: projectName,
+          runtime: { _tag: "bun" },
+          infrastructure: "cloudflare",
+        }),
+        generationDomainAdapterId: GenerationDomainAdapterId.make(
+          "cloudflare-website-vite",
+        ),
+      });
+
+      return context
+        .resolve(
+          "{{providerSafeProjectName}}:{{providerSafeTargetName}}:{{targetPath}}:{{stableIdentityHash}}",
+        )
+        .split(":");
+    };
+
+    expect(resolveNames("!", "!").slice(0, 2)).toEqual([
+      "se-encoded-project-x21",
+      "se-encoded-client-react-x21",
+    ]);
+    expect(resolveNames("project-x-21", "project-x-21").slice(0, 2)).toEqual([
+      "project-x-21",
+      "project-x-21",
+    ]);
+    expect(resolveNames("A", "A").slice(0, 2)).toEqual([
+      "se-encoded-a-x41",
+      "se-encoded-a-x41",
+    ]);
+    expect(resolveNames("a-x-41", "a-x-41").slice(0, 2)).toEqual([
+      "a-x-41",
+      "a-x-41",
+    ]);
+
+    const reserved = resolveNames(
+      "se-encoded-project-x21",
+      "se-encoded-client-react-x21",
+    );
+    expect(reserved.slice(0, 2)).toEqual([
+      "se-encoded-se-encoded-project-x-21-x73652d656e636f6465642d70726f6a6563742d783231",
+      "se-encoded-se-encoded-client-react-x-21-x73652d656e636f6465642d636c69656e742d72656163742d783231",
+    ]);
+  });
+
+  it("encodes accepted whitespace target names without collapsing raw bytes", () => {
+    const resolveTarget = (targetName: string) => {
+      const identity = new TargetIdentity({
+        kind: TargetKind.make("client-react"),
+        name: targetName,
+      });
+      const context = new ContributionTokenContext({
+        targetKey: identity.toKey(),
+        identity,
+        config: new StackConfig({
+          name: "stack-effect",
+          runtime: { _tag: "bun" },
+          infrastructure: "cloudflare",
+        }),
+        generationDomainAdapterId: GenerationDomainAdapterId.make(
+          "cloudflare-website-vite",
+        ),
+      });
+
+      const [providerName, targetPath, hash] = context
+        .resolve(
+          "{{providerSafeTargetName}}:{{targetPath}}:{{stableIdentityHash}}",
+        )
+        .split(":");
+      return { providerName, targetPath, hash };
+    };
+
+    const variants = ["", " ", "\t"].map(resolveTarget);
+    expect(variants.map(({ providerName }) => providerName)).toEqual([
+      "se-encoded-client-react-x",
+      "se-encoded-client-react-x20",
+      "se-encoded-client-react-x09",
+    ]);
+    expect(variants.map(({ targetPath }) => targetPath)).toEqual([
+      "apps/client-react",
+      "apps/client-react",
+      "apps/client-react",
+    ]);
+    expect(new Set(variants.map(({ hash }) => hash))).toHaveLength(1);
   });
 });

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -1,9 +1,24 @@
-import { Schema, SchemaGetter } from "effect";
-import { Contribution, ModuleId, TargetIdentity, TargetKey } from "./Catalog";
+import { Hash, Schema, SchemaGetter, String as Str } from "effect";
+import {
+  Contribution,
+  GenerationDomainAdapterId,
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  ModuleId,
+  TargetIdentity,
+  TargetKey,
+} from "./Catalog";
+
+export const GenerationDomainContributionProvenance = Schema.Struct({
+  domainId: GenerationDomainId,
+  optionId: GenerationDomainOptionId,
+  adapterId: Schema.optional(GenerationDomainAdapterId),
+});
 
 export const TargetContribution = Schema.Struct({
   targetKey: TargetKey,
   contributions: Schema.Array(Contribution),
+  generationDomain: Schema.optional(GenerationDomainContributionProvenance),
 });
 
 export const ModuleContribution = Schema.Struct({
@@ -82,12 +97,71 @@ export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   }
 }
 
+const toHexByte = (byte: number): string => byte.toString(16).padStart(2, "0");
+
+const encodeUtf8CodePoint = (codePoint: number): string => {
+  if (codePoint <= 0x7f) return toHexByte(codePoint);
+  if (codePoint <= 0x7ff) {
+    return [0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f)]
+      .map(toHexByte)
+      .join("");
+  }
+  if (codePoint <= 0xffff) {
+    return [
+      0xe0 | (codePoint >> 12),
+      0x80 | ((codePoint >> 6) & 0x3f),
+      0x80 | (codePoint & 0x3f),
+    ]
+      .map(toHexByte)
+      .join("");
+  }
+  return [
+    0xf0 | (codePoint >> 18),
+    0x80 | ((codePoint >> 12) & 0x3f),
+    0x80 | ((codePoint >> 6) & 0x3f),
+    0x80 | (codePoint & 0x3f),
+  ]
+    .map(toHexByte)
+    .join("");
+};
+
+const encodeUtf8Hex = (value: string): string =>
+  Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint === undefined ? "" : encodeUtf8CodePoint(codePoint);
+  }).join("");
+
+const ProviderSafeEncodedPrefix = "se-encoded-";
+const ProviderSafeIdentityPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const toProviderSafeSlug = (value: string): string =>
+  Str.kebabCase(value.trim())
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-|-$/g, "");
+
+const providerSafeIdentityComponent = (
+  rawName: string,
+  fallback: string,
+): string => {
+  if (
+    ProviderSafeIdentityPattern.test(rawName) &&
+    !rawName.startsWith(ProviderSafeEncodedPrefix)
+  ) {
+    return rawName;
+  }
+
+  const fallbackSlug = toProviderSafeSlug(fallback) || "identity";
+  const readableSlug = toProviderSafeSlug(rawName) || fallbackSlug;
+  return `${ProviderSafeEncodedPrefix}${readableSlug}-x${encodeUtf8Hex(rawName)}`;
+};
+
 export class ContributionTokenContext extends Schema.Class<ContributionTokenContext>(
   "ContributionTokenContext",
 )({
   targetKey: TargetKey,
   identity: TargetIdentity,
   config: StackConfig,
+  generationDomainAdapterId: Schema.optional(GenerationDomainAdapterId),
 }) {
   /**
    * Resolve template tokens and conditionals in a string.
@@ -118,12 +192,33 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
         : this.identity.kind;
 
     const targetPath = this.identity.toPath();
+    const providerSafeProjectName = providerSafeIdentityComponent(
+      this.config.name,
+      "project",
+    );
+    const providerSafeTargetName = providerSafeIdentityComponent(
+      this.identity.name,
+      this.identity.kind,
+    );
 
     // NOTE: Workspace targets omit "./" so token output matches contribution paths.
     const resolveTargetToken = (t: string, token: string) =>
       targetPath === "."
         ? t.replaceAll(`${token}/`, "").replaceAll(token, "")
         : t.replaceAll(token, targetPath);
+
+    const stableIdentityHash = (
+      Hash.string(
+        [
+          this.config.name,
+          this.generationDomainAdapterId ?? "",
+          this.targetKey,
+          targetPath,
+        ].join("\0"),
+      ) >>> 0
+    )
+      .toString(16)
+      .padStart(8, "0");
 
     const getConfigValue = (field: string): string => {
       switch (field) {
@@ -141,6 +236,8 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
           return this.config.test ?? "";
         case "monorepo":
           return this.config.monorepo ?? "";
+        case "infrastructure":
+          return this.config.effectiveInfrastructure;
         default:
           return "";
       }
@@ -175,6 +272,14 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
             this.config.workspaceDependency,
           )
           .replaceAll("{{projectName}}", this.config.name)
+          .replaceAll("{{providerSafeProjectName}}", providerSafeProjectName)
+          .replaceAll("{{providerSafeTargetName}}", providerSafeTargetName)
+          .replaceAll("{{targetKey}}", this.targetKey)
+          .replaceAll(
+            "{{generationDomainAdapterId}}",
+            this.generationDomainAdapterId ?? "",
+          )
+          .replaceAll("{{stableIdentityHash}}", stableIdentityHash)
           .replaceAll("{{lint}}", this.config.lint ?? "")
           .replaceAll("{{format}}", this.config.format ?? "")
           .replaceAll("{{test}}", this.config.test ?? "")

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Schema, SchemaGetter } from "effect";
 import { Contribution, ModuleId, TargetIdentity, TargetKey } from "./Catalog";
 
 export const TargetContribution = Schema.Struct({
@@ -26,6 +26,17 @@ const Runtime = Schema.TaggedUnion({
 
 export const TypeScriptVersion = Schema.Literals(["6", "7"]);
 
+const Infrastructure = Schema.optional(
+  Schema.Literals(["none", "cloudflare"]),
+).pipe(
+  Schema.decodeTo(Schema.optional(Schema.Literal("cloudflare")), {
+    decode: SchemaGetter.transform((value) =>
+      value === "none" ? undefined : value,
+    ),
+    encode: SchemaGetter.transform((value) => value),
+  }),
+);
+
 export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   name: Schema.NonEmptyString,
   runtime: Runtime,
@@ -34,7 +45,12 @@ export class StackConfig extends Schema.Class<StackConfig>("StackConfig")({
   format: Schema.optional(Schema.String),
   test: Schema.optional(Schema.String),
   monorepo: Schema.optional(Schema.String),
+  infrastructure: Infrastructure,
 }) {
+  get effectiveInfrastructure(): "none" | "cloudflare" {
+    return this.infrastructure ?? "none";
+  }
+
   get typescriptVersion(): typeof TypeScriptVersion.Type {
     return this.typescript ?? "6";
   }

--- a/packages/domain/src/Selection.ts
+++ b/packages/domain/src/Selection.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { ModuleId, TargetIdentity } from "./Catalog";
+import { GenerationDomainSelection, ModuleId, TargetIdentity } from "./Catalog";
 
 /**
  * Captures the user's explicit intent: which targets to scaffold and which
@@ -22,4 +22,12 @@ export const Selection = Schema.Struct({
       ),
     }),
   ),
-});
+  domains: Schema.optional(Schema.Array(GenerationDomainSelection)),
+}).check(
+  Schema.makeFilter((selection) => {
+    const ids = (selection.domains ?? []).map((domain) => domain.id);
+    return new Set(ids).size === ids.length
+      ? []
+      : ["Generation domain selections must be unique by id"];
+  }),
+);

--- a/packages/scaffold/src/RecipePreviewSchema.ts
+++ b/packages/scaffold/src/RecipePreviewSchema.ts
@@ -21,8 +21,8 @@ export type RecipePreviewInput = typeof RecipePreviewInput.Type;
 
 export const RecipePreview = Schema.Struct({
   command: Schema.String,
-  selection: Selection,
-  blueprint: Blueprint,
+  selection: Schema.toEncoded(Selection),
+  blueprint: Schema.toEncoded(Blueprint),
   files: Schema.Array(ApplyPreviewFileSchema),
 });
 

--- a/packages/scaffold/src/service/blueprint/BlueprintService.ts
+++ b/packages/scaffold/src/service/blueprint/BlueprintService.ts
@@ -3,11 +3,13 @@ import {
   Blueprint,
   type BlueprintAttachedModuleNode,
   BlueprintFailure,
+  BlueprintNode,
   type BlueprintTargetNode,
   type CatalogNotFound,
   toAttachedModuleNodeId,
 } from "@repo/domain/Blueprint";
 import {
+  GenerationDomainBinding,
   ModuleDependency,
   type ModuleId,
   type TargetIdentity,
@@ -48,6 +50,7 @@ export class BlueprintService extends Context.Service<BlueprintService>()(
         selection: typeof Selection.Type,
       ) {
         yield* validateSelection(selection, catalog);
+        const domainBindings = yield* resolveDomainBindings(selection, catalog);
 
         const state = yield* resolveSelection(selection, catalog);
         const finalState = yield* Ref.get(state);
@@ -58,6 +61,7 @@ export class BlueprintService extends Context.Service<BlueprintService>()(
             ...HashMap.values(finalState.attachedModules),
           ],
           edges: Arr.fromIterable(HashMap.values(finalState.edges)),
+          ...(domainBindings.length === 0 ? {} : { domainBindings }),
         }).pipe(
           Effect.mapError(
             (cause) =>
@@ -68,6 +72,7 @@ export class BlueprintService extends Context.Service<BlueprintService>()(
           ),
         );
 
+        yield* validateResolvedDomainModules(blueprint, selection, catalog);
         return blueprint.toSorted();
       });
 
@@ -75,10 +80,144 @@ export class BlueprintService extends Context.Service<BlueprintService>()(
     }),
   },
 ) {
-  static readonly layer = Layer.effect(BlueprintService)(
+  static readonly baseLayer = Layer.effect(BlueprintService)(
     BlueprintService.make,
-  ).pipe(Layer.provide(CatalogService.layer));
+  );
+
+  static readonly layer = BlueprintService.baseLayer.pipe(
+    Layer.provide(CatalogService.layer),
+  );
 }
+
+const resolveDomainBindings = Effect.fn(
+  "BlueprintService.resolveDomainBindings",
+)(function* (
+  selection: typeof Selection.Type,
+  catalog: typeof CatalogService.Service,
+) {
+  return yield* Effect.forEach(selection.domains ?? [], (domain) =>
+    Effect.gen(function* () {
+      const option = yield* catalog.getGenerationDomainOption(
+        domain.id,
+        domain.option,
+      );
+      const candidates = Arr.filter(
+        selection.targets,
+        (target) => target.identity.kind !== "workspace",
+      );
+      if (
+        candidates.length < option.minimumBindings ||
+        candidates.length > option.maximumBindings
+      ) {
+        const targetIds = Arr.map(candidates, (candidate) =>
+          candidate.identity.toKey(),
+        );
+        return yield* new BlueprintFailure({
+          message: `Generation domain ${domain.id}/${domain.option} requires ${option.minimumBindings}-${option.maximumBindings} explicit deployable targets; received ${candidates.length}: ${Arr.join(targetIds, ", ")}`,
+          reason: "binding-cardinality",
+          domainId: domain.id,
+          optionId: domain.option,
+          targetIds,
+        });
+      }
+      return yield* Effect.forEach(candidates, (candidate) =>
+        catalog
+          .getGenerationDomainTargetAdapter(
+            domain.id,
+            domain.option,
+            candidate.identity.kind,
+          )
+          .pipe(
+            Effect.mapError(
+              () =>
+                new BlueprintFailure({
+                  message: `Unsupported target ${candidate.identity.toKey()} for generation domain ${domain.id}/${domain.option}`,
+                  reason: "unsupported-target",
+                  domainId: domain.id,
+                  optionId: domain.option,
+                  targetId: candidate.identity.toKey(),
+                }),
+            ),
+            Effect.flatMap((adapter) => {
+              const unsupported = Arr.filter(
+                candidate.modules,
+                (module) =>
+                  !adapter.supportedSelectedModules.includes(module.id),
+              );
+              return unsupported.length === 0
+                ? Effect.succeed(
+                    new GenerationDomainBinding({
+                      domainId: domain.id,
+                      optionId: domain.option,
+                      targetId: candidate.identity.toKey(),
+                      adapterId: adapter.adapterId,
+                    }),
+                  )
+                : Effect.fail(
+                    new BlueprintFailure({
+                      message: `Unsupported selected module ${unsupported[0]?.id} on ${candidate.identity.toKey()} for generation domain ${domain.id}/${domain.option}`,
+                      reason: "unsupported-module",
+                      domainId: domain.id,
+                      optionId: domain.option,
+                      targetId: candidate.identity.toKey(),
+                      moduleId: unsupported[0]!.id,
+                      moduleSource: "selected",
+                    }),
+                  );
+            }),
+          ),
+      );
+    }),
+  ).pipe(Effect.map(Arr.flatten));
+});
+
+const validateResolvedDomainModules = Effect.fn(
+  "BlueprintService.validateResolvedDomainModules",
+)(function* (
+  blueprint: typeof Blueprint.Type,
+  selection: typeof Selection.Type,
+  catalog: typeof CatalogService.Service,
+) {
+  yield* Effect.forEach(blueprint.domainBindings ?? [], (binding) =>
+    Effect.gen(function* () {
+      const target = blueprint.getTarget(binding.targetId);
+      if (target === undefined) {
+        return yield* new BlueprintFailure({
+          message: `Generation domain binding target missing: ${binding.targetId}`,
+          reason: "binding-target-missing",
+          domainId: binding.domainId,
+          optionId: binding.optionId,
+          targetId: binding.targetId,
+        });
+      }
+      const adapter = yield* catalog.getGenerationDomainTargetAdapter(
+        binding.domainId,
+        binding.optionId,
+        target.identity.kind,
+      );
+      const resolvedModules = Arr.filter(
+        Arr.filter(blueprint.nodes, BlueprintNode.guards["attached-module"]),
+        (node) => node.targetId === binding.targetId,
+      );
+      const unsupported = Arr.filter(
+        resolvedModules,
+        (node) => !adapter.supportedResolvedModules.includes(node.moduleId),
+      );
+      if (unsupported.length > 0) {
+        return yield* new BlueprintFailure({
+          message: `Unsupported resolved module ${unsupported[0]?.moduleId} on ${binding.targetId} for generation domain ${binding.domainId}/${binding.optionId}`,
+          reason: "unsupported-module",
+          domainId: binding.domainId,
+          optionId: binding.optionId,
+          targetId: binding.targetId,
+          moduleId: unsupported[0]!.moduleId,
+          moduleSource: "resolved",
+        });
+      }
+    }),
+  );
+  return selection;
+});
 
 const validateSelection = Effect.fn("BlueprintService.validateSelection")(
   function* (

--- a/packages/scaffold/src/service/blueprint/GenerationDomainBinding.test.ts
+++ b/packages/scaffold/src/service/blueprint/GenerationDomainBinding.test.ts
@@ -230,19 +230,37 @@ describe("generic generation-domain binding", () => {
               runtime: { _tag: "bun" },
             }),
           );
-          const domainContribution = contributions.targets.at(-1);
-          expect(domainContribution?.targetKey).toBe(
-            "apps/client-react-preview",
+          const domainContributions = contributions.targets.filter(
+            (contribution) => contribution.generationDomain !== undefined,
           );
-          expect(domainContribution?.contributions).toEqual([
-            expect.objectContaining({
-              path: "fixture-root.txt",
-              contents: "apps/client-react-preview",
-            }),
-            expect.objectContaining({
-              path: "apps/client-react-preview/fixture-adapter.txt",
-              contents: "apps/client-react-preview",
-            }),
+          expect(domainContributions).toEqual([
+            {
+              targetKey: "apps/client-react-preview",
+              generationDomain: {
+                domainId: "delivery",
+                optionId: "edge-preview",
+              },
+              contributions: [
+                expect.objectContaining({
+                  path: "fixture-root.txt",
+                  contents: "apps/client-react-preview",
+                }),
+              ],
+            },
+            {
+              targetKey: "apps/client-react-preview",
+              generationDomain: {
+                domainId: "delivery",
+                optionId: "edge-preview",
+                adapterId: "static-preview",
+              },
+              contributions: [
+                expect.objectContaining({
+                  path: "apps/client-react-preview/fixture-adapter.txt",
+                  contents: "apps/client-react-preview",
+                }),
+              ],
+            },
           ]);
         });
       },

--- a/packages/scaffold/src/service/blueprint/GenerationDomainBinding.test.ts
+++ b/packages/scaffold/src/service/blueprint/GenerationDomainBinding.test.ts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { layer } from "@effect/vitest";
+import { CatalogService } from "@repo/catalog";
+import { BlueprintFailure } from "@repo/domain/Blueprint";
+import {
+  Contribution,
+  GenerationDomainAdapterId,
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  ModuleDependency,
+  ModuleId,
+  TargetIdentity,
+  TargetKind,
+} from "@repo/domain/Catalog";
+import { StackConfig } from "@repo/domain/Scaffold";
+import { Cause, Effect, Exit, Layer } from "effect";
+import { describe, expect } from "vitest";
+import { ContributionResolver } from "../plan/ContributionResolver";
+import { generationDomainMetadata } from "../plan/PlanService";
+import { BlueprintService } from "./BlueprintService";
+
+const cloudflare = {
+  id: GenerationDomainId.make("infrastructure"),
+  option: GenerationDomainOptionId.make("cloudflare"),
+};
+const target = (
+  kind: string,
+  name: string,
+  modules: ReadonlyArray<string> = [],
+) => ({
+  identity: new TargetIdentity({ kind: TargetKind.make(kind), name }),
+  modules: modules.map((id) => ({ id: ModuleId.make(id) })),
+});
+
+describe("generic generation-domain binding", () => {
+  layer(BlueprintService.layer)("resolve", (it) => {
+    it.effect(
+      "binds exactly the explicitly selected React identity and preserves its path",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* BlueprintService;
+          const blueprint = yield* service.resolve({
+            targets: [
+              target("workspace", "demo"),
+              target("client-react", "marketing", ["client-react-web-worker"]),
+            ],
+            domains: [cloudflare],
+          });
+          expect(blueprint.domainBindings).toEqual([
+            {
+              domainId: "infrastructure",
+              optionId: "cloudflare",
+              targetId: "apps/client-react-marketing",
+              adapterId: "cloudflare-website-vite",
+            },
+          ]);
+          expect(
+            blueprint
+              .getTarget("apps/client-react-marketing")
+              ?.identity.toPath(),
+          ).toBe("apps/client-react-marketing");
+        }),
+    );
+
+    it.effect(
+      "rejects additional deployable targets with the requested identity",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* BlueprintService;
+          const exit = yield* Effect.exit(
+            service.resolve({
+              targets: [target("client-react", "web"), target("server", "api")],
+              domains: [cloudflare],
+            }),
+          );
+          assert(Exit.isFailure(exit));
+          const error = Cause.squash(exit.cause);
+          expect(error).toBeInstanceOf(BlueprintFailure);
+          assert(error instanceof BlueprintFailure);
+          expect(error).toMatchObject({
+            reason: "binding-cardinality",
+            domainId: "infrastructure",
+            optionId: "cloudflare",
+          });
+          expect(error).not.toHaveProperty("code");
+          expect(error.targetIds).toEqual([
+            "apps/client-react-web",
+            "apps/server-api",
+          ]);
+          expect(String(error)).toContain("apps/server-api");
+        }),
+    );
+
+    it.effect(
+      "rejects backend-dependent selected modules while accepting explicit DevTools",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* BlueprintService;
+          const accepted = yield* service.resolve({
+            targets: [target("client-react", "web", ["client-react-devtools"])],
+            domains: [cloudflare],
+          });
+          expect(accepted.domainBindings?.[0]?.targetId).toBe(
+            "apps/client-react-web",
+          );
+          const exit = yield* Effect.exit(
+            service.resolve({
+              targets: [
+                target("client-react", "web", ["client-react-http-api"]),
+              ],
+              domains: [cloudflare],
+            }),
+          );
+          assert(Exit.isFailure(exit));
+          const error = Cause.squash(exit.cause);
+          expect(error).toBeInstanceOf(BlueprintFailure);
+          assert(error instanceof BlueprintFailure);
+          expect(error).toMatchObject({
+            reason: "unsupported-module",
+            domainId: "infrastructure",
+            optionId: "cloudflare",
+            targetId: "apps/client-react-web",
+            moduleId: "client-react-http-api",
+            moduleSource: "selected",
+          });
+          expect(String(error)).toContain("client-react-http-api");
+        }),
+    );
+    it.effect(
+      "runs a provider-neutral fixture through registry lookup, exact binding, Plan metadata, and contributions",
+      () => {
+        const domainId = GenerationDomainId.make("delivery");
+        const optionId = GenerationDomainOptionId.make("edge-preview");
+        const adapterId = GenerationDomainAdapterId.make("static-preview");
+        const fixtureLayer = Layer.effect(
+          CatalogService,
+          Effect.map(CatalogService.make, (catalog) => ({
+            ...catalog,
+            getModule: (moduleId: typeof ModuleId.Type) =>
+              moduleId === "client-react-http-api"
+                ? Effect.map(catalog.getModule(moduleId), (definition) => ({
+                    ...definition,
+                    dependencies: [
+                      ...(definition.dependencies ?? []),
+                      ModuleDependency.cases["required-target"].make({
+                        identity: new TargetIdentity({
+                          kind: TargetKind.make("server"),
+                          name: "dependency",
+                        }),
+                      }),
+                    ],
+                  }))
+                : catalog.getModule(moduleId),
+            getGenerationDomainOption: (
+              id: typeof domainId,
+              option: typeof optionId,
+            ) =>
+              id === domainId && option === optionId
+                ? Effect.succeed({
+                    id: optionId,
+                    title: "Edge preview",
+                    minimumBindings: 1,
+                    maximumBindings: 1,
+                    rootContributions: [
+                      Contribution.cases.file.make({
+                        path: "fixture-root.txt",
+                        contents: "{{targetPath}}",
+                      }),
+                    ],
+                    nextSteps: [],
+                  })
+                : catalog.getGenerationDomainOption(id, option),
+            getGenerationDomainTargetAdapter: (
+              id: typeof domainId,
+              option: typeof optionId,
+              kind: typeof TargetKind.Type,
+            ) =>
+              id === domainId && option === optionId && kind === "client-react"
+                ? Effect.succeed({
+                    domainId,
+                    optionId,
+                    adapterId,
+                    targetKind: TargetKind.make("client-react"),
+                    supportedSelectedModules: [
+                      ModuleId.make("client-react-http-api"),
+                    ],
+                    supportedResolvedModules: [
+                      ModuleId.make("client-react-http-api"),
+                      ModuleId.make("config-typescript-vite"),
+                    ],
+                    contributions: [
+                      Contribution.cases.file.make({
+                        path: "{{targetPath}}/fixture-adapter.txt",
+                        contents: "{{targetPath}}",
+                      }),
+                    ],
+                  })
+                : catalog.getGenerationDomainTargetAdapter(id, option, kind),
+          })),
+        );
+        return Effect.gen(function* () {
+          const blueprintService = yield* BlueprintService.make.pipe(
+            Effect.provide(fixtureLayer),
+          );
+          const resolver = yield* ContributionResolver.make.pipe(
+            Effect.provide(fixtureLayer),
+          );
+          const blueprint = yield* blueprintService.resolve({
+            targets: [
+              target("client-react", "preview", ["client-react-http-api"]),
+            ],
+            domains: [{ id: domainId, option: optionId }],
+          });
+          expect(blueprint.domainBindings).toHaveLength(1);
+          expect(blueprint.domainBindings?.[0]).toMatchObject({
+            domainId: "delivery",
+            optionId: "edge-preview",
+            targetId: "apps/client-react-preview",
+            adapterId: "static-preview",
+          });
+          expect(blueprint.hasTarget("apps/server-dependency")).toBe(true);
+          expect(generationDomainMetadata(blueprint)?.[0]?.selection).toEqual({
+            id: "delivery",
+            option: "edge-preview",
+          });
+          const contributions = yield* resolver.resolve(
+            blueprint,
+            new StackConfig({
+              name: "fixture",
+              runtime: { _tag: "bun" },
+            }),
+          );
+          const domainContribution = contributions.targets.at(-1);
+          expect(domainContribution?.targetKey).toBe(
+            "apps/client-react-preview",
+          );
+          expect(domainContribution?.contributions).toEqual([
+            expect.objectContaining({
+              path: "fixture-root.txt",
+              contents: "apps/client-react-preview",
+            }),
+            expect.objectContaining({
+              path: "apps/client-react-preview/fixture-adapter.txt",
+              contents: "apps/client-react-preview",
+            }),
+          ]);
+        });
+      },
+    );
+
+    it.effect(
+      "rejects an unsupported resolved module with structured context",
+      () => {
+        const domainId = GenerationDomainId.make("delivery");
+        const optionId = GenerationDomainOptionId.make("strict-preview");
+        const fixtureLayer = Layer.effect(
+          CatalogService,
+          Effect.map(CatalogService.make, (catalog) => ({
+            ...catalog,
+            getGenerationDomainOption: () =>
+              Effect.succeed({
+                id: optionId,
+                title: "Strict preview",
+                minimumBindings: 1,
+                maximumBindings: 1,
+                rootContributions: [],
+                nextSteps: [],
+              }),
+            getGenerationDomainTargetAdapter: () =>
+              Effect.succeed({
+                domainId,
+                optionId,
+                adapterId: GenerationDomainAdapterId.make("strict-static"),
+                targetKind: TargetKind.make("client-react"),
+                supportedSelectedModules: [
+                  ModuleId.make("client-react-http-api"),
+                ],
+                supportedResolvedModules: [
+                  ModuleId.make("config-typescript-vite"),
+                ],
+                contributions: [],
+              }),
+          })),
+        );
+
+        return Effect.gen(function* () {
+          const service = yield* BlueprintService.make.pipe(
+            Effect.provide(fixtureLayer),
+          );
+          const exit = yield* Effect.exit(
+            service.resolve({
+              targets: [
+                target("client-react", "preview", ["client-react-http-api"]),
+              ],
+              domains: [{ id: domainId, option: optionId }],
+            }),
+          );
+          assert(Exit.isFailure(exit));
+          const error = Cause.squash(exit.cause);
+          assert(error instanceof BlueprintFailure);
+          expect(error).toMatchObject({
+            reason: "unsupported-module",
+            domainId: "delivery",
+            optionId: "strict-preview",
+            targetId: "apps/client-react-preview",
+            moduleId: "client-react-http-api",
+            moduleSource: "resolved",
+          });
+          expect(String(error)).toContain("Unsupported resolved module");
+        });
+      },
+    );
+  });
+});

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -102,21 +102,40 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
                 targetKey: target.id,
                 identity: target.identity,
                 config,
+                generationDomainAdapterId: binding.adapterId,
               });
-              return TargetContribution.make({
-                targetKey: target.id,
-                contributions: resolveContributionTokens(
-                  [...option.rootContributions, ...adapter.contributions],
-                  context,
-                ),
-              });
+              return [
+                TargetContribution.make({
+                  targetKey: target.id,
+                  generationDomain: {
+                    domainId: binding.domainId,
+                    optionId: binding.optionId,
+                  },
+                  contributions: resolveContributionTokens(
+                    option.rootContributions,
+                    context,
+                  ),
+                }),
+                TargetContribution.make({
+                  targetKey: target.id,
+                  generationDomain: {
+                    domainId: binding.domainId,
+                    optionId: binding.optionId,
+                    adapterId: adapter.adapterId,
+                  },
+                  contributions: resolveContributionTokens(
+                    adapter.contributions,
+                    context,
+                  ),
+                }),
+              ];
             }),
         );
 
         return {
           targets: [
             ...Arr.map(targetResults, (r) => r.contribution),
-            ...domainContributions,
+            ...Arr.flatten(domainContributions),
           ],
           modules: moduleContributions,
         } satisfies typeof NormalizedContributions.Type;

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -77,8 +77,47 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
             }),
         );
 
+        const domainContributions = yield* Effect.forEach(
+          blueprint.domainBindings ?? [],
+          (binding) =>
+            Effect.gen(function* () {
+              const target = blueprint.getTarget(binding.targetId);
+              if (target === undefined) {
+                return yield* Effect.die(
+                  new Error(
+                    `Validated Blueprint is missing bound target ${binding.targetId}`,
+                  ),
+                );
+              }
+              const option = yield* catalog.getGenerationDomainOption(
+                binding.domainId,
+                binding.optionId,
+              );
+              const adapter = yield* catalog.getGenerationDomainTargetAdapter(
+                binding.domainId,
+                binding.optionId,
+                target.identity.kind,
+              );
+              const context = new ContributionTokenContext({
+                targetKey: target.id,
+                identity: target.identity,
+                config,
+              });
+              return TargetContribution.make({
+                targetKey: target.id,
+                contributions: resolveContributionTokens(
+                  [...option.rootContributions, ...adapter.contributions],
+                  context,
+                ),
+              });
+            }),
+        );
+
         return {
-          targets: Arr.map(targetResults, (r) => r.contribution),
+          targets: [
+            ...Arr.map(targetResults, (r) => r.contribution),
+            ...domainContributions,
+          ],
           modules: moduleContributions,
         } satisfies typeof NormalizedContributions.Type;
       });
@@ -87,9 +126,13 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
     }),
   },
 ) {
-  static readonly layer = Layer.effect(ContributionResolver)(
+  static readonly baseLayer = Layer.effect(ContributionResolver)(
     ContributionResolver.make,
-  ).pipe(Layer.provide(CatalogService.layer));
+  );
+
+  static readonly layer = ContributionResolver.baseLayer.pipe(
+    Layer.provide(CatalogService.layer),
+  );
 }
 
 const resolveContributionTokens = (

--- a/packages/scaffold/src/service/plan/PlanService.ts
+++ b/packages/scaffold/src/service/plan/PlanService.ts
@@ -35,6 +35,25 @@ export interface PlanServiceShape {
   ) => Effect.Effect<typeof Plan.Type, PlanFailure | CatalogNotFound, never>;
 }
 
+export const generationDomainMetadata = (blueprint: typeof Blueprint.Type) =>
+  blueprint.domainBindings?.length
+    ? Arr.map(
+        Object.entries(
+          Arr.groupBy(
+            blueprint.domainBindings,
+            (binding) => `${binding.domainId}/${binding.optionId}`,
+          ),
+        ),
+        ([, bindings]) => ({
+          selection: {
+            id: bindings[0]!.domainId,
+            option: bindings[0]!.optionId,
+          },
+          bindings,
+        }),
+      )
+    : undefined;
+
 export class PlanService extends Context.Service<
   PlanService,
   PlanServiceShape
@@ -68,15 +87,22 @@ export class PlanService extends Context.Service<
         repoRoot,
       });
 
-      return yield* projectPlan({ planningPaths, repoSnapshot });
+      const generationDomains = generationDomainMetadata(blueprint);
+      return yield* projectPlan({
+        planningPaths,
+        repoSnapshot,
+        generationDomains,
+      });
     });
 
     const projectPlan = ({
       planningPaths,
       repoSnapshot,
+      generationDomains,
     }: {
       planningPaths: ReadonlyArray<PlanningIntentPath>;
       repoSnapshot: typeof RepoSnapshot.Type;
+      generationDomains?: (typeof Plan.Type)["generationDomains"];
     }) =>
       Effect.gen(function* () {
         const snapshotPaths = new Map(
@@ -132,6 +158,7 @@ export class PlanService extends Context.Service<
             assessedPaths,
             ({ assessment }) => assessment.conflicts,
           ),
+          ...(generationDomains === undefined ? {} : { generationDomains }),
         }).pipe(
           Effect.mapError(
             (cause) =>

--- a/packages/scaffold/src/service/recipe/RecipeService.ts
+++ b/packages/scaffold/src/service/recipe/RecipeService.ts
@@ -2,6 +2,7 @@ import { CatalogService } from "@repo/catalog";
 import {
   GenerationDomainId,
   GenerationDomainOptionId,
+  GenerationDomainSelection,
   ModuleId,
   TargetIdentity,
   TargetKind,
@@ -234,10 +235,10 @@ export class RecipeService extends Context.Service<
         ? {
             ...selection,
             domains: [
-              {
+              new GenerationDomainSelection({
                 id: GenerationDomainId.make("infrastructure"),
                 option: GenerationDomainOptionId.make("cloudflare"),
-              },
+              }),
             ],
           }
         : selection;
@@ -300,6 +301,9 @@ export class RecipeService extends Context.Service<
         ...renderChangedFlag("--lint", config.lint, defaults.lint ?? ""),
         ...renderChangedFlag("--format", config.format, defaults.format ?? ""),
         ...renderChangedFlag("--test", config.test, defaults.test ?? ""),
+        ...(config.effectiveInfrastructure === "cloudflare"
+          ? ["--infrastructure", "cloudflare"]
+          : []),
         ...(selectionIncludesWorkspaceModule(selection, "workspace-devenv-git")
           ? []
           : ["--no-git"]),

--- a/packages/scaffold/src/service/recipe/RecipeService.ts
+++ b/packages/scaffold/src/service/recipe/RecipeService.ts
@@ -1,5 +1,11 @@
 import { CatalogService } from "@repo/catalog";
-import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
+import {
+  GenerationDomainId,
+  GenerationDomainOptionId,
+  ModuleId,
+  TargetIdentity,
+  TargetKind,
+} from "@repo/domain/Catalog";
 import type { RecipeSpec, RecipeTargetSpec } from "@repo/domain/Recipe";
 import { StackConfig } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
@@ -212,7 +218,7 @@ export class RecipeService extends Context.Service<
         }),
       );
 
-      return toSelection(
+      const selection = toSelection(
         mergeTargets([
           {
             identity: new TargetIdentity({
@@ -224,6 +230,17 @@ export class RecipeService extends Context.Service<
           ...recipeTargets,
         ]),
       );
+      return options.config.effectiveInfrastructure === "cloudflare"
+        ? {
+            ...selection,
+            domains: [
+              {
+                id: GenerationDomainId.make("infrastructure"),
+                option: GenerationDomainOptionId.make("cloudflare"),
+              },
+            ],
+          }
+        : selection;
     });
 
     const renderCreateCommand: RecipeServiceShape["renderCreateCommand"] = ({


### PR DESCRIPTION
## Goals/Scope

Closes #227

- Add an optional `none | cloudflare` Infrastructure as Effects selection across the CLI and Recipe Builder.
- Deliver the first bounded Cloudflare slice for one static React application using `Cloudflare.Website.Vite`.
- Preserve omitted/default `none` behavior and existing generated projects.
- Make `infra:dev` the credential-free local development path while keeping remote lifecycle operations explicitly user-owned.

Success for this slice means:

- the infrastructure selection round-trips through CLI, Recipe Builder, URL state, Selection, Blueprint, Plan, and Apply;
- generated Cloudflare React projects start locally through native `alchemy dev`;
- ordinary projects remain byte-identical and contain no infrastructure artifacts;
- no credentials or remote Cloudflare resources are required for acceptance.

Suggested review order:

1. shared infrastructure domain and scaffold contracts;
2. catalog generation and Alchemy template;
3. CLI and Recipe Builder integration;
4. compatibility, generated-output, and runtime-boundary tests;
5. documentation and changeset.

## Description

| Area | Change |
| --- | --- |
| Domain and scaffold | Add the generic Infrastructure as Effects selection with `none` as the default |
| Catalog | Generate one deterministic `Alchemy.localState()` stack with `Cloudflare.Website.Vite` |
| Dependencies | Pin `alchemy@2.0.0-beta.73` and the compatible Effect tuple, including `@effect/platform-bun@4.0.0-rc.111` |
| Lifecycle | Add namespaced `infra:dev`, `infra:plan`, `infra:deploy`, and `infra:destroy` scripts without changing root `dev` |
| CLI | Support interactive and non-interactive infrastructure selection |
| Recipe Builder | Support selection, URL serialization, command generation, and restoration |
| Compatibility | Keep omitted and explicit `none` output byte-identical and leak-free |
| Guidance | Document local startup separately from credentialed remote operations |

Generated Cloudflare React projects use the exact selected target root and a deterministic provider-safe identity. `infra:dev` invokes native `alchemy dev`; local state remains under the ignored `.alchemy/` directory.

### How to Test

Repository validation completed successfully:

```sh
bun format
bun lint
bun run type-check
bun run test -- --force

bun run catalog:reset-workspace
bun run catalog:validate-workspace
bun run catalog:diff-workspace
```

Results:

- formatting passed with no fixes;
- lint and type-check passed;
- full Turbo suite passed: 331/331 tests;
- focused impacted suites passed: 184/184 tests;
- catalog reset/validate/diff passed with an empty final diff;
- `git diff --check` passed.

Local runtime acceptance used a disposable generated workspace with Bun 1.2.21:

1. install the exact generated Alchemy/Effect dependency tuple;
2. run generated `infra:dev`;
3. wait for native Alchemy at `http://localhost:1337`;
4. request `/` and `/client-owned/deep-route`;
5. confirm both return the same SPA application shell;
6. stop through graceful SIGINT and confirm no Alchemy, Vite, workerd, fixture, or provider-state residue remains.

The acceptance harness permitted loopback traffic only and used no real Cloudflare credentials.

Backward compatibility was also checked through omitted and explicit `none` dry runs. Their outputs were byte-identical and leak-free. A complete disposable differential produced identical 21,746-file trees.

## Comments

### Remote lifecycle boundary

Stack Effect does not generate, store, or print Cloudflare credentials.

Users configure credentials through Alchemy and Cloudflare's documented conventions before running:

- `infra:plan`
- `infra:deploy`
- `infra:destroy`

Local acceptance does **not** verify or claim:

- `workers.dev` allocation;
- edge upload;
- TLS or global routing;
- provider authentication;
- remote plan or deployment behavior;
- remote destruction or cleanup.

Those operations remain intentionally unverified and user-owned.

### Out of scope

This PR does not implement:

- Foldkit deployment;
- Server or Worker deployment;
- HTTP API or Event RPC Worker adapters;
- databases, AWS, custom domains, or preview environments;
- credential management;
- remote provider acceptance.

Those remain follow-up slices under #227.

### Review workload

This is a larger single PR—45 files and 2,508 insertions plus 94 deletions—but the scope remains bounded to the generic infrastructure foundation, one React Cloudflare adapter, CLI/Builder parity, documentation, and supporting tests.

---

- [x] Timeframe: `1 week`
- [ ] Urgent!
- [ ] Merge without review
- [ ] cc: @person
