### PR TITLE
feat: add optional Git hook providers

### DIFF
--- a/.changeset/git-hooks.md
+++ b/.changeset/git-hooks.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": minor
+---
+
+Add optional Lefthook and Husky Git hook providers to generated projects.

--- a/apps/cli/e2e/git-hooks-runtime-harness.ts
+++ b/apps/cli/e2e/git-hooks-runtime-harness.ts
@@ -1,0 +1,493 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const BUN = "/home/andresdavid/.local/share/mise/installs/bun/1.2.21/bin/bun";
+const CLI = resolve(import.meta.dirname, "../src/index.ts");
+const target = "package/domain:domain-api-contracts";
+
+type Provider = "lefthook" | "husky";
+type PackageManager = "bun" | "npm" | "pnpm";
+type Quality =
+  | "biome-format"
+  | "oxfmt"
+  | "biome-lint"
+  | "oxlint"
+  | "biome-combined"
+  | "oxc-combined";
+
+export interface RuntimeCell {
+  readonly provider: Provider;
+  readonly runtime: "bun" | "node";
+  readonly packageManager: PackageManager;
+  readonly quality: Quality;
+  readonly hasFormat: boolean;
+  readonly hasLint: boolean;
+  readonly args: ReadonlyArray<string>;
+}
+
+const qualities: ReadonlyArray<
+  Omit<RuntimeCell, "provider" | "runtime" | "packageManager">
+> = [
+  {
+    quality: "biome-format",
+    hasFormat: true,
+    hasLint: false,
+    args: ["--format", "biome", "--lint", "none"],
+  },
+  {
+    quality: "oxfmt",
+    hasFormat: true,
+    hasLint: false,
+    args: ["--format", "oxfmt", "--lint", "none"],
+  },
+  {
+    quality: "biome-lint",
+    hasFormat: false,
+    hasLint: true,
+    args: ["--format", "none", "--lint", "biome"],
+  },
+  {
+    quality: "oxlint",
+    hasFormat: false,
+    hasLint: true,
+    args: ["--format", "none", "--lint", "oxlint"],
+  },
+  {
+    quality: "biome-combined",
+    hasFormat: true,
+    hasLint: true,
+    args: ["--format", "biome", "--lint", "biome"],
+  },
+  {
+    quality: "oxc-combined",
+    hasFormat: true,
+    hasLint: true,
+    args: ["--format", "oxfmt", "--lint", "oxlint"],
+  },
+];
+
+const providers = [
+  {
+    provider: "lefthook" as const,
+    runtime: "bun" as const,
+    packageManager: "bun" as const,
+  },
+  {
+    provider: "lefthook" as const,
+    runtime: "node" as const,
+    packageManager: "npm" as const,
+  },
+  {
+    provider: "lefthook" as const,
+    runtime: "node" as const,
+    packageManager: "pnpm" as const,
+  },
+  {
+    provider: "husky" as const,
+    runtime: "node" as const,
+    packageManager: "npm" as const,
+  },
+  {
+    provider: "husky" as const,
+    runtime: "node" as const,
+    packageManager: "pnpm" as const,
+  },
+];
+
+export const advertisedRuntimeCells: ReadonlyArray<RuntimeCell> =
+  providers.flatMap((provider) =>
+    qualities.map((quality) => ({ ...provider, ...quality })),
+  );
+
+interface Result {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+const execute = (
+  cwd: string,
+  command: string,
+  args: ReadonlyArray<string>,
+): Result => {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${dirname(BUN)}:${process.env["PATH"] ?? ""}`,
+      GIT_AUTHOR_NAME: "Stack Effect Runtime Acceptance",
+      GIT_AUTHOR_EMAIL: "runtime@example.invalid",
+      GIT_COMMITTER_NAME: "Stack Effect Runtime Acceptance",
+      GIT_COMMITTER_EMAIL: "runtime@example.invalid",
+      CI: "1",
+    },
+    timeout: 170_000,
+  });
+  return {
+    code: result.status ?? 128,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? String(result.error ?? ""),
+  };
+};
+const must = (
+  cwd: string,
+  command: string,
+  args: ReadonlyArray<string>,
+  label: string,
+) => {
+  const result = execute(cwd, command, args);
+  if (result.code !== 0)
+    throw new Error(
+      `${label} failed (${result.code})\n${result.stdout}\n${result.stderr}`,
+    );
+  return result;
+};
+const git = (cwd: string, ...args: ReadonlyArray<string>) =>
+  must(cwd, "git", args, `git ${args.join(" ")}`).stdout.trim();
+const inventory = (cwd: string, cached: boolean) =>
+  execute(cwd, "git", [
+    "diff",
+    ...(cached ? ["--cached"] : []),
+    "--name-status",
+  ])
+    .stdout.trim()
+    .split("\n")
+    .filter(Boolean);
+const write = (root: string, path: string, content: string) => {
+  const absolute = join(root, path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+};
+
+interface FormatterRuntimeVerdict {
+  kind: "formatter-present";
+  before: string;
+  committed: string;
+  worktree: string;
+  commit: string;
+  headAfter: string;
+}
+
+interface LinterOnlyRuntimeVerdict {
+  kind: "linter-only";
+  taskEvidence: string;
+  outputLine: string;
+  before: string;
+  committed: string;
+  worktree: string;
+  headBefore: string;
+  headAfter: string;
+}
+
+export interface RuntimeVerdict {
+  canonicalVerdict: "PASS";
+  success: { headAdvanced: true };
+  qualityEvidence: FormatterRuntimeVerdict | LinterOnlyRuntimeVerdict;
+  failure: {
+    path: string;
+    exitCode: number;
+    headBefore: string;
+    headAfter: string;
+    indexInventory: ReadonlyArray<string>;
+    worktreeInventory: ReadonlyArray<string>;
+    indexContent: string;
+    expectedContent: string;
+  };
+  partialStage: {
+    path: string;
+    indexInventory: ReadonlyArray<string>;
+    worktreeInventory: ReadonlyArray<string>;
+    committedContent: string;
+    worktreeContent: string;
+    expectedCommittedContent: string;
+    expectedWorktreeContent: string;
+  };
+  hookOrder: ReadonlyArray<"format" | "lint">;
+  lefthookAllowBuildsSufficient: boolean;
+  husky?: {
+    initialCommitMarker: number;
+    installMarker: number;
+    initialCommitSegment: string;
+    laterCommitHookEvidence: string;
+    prepareUnchanged: boolean;
+    installerOwnedHooksPath: string;
+  };
+  cleanup: { rootRemoved: boolean };
+}
+
+export const runProviderCommitAcceptance = async (
+  cell: RuntimeCell,
+): Promise<RuntimeVerdict> => {
+  const outer = mkdtempSync(join(tmpdir(), "stack-effect-hook-runtime-"));
+  const name = `accept-${cell.provider}-${cell.packageManager}-${cell.quality}`;
+  const root = join(outer, name);
+  let verdict: RuntimeVerdict | undefined;
+  try {
+    const generated = must(
+      outer,
+      BUN,
+      [
+        "run",
+        CLI,
+        "create",
+        name,
+        "--target",
+        target,
+        "--yes",
+        "--trust",
+        "--root",
+        outer,
+        "--runtime",
+        cell.runtime,
+        "--package-manager",
+        cell.packageManager,
+        "--typescript",
+        "7",
+        "--git-hooks",
+        cell.provider,
+        ...cell.args,
+      ],
+      "generate",
+    );
+    const initialHead = git(root, "rev-parse", "HEAD");
+    const packageJson = JSON.parse(
+      readFileSync(join(root, "package.json"), "utf8"),
+    );
+    const prepareUnchanged =
+      packageJson.scripts.prepare === "effect-tsgo patch";
+    const hooksPath = execute(root, "git", [
+      "config",
+      "--get",
+      "core.hooksPath",
+    ]).stdout.trim();
+    const allowBuilds =
+      cell.packageManager !== "pnpm" ||
+      cell.provider !== "lefthook" ||
+      readFileSync(join(root, "pnpm-workspace.yaml"), "utf8").includes(
+        "lefthook: true",
+      );
+
+    const nested = "packages/domain/src/runtime acceptance/file with spaces.ts";
+    write(root, nested, "export const clean = true;\n");
+    git(root, "add", nested);
+    const successRun = execute(root, "git", [
+      "commit",
+      "-m",
+      "runtime success",
+    ]);
+    if (successRun.code !== 0)
+      throw new Error(
+        `success commit failed\n${successRun.stdout}\n${successRun.stderr}`,
+      );
+    const successHead = git(root, "rev-parse", "HEAD");
+
+    const mutation = "packages/domain/src/runtime-acceptance-mutation.ts";
+    const mutationBefore = "export const mutation={nested:true}\n";
+    write(root, mutation, mutationBefore);
+    git(root, "add", mutation);
+    const mutationHeadBefore = git(root, "rev-parse", "HEAD");
+    const mutationRun = execute(root, "git", [
+      "commit",
+      "-m",
+      cell.hasFormat ? "runtime mutation" : "runtime lint",
+    ]);
+    if (mutationRun.code !== 0)
+      throw new Error(
+        `mutation commit failed\n${mutationRun.stdout}\n${mutationRun.stderr}`,
+      );
+    const mutationHead = git(root, "rev-parse", "HEAD");
+    const mutationCommit = git(root, "log", "-1", "--format=%H");
+    const committedMutation = `${git(root, "show", `HEAD:${mutation}`)}\n`;
+    const worktreeMutation = readFileSync(join(root, mutation), "utf8");
+    const expectedLintTaskEvidence =
+      cell.provider === "lefthook"
+        ? "lint ❯"
+        : `${cell.packageManager} run git-hooks:lint --`;
+    const lintOutputLine = `${mutationRun.stdout}\n${mutationRun.stderr}`
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.includes(expectedLintTaskEvidence));
+    if (
+      worktreeMutation !== committedMutation ||
+      mutationCommit !== mutationHead ||
+      (cell.hasFormat && committedMutation === mutationBefore) ||
+      (!cell.hasFormat &&
+        (committedMutation !== mutationBefore ||
+          mutationHead === mutationHeadBefore ||
+          lintOutputLine === undefined))
+    )
+      throw new Error(
+        `quality evidence was not observed\nbefore=${JSON.stringify(mutationBefore)}\ncommitted=${JSON.stringify(committedMutation)}\nworktree=${JSON.stringify(worktreeMutation)}\nexpectedLintTaskEvidence=${JSON.stringify(expectedLintTaskEvidence)}\noutput=${JSON.stringify(`${mutationRun.stdout}\n${mutationRun.stderr}`)}`,
+      );
+
+    const failure = "packages/domain/src/runtime acceptance/non fixable.ts";
+    const failureContent = "export const broken: = 1;\n";
+    write(root, failure, failureContent);
+    git(root, "add", failure);
+    const beforeFailure = git(root, "rev-parse", "HEAD");
+    const failureRun = execute(root, "git", ["commit", "-m", "must fail"]);
+    const failureHead = git(root, "rev-parse", "HEAD");
+    if (failureRun.code === 0 || failureHead !== beforeFailure)
+      throw new Error("non-fixable task did not block HEAD");
+    const failureIndex = inventory(root, true);
+    const failureWorktree = inventory(root, false);
+    const failureIndexContent = `${git(root, "show", `:${failure}`)}\n`;
+    if (
+      failureIndex.join("\n") !== `A\t${failure}` ||
+      failureWorktree.length !== 0 ||
+      failureIndexContent !== failureContent
+    )
+      throw new Error(
+        "failed commit did not preserve the exact intended staged state",
+      );
+    git(root, "reset", "--hard", "HEAD");
+
+    const partial = "packages/domain/src/runtime acceptance/partial stage.ts";
+    const partialStaged = "export const staged={value:1}\n";
+    const partialCommittedExpected = cell.hasFormat
+      ? "export const staged = { value: 1 };\n"
+      : partialStaged;
+    const partialWorktree = `${partialStaged}export const userWorktree = 'preserve me'\n`;
+    const partialWorktreeExpected = `${partialCommittedExpected}export const userWorktree = 'preserve me'\n`;
+    write(root, partial, partialStaged);
+    git(root, "add", partial);
+    write(root, partial, partialWorktree);
+    const partialRun = execute(root, "git", [
+      "commit",
+      "-m",
+      "runtime partial stage",
+    ]);
+    if (partialRun.code !== 0)
+      throw new Error(
+        `partial commit failed\n${partialRun.stdout}\n${partialRun.stderr}`,
+      );
+    const committedPartial = `${git(root, "show", `HEAD:${partial}`)}\n`;
+    const worktreePartial = readFileSync(join(root, partial), "utf8");
+    const partialIndex = inventory(root, true);
+    const partialWorktreeInventory = inventory(root, false);
+    if (
+      committedPartial !== partialCommittedExpected ||
+      worktreePartial !== partialWorktreeExpected ||
+      partialIndex.length !== 0 ||
+      partialWorktreeInventory.join("\n") !== `M\t${partial}`
+    )
+      throw new Error(
+        "partial commit did not preserve exact index/worktree content",
+      );
+
+    const hookOutput = `${successRun.stdout}\n${successRun.stderr}\n${mutationRun.stdout}\n${mutationRun.stderr}`;
+    const expectedOrder =
+      cell.hasFormat && cell.hasLint
+        ? (["format", "lint"] as const)
+        : cell.hasFormat
+          ? (["format"] as const)
+          : (["lint"] as const);
+    let cursor = -1;
+    for (const task of expectedOrder) {
+      const evidence =
+        cell.provider === "lefthook"
+          ? new RegExp(`(?:^|\\n)[^\\n]*${task}\\s+❯`, "m")
+          : new RegExp(`(?:npm|pnpm) run git-hooks:${task} --`);
+      const match = evidence.exec(hookOutput.slice(cursor + 1));
+      if (match === null)
+        throw new Error(
+          `missing provider-native runtime order evidence for ${task}`,
+        );
+      cursor += match.index + match[0].length;
+    }
+    const initialCommitMarker = generated.stdout.indexOf("initial commit");
+    const installMarker = generated.stdout.indexOf(
+      `${cell.packageManager} run husky:install`,
+    );
+    const initialCommitSegment = generated.stdout.slice(
+      initialCommitMarker,
+      installMarker,
+    );
+    const laterCommitHookEvidence = hookOutput.match(
+      /(?:npm|pnpm) run git-hooks:(?:format|lint) --[^\n]*/,
+    )?.[0];
+    if (
+      cell.provider === "husky" &&
+      (!hooksPath.startsWith(".husky/_") ||
+        !prepareUnchanged ||
+        initialCommitMarker < 0 ||
+        installMarker <= initialCommitMarker ||
+        /lint-staged/i.test(initialCommitSegment) ||
+        laterCommitHookEvidence === undefined)
+    )
+      throw new Error("Husky lifecycle event ordering was not observed");
+    if (!allowBuilds || successHead === initialHead)
+      throw new Error(
+        "provider install/build or real hook execution not proven",
+      );
+
+    verdict = {
+      canonicalVerdict: "PASS",
+      success: { headAdvanced: true },
+      qualityEvidence: cell.hasFormat
+        ? {
+            kind: "formatter-present",
+            before: mutationBefore,
+            committed: committedMutation,
+            worktree: worktreeMutation,
+            commit: mutationCommit,
+            headAfter: mutationHead,
+          }
+        : {
+            kind: "linter-only",
+            taskEvidence: expectedLintTaskEvidence,
+            outputLine: lintOutputLine!,
+            before: mutationBefore,
+            committed: committedMutation,
+            worktree: worktreeMutation,
+            headBefore: mutationHeadBefore,
+            headAfter: mutationHead,
+          },
+      failure: {
+        path: failure,
+        exitCode: failureRun.code,
+        headBefore: beforeFailure,
+        headAfter: failureHead,
+        indexInventory: failureIndex,
+        worktreeInventory: failureWorktree,
+        indexContent: failureIndexContent,
+        expectedContent: failureContent,
+      },
+      partialStage: {
+        path: partial,
+        indexInventory: partialIndex,
+        worktreeInventory: partialWorktreeInventory,
+        committedContent: committedPartial,
+        worktreeContent: worktreePartial,
+        expectedCommittedContent: partialCommittedExpected,
+        expectedWorktreeContent: partialWorktreeExpected,
+      },
+      hookOrder: [...expectedOrder],
+      lefthookAllowBuildsSufficient: allowBuilds,
+      ...(cell.provider === "husky"
+        ? {
+            husky: {
+              initialCommitMarker,
+              installMarker,
+              initialCommitSegment,
+              laterCommitHookEvidence: laterCommitHookEvidence!,
+              prepareUnchanged,
+              installerOwnedHooksPath: hooksPath,
+            },
+          }
+        : {}),
+      cleanup: { rootRemoved: false },
+    };
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+  return { ...verdict!, cleanup: { rootRemoved: true } };
+};

--- a/apps/cli/e2e/git-hooks-runtime.test.ts
+++ b/apps/cli/e2e/git-hooks-runtime.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  advertisedRuntimeCells,
+  runProviderCommitAcceptance,
+} from "./git-hooks-runtime-harness";
+
+describe.sequential("provider-native real-commit release acceptance", () => {
+  it("enumerates every advertised provider/runtime/package-manager/tool cell", () => {
+    expect(advertisedRuntimeCells).toHaveLength(30);
+    expect(
+      advertisedRuntimeCells.filter(({ provider }) => provider === "lefthook"),
+    ).toHaveLength(18);
+    expect(
+      advertisedRuntimeCells.filter(({ provider }) => provider === "husky"),
+    ).toHaveLength(12);
+  });
+
+  for (const cell of advertisedRuntimeCells) {
+    it(`${cell.provider} ${cell.runtime}/${cell.packageManager} ${cell.quality}`, async () => {
+      const verdict = await runProviderCommitAcceptance(cell);
+      expect(verdict.canonicalVerdict).toBe("PASS");
+      expect(verdict.success.headAdvanced).toBe(true);
+      if (verdict.qualityEvidence.kind === "formatter-present") {
+        expect(verdict.qualityEvidence.before).not.toBe(
+          verdict.qualityEvidence.committed,
+        );
+        expect(verdict.qualityEvidence.worktree).toBe(
+          verdict.qualityEvidence.committed,
+        );
+        expect(verdict.qualityEvidence.commit).toBe(
+          verdict.qualityEvidence.headAfter,
+        );
+      } else {
+        expect(verdict.qualityEvidence.outputLine).toContain(
+          verdict.qualityEvidence.taskEvidence,
+        );
+        expect(verdict.qualityEvidence.committed).toBe(
+          verdict.qualityEvidence.before,
+        );
+        expect(verdict.qualityEvidence.worktree).toBe(
+          verdict.qualityEvidence.before,
+        );
+        expect(verdict.qualityEvidence.headAfter).not.toBe(
+          verdict.qualityEvidence.headBefore,
+        );
+      }
+      expect(verdict.failure.exitCode).not.toBe(0);
+      expect(verdict.failure.headAfter).toBe(verdict.failure.headBefore);
+      expect(verdict.failure.indexInventory).toEqual([
+        `A\t${verdict.failure.path}`,
+      ]);
+      expect(verdict.failure.worktreeInventory).toEqual([]);
+      expect(verdict.failure.indexContent).toBe(
+        verdict.failure.expectedContent,
+      );
+      expect(verdict.partialStage.indexInventory).toEqual([]);
+      expect(verdict.partialStage.worktreeInventory).toEqual([
+        `M\t${verdict.partialStage.path}`,
+      ]);
+      expect(verdict.partialStage.committedContent).toBe(
+        verdict.partialStage.expectedCommittedContent,
+      );
+      expect(verdict.partialStage.worktreeContent).toBe(
+        verdict.partialStage.expectedWorktreeContent,
+      );
+      expect(verdict.partialStage.committedContent).not.toContain(
+        "userWorktree",
+      );
+      expect(verdict.hookOrder).toEqual(
+        cell.hasFormat && cell.hasLint
+          ? ["format", "lint"]
+          : cell.hasFormat
+            ? ["format"]
+            : ["lint"],
+      );
+      expect(verdict.cleanup.rootRemoved).toBe(true);
+      if (cell.provider === "lefthook" && cell.packageManager === "pnpm") {
+        expect(verdict.lefthookAllowBuildsSufficient).toBe(true);
+      }
+      if (cell.provider === "husky") {
+        expect(verdict.husky?.initialCommitMarker).toBeLessThan(
+          verdict.husky?.installMarker ?? -1,
+        );
+        expect(verdict.husky?.initialCommitSegment).not.toMatch(/lint-staged/i);
+        expect(verdict.husky?.laterCommitHookEvidence).toMatch(
+          /(?:npm|pnpm) run git-hooks:(?:format|lint) --/,
+        );
+        expect(verdict.husky?.prepareUnchanged).toBe(true);
+        expect(verdict.husky?.installerOwnedHooksPath).toMatch(/^\.husky\/_$/);
+      }
+    }, 180_000);
+  }
+});

--- a/apps/cli/e2e/git-hooks.test.ts
+++ b/apps/cli/e2e/git-hooks.test.ts
@@ -1,0 +1,246 @@
+import { stripVTControlCharacters } from "node:util";
+import { assert, describe, layer } from "@effect/vitest";
+import { Effect } from "effect";
+import { CLI } from "./harness";
+
+const target = "package/domain:domain-api-contracts";
+
+const runPreview = (
+  cli: typeof CLI.Service,
+  name: string,
+  ...args: ReadonlyArray<string>
+) =>
+  Effect.gen(function* () {
+    yield* cli.run(
+      "create",
+      name,
+      "--target",
+      target,
+      "--yes",
+      "--dry-run",
+      "--show-files",
+      "--root",
+      cli.workdir,
+      ...args,
+    );
+    yield* cli.expectExitCode(0);
+    return stripVTControlCharacters(cli.lastResult().stdout);
+  });
+
+const compact = (value: string) => value.replace(/\s+/g, " ");
+
+const expectContains = (output: string, ...values: ReadonlyArray<string>) =>
+  values.forEach((value) => assert.include(compact(output), compact(value)));
+
+const expectExcludes = (output: string, ...values: ReadonlyArray<string>) =>
+  values.forEach((value) => assert.notInclude(compact(output), compact(value)));
+
+interface QualityCase {
+  readonly label: string;
+  readonly args: ReadonlyArray<string>;
+  readonly format?: string;
+  readonly lint?: string;
+}
+
+const qualityCases: ReadonlyArray<QualityCase> = [
+  {
+    label: "Biome formatter only",
+    args: ["--format", "biome", "--lint", "none"],
+    format: "biome format --write",
+  },
+  {
+    label: "Oxfmt formatter only",
+    args: ["--format", "oxfmt", "--lint", "none"],
+    format: "oxfmt",
+  },
+  {
+    label: "Biome linter only",
+    args: ["--format", "dprint", "--lint", "biome"],
+    lint: "biome lint --write",
+  },
+  {
+    label: "Oxlint linter only",
+    args: ["--format", "dprint", "--lint", "oxlint"],
+    lint: "oxlint --fix",
+  },
+  {
+    label: "Biome combined",
+    args: ["--format", "biome", "--lint", "biome"],
+    format: "biome format --write",
+    lint: "biome lint --write",
+  },
+  {
+    label: "Oxc combined",
+    args: ["--format", "oxfmt", "--lint", "oxlint"],
+    format: "oxfmt",
+    lint: "oxlint --fix",
+  },
+];
+
+const providerCases = [
+  { provider: "lefthook", runtime: "bun", packageManager: "bun" },
+  { provider: "lefthook", runtime: "node", packageManager: "npm" },
+  { provider: "lefthook", runtime: "node", packageManager: "pnpm" },
+  { provider: "husky", runtime: "node", packageManager: "npm" },
+  { provider: "husky", runtime: "node", packageManager: "pnpm" },
+] as const;
+
+describe("generated Git-hook contracts", () => {
+  layer(CLI.layer)("CLI previews", (it) => {
+    it.effect("preserves omitted and explicit-none default parity", () =>
+      Effect.gen(function* () {
+        const cli = yield* CLI;
+        const omitted = yield* runPreview(cli, "default-parity");
+        const explicit = yield* runPreview(
+          cli,
+          "default-parity",
+          "--git-hooks",
+          "none",
+        );
+
+        assert.strictEqual(omitted, explicit);
+        expectContains(omitted, "--git-hooks none");
+        expectExcludes(
+          omitted,
+          "lefthook.yml",
+          "lint-staged.config.mjs",
+          ".husky/pre-commit",
+          "lefthook:install",
+          "husky:install",
+        );
+      }).pipe(Effect.provide(CLI.layer)),
+    );
+
+    for (const [providerIndex, entry] of providerCases.entries()) {
+      for (const [qualityIndex, quality] of qualityCases.entries()) {
+        it.effect(
+          `${entry.provider} ${entry.runtime}/${entry.packageManager} ${quality.label}`,
+          () =>
+            Effect.gen(function* () {
+              const cli = yield* CLI;
+              const output = yield* runPreview(
+                cli,
+                `hooks-${providerIndex}-${qualityIndex}`,
+                "--git-hooks",
+                entry.provider,
+                "--runtime",
+                entry.runtime,
+                "--package-manager",
+                entry.packageManager,
+                ...quality.args,
+              );
+
+              expectContains(
+                output,
+                `--git-hooks ${entry.provider}`,
+                `\"git-hooks:${quality.format ? "format" : "lint"}\"`,
+                quality.format ?? quality.lint ?? "missing quality command",
+              );
+
+              if (entry.provider === "lefthook") {
+                expectContains(
+                  output,
+                  "lefthook.yml",
+                  '\"lefthook\": \"2.1.10\"',
+                  "stage_fixed: true",
+                  `${entry.packageManager} run lefthook:install`,
+                );
+                entry.packageManager === "pnpm"
+                  ? expectContains(output, "lefthook: true")
+                  : expectExcludes(output, "lefthook: true");
+                expectExcludes(
+                  output,
+                  "lint-staged.config.mjs",
+                  "husky:install",
+                );
+              } else {
+                expectContains(
+                  output,
+                  ".husky/pre-commit",
+                  "lint-staged.config.mjs",
+                  '\"husky\": \"9.1.7\"',
+                  '\"lint-staged\": \"17.4.1\"',
+                  `${entry.packageManager} run lint-staged`,
+                  `${entry.packageManager} run husky:install`,
+                );
+                expectExcludes(output, "lefthook.yml", "stage_fixed: true");
+              }
+
+              quality.format
+                ? expectContains(output, '"git-hooks:format"')
+                : expectExcludes(output, '"git-hooks:format"');
+              quality.lint
+                ? expectContains(output, '"git-hooks:lint"')
+                : expectExcludes(output, '"git-hooks:lint"');
+
+              if (quality.format && quality.lint) {
+                assert.isBelow(
+                  output.indexOf(
+                    `${entry.packageManager} run git-hooks:format --`,
+                  ),
+                  output.indexOf(
+                    `${entry.packageManager} run git-hooks:lint --`,
+                  ),
+                );
+              }
+            }).pipe(Effect.provide(CLI.layer)),
+          { timeout: 30_000 },
+        );
+      }
+    }
+
+    it.effect("rejects invalid hook input before creating a project", () =>
+      Effect.gen(function* () {
+        const cli = yield* CLI;
+        yield* cli.run(
+          "create",
+          "invalid-hooks",
+          "--target",
+          target,
+          "--yes",
+          "--root",
+          cli.workdir,
+          "--git-hooks",
+          "husky",
+          "--runtime",
+          "bun",
+          "--package-manager",
+          "bun",
+        );
+        yield* cli.expectExitCode(1);
+        yield* cli.expectFileNotExists("invalid-hooks");
+      }).pipe(Effect.provide(CLI.layer)),
+    );
+
+    it.effect("preserves TypeScript-owned prepare for versions 6 and 7", () =>
+      Effect.gen(function* () {
+        const cli = yield* CLI;
+        const cases = [
+          { typescript: "6", prepare: "effect-language-service patch" },
+          { typescript: "7", prepare: "effect-tsgo patch" },
+        ] as const;
+
+        yield* Effect.forEach(cases, ({ typescript, prepare }) =>
+          Effect.forEach(["lefthook", "husky"] as const, (provider) =>
+            Effect.gen(function* () {
+              const output = yield* runPreview(
+                cli,
+                `typescript-${typescript}-${provider}`,
+                "--runtime",
+                "node",
+                "--package-manager",
+                "npm",
+                "--typescript",
+                typescript,
+                "--git-hooks",
+                provider,
+              );
+              expectContains(output, `\"prepare\": \"${prepare}\"`);
+              expectExcludes(output, '"postinstall"', "husky init", "chmod");
+            }),
+          ),
+        );
+      }).pipe(Effect.provide(CLI.layer)),
+    );
+  });
+});

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -286,6 +286,8 @@ export class CLI extends Context.Service<CLI>()("e2e/CLI", {
           ),
         ),
 
+      lastResult: () => lastResult,
+
       expectExitCode: (code: number) =>
         Effect.suspend(() =>
           lastResult.exitCode === code

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -725,6 +725,112 @@ describe("init", () => {
     );
 
     it.effect(
+      "rejects unknown git-hook values before init writes",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          yield* cli.run(
+            "init",
+            "unknown-hooks",
+            "--yes",
+            "--git-hooks",
+            "unknown",
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(1);
+          yield* cli.expectFileNotExists("unknown-hooks/stack.effect.json");
+          yield* cli.expectFileNotExists("unknown-hooks/.git");
+        }),
+      { timeout: 15_000 },
+    );
+
+    it.effect(
+      "rejects contradictory init provider intent before writes",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const cases = [
+            {
+              name: "hooks-without-git",
+              args: ["--git-hooks", "lefthook", "--no-git"],
+              error: "requires Git",
+            },
+            {
+              name: "husky-with-bun",
+              args: ["--git-hooks", "husky", "--runtime", "bun"],
+              error: "Node >=24",
+            },
+          ] as const;
+
+          yield* Effect.forEach(cases, ({ name, args, error }) =>
+            Effect.gen(function* () {
+              yield* cli.run(
+                "init",
+                name,
+                "--yes",
+                ...args,
+                "--root",
+                cli.workdir,
+              );
+              yield* cli.expectExitCode(1);
+              yield* cli.expectErrorContaining(error);
+              yield* cli.expectFileNotExists(`${name}/stack.effect.json`);
+              yield* cli.expectFileNotExists(`${name}/.git`);
+            }),
+          );
+        }),
+      { timeout: 15_000 },
+    );
+
+    it.effect(
+      "rejects contradictory create provider intent before writes",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const cases = [
+            {
+              name: "invalid-create-hooks",
+              args: ["--git-hooks", "lefthook", "--no-git"],
+              error: "requires Git",
+            },
+            {
+              name: "create-hooks-without-task",
+              args: [
+                "--git-hooks",
+                "lefthook",
+                "--format",
+                "dprint",
+                "--lint",
+                "eslint",
+              ],
+              error: "Biome or Oxc",
+            },
+          ] as const;
+
+          yield* Effect.forEach(cases, ({ name, args, error }) =>
+            Effect.gen(function* () {
+              yield* cli.run(
+                "create",
+                name,
+                "--target",
+                "package/domain:domain-api-contracts",
+                "--yes",
+                ...args,
+                "--root",
+                cli.workdir,
+              );
+              yield* cli.expectExitCode(1);
+              yield* cli.expectErrorContaining(error);
+              yield* cli.expectFileNotExists(`${name}/stack.effect.json`);
+              yield* cli.expectFileNotExists(`${name}/.git`);
+            }),
+          );
+        }),
+      { timeout: 15_000 },
+    );
+
+    it.effect(
       "init --yes --no-git skips git initialization",
       () =>
         Effect.gen(function* () {

--- a/apps/cli/src/commands/catalog.test.ts
+++ b/apps/cli/src/commands/catalog.test.ts
@@ -1,0 +1,59 @@
+import * as nodeFs from "node:fs/promises";
+import * as nodeOs from "node:os";
+import * as nodePath from "node:path";
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+import { linkWorkspacePackages, WorkspaceCommandFailed } from "./catalog";
+
+const roots: Array<string> = [];
+
+const makeWorkspace = async () => {
+  const root = await nodeFs.mkdtemp(
+    nodePath.join(nodeOs.tmpdir(), "catalog-link-"),
+  );
+  roots.push(root);
+  await nodeFs.mkdir(nodePath.join(root, "packages", "ai"), {
+    recursive: true,
+  });
+  await nodeFs.mkdir(nodePath.join(root, "node_modules", "@repo"), {
+    recursive: true,
+  });
+  return root;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => nodeFs.rm(root, { recursive: true })),
+  );
+});
+
+describe("linkWorkspacePackages", () => {
+  it("accepts an already-materialized correct workspace package link", async () => {
+    const root = await makeWorkspace();
+    const target = nodePath.join(root, "packages", "ai");
+    const link = nodePath.join(root, "node_modules", "@repo", "ai");
+    await nodeFs.symlink(target, link, "dir");
+
+    await Effect.runPromise(linkWorkspacePackages(root));
+
+    expect(await nodeFs.realpath(link)).toBe(await nodeFs.realpath(target));
+  });
+
+  it("rejects an existing link that resolves to the wrong package", async () => {
+    const root = await makeWorkspace();
+    const wrong = nodePath.join(root, "packages", "wrong");
+    await nodeFs.mkdir(wrong);
+    await nodeFs.symlink(
+      wrong,
+      nodePath.join(root, "node_modules", "@repo", "ai"),
+      "dir",
+    );
+
+    const error = await Effect.runPromise(
+      Effect.flip(linkWorkspacePackages(root)),
+    );
+
+    expect(error).toBeInstanceOf(WorkspaceCommandFailed);
+    expect(error.command).toBe("link @repo/ai");
+  });
+});

--- a/apps/cli/src/commands/catalog.ts
+++ b/apps/cli/src/commands/catalog.ts
@@ -1,4 +1,5 @@
 import * as nodeFs from "node:fs/promises";
+import * as nodePath from "node:path";
 import { CatalogService } from "@repo/catalog";
 import { Apply } from "@repo/domain/Apply";
 import {
@@ -488,37 +489,62 @@ const runValidationCommand = Effect.fn(
   }
 });
 
-const linkWorkspacePackages = Effect.fn("catalog.workspace.linkPackages")(
-  function* (repoRoot: string) {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const packagesRoot = path.join(repoRoot, "packages");
-    const packageNames = yield* fs
-      .readDirectory(packagesRoot)
-      .pipe(Effect.catch(() => Effect.succeed([] as Array<string>)));
-    const scopeRoot = path.join(repoRoot, "node_modules", "@repo");
+export const linkWorkspacePackages = Effect.fn(
+  "catalog.workspace.linkPackages",
+)(function* (repoRoot: string) {
+  const packagesRoot = nodePath.join(repoRoot, "packages");
+  const packageNames = yield* Effect.promise(() =>
+    nodeFs.readdir(packagesRoot).catch(() => [] as Array<string>),
+  );
+  const scopeRoot = nodePath.join(repoRoot, "node_modules", "@repo");
 
-    yield* fs.makeDirectory(scopeRoot, { recursive: true });
-    yield* Effect.forEach(
-      packageNames,
-      (packageName) =>
-        Effect.tryPromise({
-          try: () =>
-            nodeFs.symlink(
-              path.join(packagesRoot, packageName),
-              path.join(scopeRoot, packageName),
-              "dir",
-            ),
-          catch: (error) =>
-            new WorkspaceCommandFailed({
-              command: `link @repo/${packageName}`,
-              cause: error,
-            }),
-        }),
-      { concurrency: 1 },
-    );
-  },
-);
+  yield* Effect.promise(() => nodeFs.mkdir(scopeRoot, { recursive: true }));
+  yield* Effect.forEach(
+    packageNames,
+    (packageName) => {
+      const target = nodePath.join(packagesRoot, packageName);
+      const link = nodePath.join(scopeRoot, packageName);
+
+      return Effect.tryPromise({
+        try: async () => {
+          try {
+            const existing = await nodeFs.lstat(link);
+            if (!existing.isSymbolicLink()) {
+              throw new Error(`${link} exists and is not a symbolic link`);
+            }
+            const [actualTarget, expectedTarget] = await Promise.all([
+              nodeFs.realpath(link),
+              nodeFs.realpath(target),
+            ]);
+            if (actualTarget !== expectedTarget) {
+              throw new Error(
+                `${link} points to ${actualTarget}, not ${expectedTarget}`,
+              );
+            }
+            return;
+          } catch (error) {
+            if (
+              error !== null &&
+              typeof error === "object" &&
+              "code" in error &&
+              error.code === "ENOENT"
+            ) {
+              await nodeFs.symlink(target, link, "dir");
+              return;
+            }
+            throw error;
+          }
+        },
+        catch: (error) =>
+          new WorkspaceCommandFailed({
+            command: `link @repo/${packageName}`,
+            cause: error,
+          }),
+      });
+    },
+    { concurrency: 1 },
+  );
+});
 
 const runFinalizeScripts = Effect.fn("catalog.workspace.runFinalizeScripts")(
   function* ({

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -106,8 +106,12 @@ const buildConfig = ({
     runtime: runtimeConfig,
     typescript: Option.getOrElse(typescript, () => defaults.typescriptVersion),
     monorepo: Option.getOrElse(monorepo, () => defaults.monorepo),
-    lint: Option.getOrElse(lint, () => defaults.lint),
-    format: Option.getOrElse(format, () => defaults.format),
+    ...(Option.isSome(lint) && lint.value === "none"
+      ? {}
+      : { lint: Option.getOrElse(lint, () => defaults.lint) }),
+    ...(Option.isSome(format) && format.value === "none"
+      ? {}
+      : { format: Option.getOrElse(format, () => defaults.format) }),
     test: Option.getOrElse(test, () => defaults.test),
   });
 };

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -1,12 +1,17 @@
 import { ModuleId, TargetIdentity, TargetKind } from "@repo/domain/Catalog";
 import type { RecipeSpec, RecipeTargetSpec } from "@repo/domain/Recipe";
 import { StackConfig } from "@repo/domain/Scaffold";
-import { RecipeService, StackConfigDefaults } from "@repo/scaffold";
+import {
+  getGitHookProvider,
+  RecipeService,
+  StackConfigDefaults,
+} from "@repo/scaffold";
 import { Console, Effect, Option, Schema } from "effect";
 import { Command } from "effect/unstable/cli";
 import {
   dryRunFlag,
   formatFlag,
+  gitHooksFlag,
   lintFlag,
   monorepoFlag,
   noGitFlag,
@@ -110,22 +115,33 @@ const buildConfig = ({
 const buildRecipeSpec = (
   targets: ReadonlyArray<RecipeTargetSpec>,
   includeGit: boolean,
-): RecipeSpec => ({
-  targets: [
-    ...(includeGit
-      ? [
-          {
-            target: new TargetIdentity({
-              kind: TargetKind.make("workspace"),
-              name: "",
-            }),
-            modules: [ModuleId.make("workspace-devenv-git")],
-          },
-        ]
-      : []),
-    ...targets,
-  ],
-});
+  gitHooks: "none" | "lefthook" | "husky",
+): RecipeSpec => {
+  const workspaceModules = [
+    ...(includeGit ? [ModuleId.make("workspace-devenv-git")] : []),
+    ...Option.fromNullishOr(getGitHookProvider(gitHooks).moduleId).pipe(
+      Option.map(ModuleId.make),
+      Option.toArray,
+    ),
+  ];
+
+  return {
+    targets: [
+      ...(workspaceModules.length === 0
+        ? []
+        : [
+            {
+              target: new TargetIdentity({
+                kind: TargetKind.make("workspace"),
+                name: "",
+              }),
+              modules: workspaceModules,
+            },
+          ]),
+      ...targets,
+    ],
+  };
+};
 
 export const create = Command.make(
   "create",
@@ -140,6 +156,7 @@ export const create = Command.make(
     lint: lintFlag,
     format: formatFlag,
     test: testFlag,
+    gitHooks: gitHooksFlag,
     noGit: noGitFlag,
     yes: yesFlag,
     trust: trustFlag,
@@ -186,7 +203,11 @@ export const create = Command.make(
         test: flags.test,
         defaults,
       });
-      const recipeSpec = buildRecipeSpec(flags.target.value, !flags.noGit);
+      const recipeSpec = buildRecipeSpec(
+        flags.target.value,
+        !flags.noGit,
+        Option.getOrElse(flags.gitHooks, () => "none" as const),
+      );
       const selection = yield* recipes.resolve(recipeSpec, {
         config,
         providerStrategy: { _tag: "fail-on-ambiguous" },

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -19,7 +19,9 @@ import { Command } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import {
   dryRunFlag,
+  formatFlag,
   gitHooksFlag,
+  lintFlag,
   noGitFlag,
   projectNameArg,
   rootFlag,
@@ -93,6 +95,8 @@ export const init = Command.make(
     showFiles: showFilesFlag,
     runtime: runtimeFlag,
     typescript: typescriptFlag,
+    lint: lintFlag,
+    format: formatFlag,
     gitHooks: gitHooksFlag,
     noGit: noGitFlag,
     trust: trustFlag,
@@ -216,18 +220,26 @@ export const init = Command.make(
         monorepoChoices,
         defaults.monorepo ?? "",
       );
-      const lint = yield* chooseOptionalTool(
-        flags.yes,
-        "What will you use for linting?",
-        lintChoices,
-        defaults.lint ?? "",
-      );
-      const format_ = yield* chooseOptionalTool(
-        flags.yes,
-        "What will you use for formatting?",
-        formatChoices,
-        defaults.format ?? "",
-      );
+      const lint = Option.isSome(flags.lint)
+        ? flags.lint.value === "none"
+          ? Option.none<string>()
+          : flags.lint
+        : yield* chooseOptionalTool(
+            flags.yes,
+            "What will you use for linting?",
+            lintChoices,
+            defaults.lint ?? "",
+          );
+      const format_ = Option.isSome(flags.format)
+        ? flags.format.value === "none"
+          ? Option.none<string>()
+          : flags.format
+        : yield* chooseOptionalTool(
+            flags.yes,
+            "What will you use for formatting?",
+            formatChoices,
+            defaults.format ?? "",
+          );
       const test = yield* chooseOptionalTool(
         flags.yes,
         "What test framework will you use?",

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -6,6 +6,9 @@ import {
   TargetKind,
 } from "@repo/domain/Catalog";
 import {
+  GIT_HOOK_PROVIDERS,
+  getGitHookProvider,
+  isGitHookProviderEligible,
   RecipeService,
   StackConfigDefaults,
   toWorkspaceToolValue,
@@ -16,6 +19,7 @@ import { Command } from "effect/unstable/cli";
 import { Ansi, Box } from "effect-boxes";
 import {
   dryRunFlag,
+  gitHooksFlag,
   noGitFlag,
   projectNameArg,
   rootFlag,
@@ -89,6 +93,7 @@ export const init = Command.make(
     showFiles: showFilesFlag,
     runtime: runtimeFlag,
     typescript: typescriptFlag,
+    gitHooks: gitHooksFlag,
     noGit: noGitFlag,
     trust: trustFlag,
   },
@@ -239,6 +244,27 @@ export const init = Command.make(
               initial: true,
             });
 
+      const gitHooks = Option.isSome(flags.gitHooks)
+        ? flags.gitHooks.value
+        : flags.yes || !git
+          ? ("none" as const)
+          : yield* Select({
+              message: "What Git-hook provider will you use?",
+              choices: GIT_HOOK_PROVIDERS.filter((provider) =>
+                isGitHookProviderEligible(provider.value, {
+                  runtime: runtime._tag,
+                  packageManager:
+                    runtime._tag === "bun" ? "bun" : runtime.packageManager,
+                  git,
+                  ...(Option.isSome(format_) ? { format: format_.value } : {}),
+                  ...(Option.isSome(lint) ? { lint: lint.value } : {}),
+                }),
+              ).map((provider) => ({
+                title: provider.label,
+                value: provider.value,
+              })),
+            });
+
       const dxExtras =
         devenvChoices.length === 0
           ? []
@@ -274,6 +300,37 @@ export const init = Command.make(
         }),
       });
 
+      const pipeline = yield* ScaffoldPipeline;
+      const recipe = yield* RecipeService;
+      const providerModule = getGitHookProvider(gitHooks).moduleId;
+      const explicitWorkspaceModules = [
+        ...(git ? [ModuleId.make("workspace-devenv-git")] : []),
+        ...(providerModule === undefined
+          ? []
+          : [ModuleId.make(providerModule)]),
+        ...dxExtras.map((moduleId) => ModuleId.make(moduleId)),
+      ];
+      const selection = yield* recipe.resolve(
+        {
+          targets:
+            explicitWorkspaceModules.length === 0
+              ? []
+              : [
+                  {
+                    target: new TargetIdentity({
+                      kind: TargetKind.make("workspace"),
+                      name: config.name,
+                    }),
+                    modules: explicitWorkspaceModules,
+                  },
+                ],
+        },
+        {
+          config,
+          providerStrategy: { _tag: "fail-on-ambiguous" },
+        },
+      );
+
       const dxExtrasDisplay =
         dxExtras.length === 0 ? "none" : dxExtras.join(", ");
       const configBox = Box.vsep(
@@ -295,6 +352,7 @@ export const init = Command.make(
                   Box.text("Format:"),
                   Box.text("Test:"),
                   Box.text("Git:"),
+                  Box.text("Git hooks:"),
                   Box.text("DX Extras:"),
                   Box.text("Config:"),
                 ],
@@ -312,6 +370,7 @@ export const init = Command.make(
                   Box.text(config.format ?? "none"),
                   Box.text(config.test ?? "none"),
                   Box.text(git === false ? "no" : "yes"),
+                  Box.text(gitHooks),
                   Box.text(dxExtrasDisplay),
                   Box.text(configure.configPath(repoRoot)),
                 ],
@@ -342,33 +401,6 @@ export const init = Command.make(
         yield* configure.writeConfig(repoRoot, config);
         yield* Console.log(`\nWritten ${CONFIG_FILENAME}`);
       }
-
-      const pipeline = yield* ScaffoldPipeline;
-      const recipe = yield* RecipeService;
-      const explicitWorkspaceModules = [
-        ...(git ? [ModuleId.make("workspace-devenv-git")] : []),
-        ...dxExtras.map((moduleId) => ModuleId.make(moduleId)),
-      ];
-      const selection = yield* recipe.resolve(
-        {
-          targets:
-            explicitWorkspaceModules.length === 0
-              ? []
-              : [
-                  {
-                    target: new TargetIdentity({
-                      kind: TargetKind.make("workspace"),
-                      name: config.name,
-                    }),
-                    modules: explicitWorkspaceModules,
-                  },
-                ],
-        },
-        {
-          config,
-          providerStrategy: { _tag: "fail-on-ambiguous" },
-        },
-      );
 
       yield* pipeline.run({
         selection,

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -98,12 +98,14 @@ export const monorepoFlag = Flag.string("monorepo").pipe(
 
 export const lintFlag = Flag.string("lint").pipe(
   Flag.optional,
-  Flag.withDescription("Override the default lint tool"),
+  Flag.withDescription("Override the default lint tool (use none to opt out)"),
 );
 
 export const formatFlag = Flag.string("format").pipe(
   Flag.optional,
-  Flag.withDescription("Override the default format tool"),
+  Flag.withDescription(
+    "Override the default format tool (use none to opt out)",
+  ),
 );
 
 export const testFlag = Flag.string("test").pipe(

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -1,4 +1,4 @@
-import { RecipeTargetString } from "@repo/scaffold";
+import { GIT_HOOK_PROVIDER_VALUES, RecipeTargetString } from "@repo/scaffold";
 import { Effect, Schema } from "effect";
 import { Argument, Flag } from "effect/unstable/cli";
 
@@ -50,6 +50,14 @@ export const yesFlag = Flag.boolean("yes").pipe(
   Flag.withDescription(
     "Skip confirmation prompts (uses defaults where available)",
   ),
+);
+
+export const gitHooksFlag = Flag.choice(
+  "git-hooks",
+  GIT_HOOK_PROVIDER_VALUES,
+).pipe(
+  Flag.optional,
+  Flag.withDescription("Git-hook provider (defaults to none)"),
 );
 
 export const noGitFlag = Flag.boolean("no-git").pipe(

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -842,6 +842,125 @@ describe("RecipeService", () => {
     );
   });
 
+  describe("git-hook provider validation", () => {
+    const workspaceTarget = (...modules: ReadonlyArray<string>) => ({
+      target: new TargetIdentity({
+        kind: TargetKind.make("workspace"),
+        name: "recipe-app",
+      }),
+      modules: modules.map((moduleId) => ModuleId.make(moduleId)),
+    });
+
+    const resolveProvider = (
+      modules: ReadonlyArray<string>,
+      config: typeof StackConfig.Type = testConfig,
+    ) =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        return yield* service.resolve(
+          { targets: [workspaceTarget(...modules)] },
+          {
+            config,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+      }).pipe(Effect.provide(TestLayer));
+
+    it.effect("accepts no provider and each valid canonical provider", () =>
+      Effect.gen(function* () {
+        const cases = [
+          { modules: ["workspace-devenv-git"], expected: undefined },
+          {
+            modules: ["workspace-devenv-git", "workspace-git-hooks-lefthook"],
+            expected: "workspace-git-hooks-lefthook",
+          },
+          {
+            modules: ["workspace-devenv-git", "workspace-git-hooks-husky"],
+            config: new StackConfig({
+              ...testConfig,
+              runtime: { _tag: "node", packageManager: "npm" },
+            }),
+            expected: "workspace-git-hooks-husky",
+          },
+        ] as const;
+
+        yield* Effect.forEach(cases, (entry) =>
+          resolveProvider(
+            entry.modules,
+            "config" in entry ? entry.config : testConfig,
+          ).pipe(
+            Effect.tap((selection) =>
+              Effect.sync(() => {
+                const ids = modulesForTarget(selection.targets, ".") ?? [];
+                if (entry.expected === undefined) {
+                  assert.isFalse(ids.some((id) => id.includes("git-hooks")));
+                } else {
+                  assert.include(ids, ModuleId.make(entry.expected));
+                }
+              }),
+            ),
+          ),
+        );
+      }),
+    );
+
+    it.effect(
+      "rejects invalid provider combinations with actionable issues",
+      () =>
+        Effect.gen(function* () {
+          const cases = [
+            {
+              label: "without Git",
+              modules: ["workspace-git-hooks-lefthook"],
+              config: testConfig,
+              message: "requires Git",
+            },
+            {
+              label: "Husky with Bun",
+              modules: ["workspace-devenv-git", "workspace-git-hooks-husky"],
+              config: testConfig,
+              message: "Node",
+            },
+            {
+              label: "without a supported task",
+              modules: ["workspace-devenv-git", "workspace-git-hooks-lefthook"],
+              config: new StackConfig({
+                ...testConfig,
+                format: "dprint",
+                lint: "eslint",
+              }),
+              message: "Biome or Oxc",
+            },
+            {
+              label: "with multiple providers",
+              modules: [
+                "workspace-devenv-git",
+                "workspace-git-hooks-lefthook",
+                "workspace-git-hooks-husky",
+              ],
+              config: new StackConfig({
+                ...testConfig,
+                runtime: { _tag: "node", packageManager: "pnpm" },
+              }),
+              message: "at most one",
+            },
+          ] as const;
+
+          yield* Effect.forEach(cases, ({ modules, config, message }) =>
+            Effect.flip(resolveProvider(modules, config)).pipe(
+              Effect.tap((error) =>
+                Effect.sync(() => {
+                  assert.strictEqual(error._tag, "InvalidRecipeSpec");
+                  if (error._tag !== "InvalidRecipeSpec") return;
+                  assert.include(error.issues[0]?.message, message);
+                }),
+              ),
+            ),
+          );
+        }),
+    );
+  });
+
   describe("renderCreateCommand", () => {
     it.effect(
       "should omit values supplied by an injected default StackConfig",
@@ -871,7 +990,7 @@ describe("RecipeService", () => {
               config: injectedDefaults,
               selection,
             }),
-            "bunx stack-effect@latest create injected-defaults --no-git",
+            "bunx stack-effect@latest create injected-defaults --git-hooks none --no-git",
           );
         }).pipe(Effect.provide(makeTestLayer(injectedDefaults)));
       },
@@ -896,7 +1015,7 @@ describe("RecipeService", () => {
 
           assert.strictEqual(
             service.renderCreateCommand({ config, selection }),
-            "bunx stack-effect@latest create recipe-app --monorepo nx --no-git",
+            "bunx stack-effect@latest create recipe-app --monorepo nx --git-hooks none --no-git",
           );
         }).pipe(Effect.provide(TestLayer)),
     );
@@ -920,7 +1039,7 @@ describe("RecipeService", () => {
 
           assert.strictEqual(
             service.renderCreateCommand({ config, selection }),
-            "bunx stack-effect@latest create recipe-app --no-git",
+            "bunx stack-effect@latest create recipe-app --git-hooks none --no-git",
           );
         }).pipe(Effect.provide(TestLayer)),
     );
@@ -955,7 +1074,7 @@ describe("RecipeService", () => {
 
         assert.strictEqual(
           service.renderCreateCommand({ config: testConfig, selection }),
-          "bunx stack-effect@latest create recipe-app --target server/api:server-http-api",
+          "bunx stack-effect@latest create recipe-app --target server/api:server-http-api --git-hooks none",
         );
       }).pipe(Effect.provide(TestLayer)),
     );
@@ -995,9 +1114,73 @@ describe("RecipeService", () => {
 
         assert.strictEqual(
           service.renderCreateCommand({ config, selection }),
-          "npx stack-effect@latest create 'node app' --target client-react/web:client-react-vite,client-react-chat --runtime node --package-manager pnpm --monorepo turbo --lint eslint --format prettier --no-git",
+          "npx stack-effect@latest create 'node app' --target client-react/web:client-react-vite,client-react-chat --runtime node --package-manager pnpm --monorepo turbo --lint eslint --format prettier --git-hooks none --no-git",
         );
       }).pipe(Effect.provide(TestLayer)),
+    );
+    it.effect(
+      "renders canonical providers and filters provider modules from targets",
+      () =>
+        Effect.gen(function* () {
+          const service = yield* RecipeService;
+          const cases = [
+            {
+              provider: "lefthook",
+              moduleId: "workspace-git-hooks-lefthook",
+              config: testConfig,
+              runner: "bunx",
+            },
+            {
+              provider: "husky",
+              moduleId: "workspace-git-hooks-husky",
+              config: new StackConfig({
+                ...testConfig,
+                runtime: { _tag: "node", packageManager: "npm" },
+              }),
+              runner: "npx",
+            },
+          ] as const;
+
+          yield* Effect.forEach(
+            cases,
+            ({ provider, moduleId, config, runner }) =>
+              service
+                .resolve(
+                  {
+                    targets: [
+                      {
+                        target: new TargetIdentity({
+                          kind: TargetKind.make("workspace"),
+                          name: config.name,
+                        }),
+                        modules: [
+                          ModuleId.make("workspace-devenv-git"),
+                          ModuleId.make(moduleId),
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    config,
+                    providerStrategy: { _tag: "fail-on-ambiguous" },
+                  },
+                )
+                .pipe(
+                  Effect.tap((selection) =>
+                    Effect.sync(() => {
+                      const command = service.renderCreateCommand({
+                        config,
+                        selection,
+                      });
+                      assert.include(command, `${runner} stack-effect@latest`);
+                      assert.include(command, `--git-hooks ${provider}`);
+                      assert.notInclude(command, `--target workspace/`);
+                      assert.notInclude(command, moduleId);
+                    }),
+                  ),
+                ),
+          );
+        }).pipe(Effect.provide(TestLayer)),
     );
   });
 

--- a/apps/cli/src/service/RecipeService.test.ts
+++ b/apps/cli/src/service/RecipeService.test.ts
@@ -996,6 +996,29 @@ describe("RecipeService", () => {
       },
     );
 
+    it.effect("renders explicit none sentinels for absent quality tools", () =>
+      Effect.gen(function* () {
+        const service = yield* RecipeService;
+        const config = new StackConfig({
+          ...testConfig,
+          lint: undefined,
+          format: undefined,
+        });
+        const selection = yield* service.resolve(
+          { targets: [] },
+          {
+            config,
+            providerStrategy: { _tag: "fail-on-ambiguous" },
+          },
+        );
+
+        const command = service.renderCreateCommand({ config, selection });
+        assert.include(command, "--lint none");
+        assert.include(command, "--format none");
+        assert.notInclude(command, "workspace-quality-none");
+      }).pipe(Effect.provide(TestLayer)),
+    );
+
     it.effect(
       "should render an explicit monorepo flag when Nx is configured",
       () =>

--- a/apps/docs/app/components/recipe-builder/form.ts
+++ b/apps/docs/app/components/recipe-builder/form.ts
@@ -4,6 +4,7 @@ import { StackConfigDefaults } from "@repo/scaffold/browser";
 import type { RecipePreviewInput } from "@repo/scaffold/recipe-preview";
 import { useForm } from "@tanstack/react-form";
 import { Array as Arr, Context, Schema } from "effect";
+import { normalizeGitHookModules } from "./git-hook-options";
 
 const RuntimeSchema = Schema.TaggedUnion({
   bun: {},
@@ -144,6 +145,13 @@ export type RecipeBuilderFormApi = ReturnType<typeof useRecipeBuilderForm>;
 export function toRecipePreviewInput(
   values: RecipeBuilderFormValues,
 ): RecipePreviewInput {
+  const developerExperienceModules = normalizeGitHookModules(
+    values.developerExperienceModules,
+    {
+      gitEnabled: values.gitEnabled,
+      runtime: values.config.runtime._tag,
+    },
+  );
   const supportTargets: ReadonlyArray<TargetInstance> =
     values.supportSelections.flatMap((selection) =>
       selection.selected.length > 0
@@ -187,7 +195,7 @@ export function toRecipePreviewInput(
     config: new StackConfig(values.config),
     recipe: {
       targets: [
-        ...(values.gitEnabled || values.developerExperienceModules.length > 0
+        ...(values.gitEnabled || developerExperienceModules.length > 0
           ? [
               {
                 target: new TargetIdentity({
@@ -198,9 +206,7 @@ export function toRecipePreviewInput(
                   ...(values.gitEnabled
                     ? [ModuleId.make("workspace-devenv-git")]
                     : []),
-                  ...values.developerExperienceModules.map((id) =>
-                    ModuleId.make(id),
-                  ),
+                  ...developerExperienceModules.map((id) => ModuleId.make(id)),
                 ],
               },
             ]

--- a/apps/docs/app/components/recipe-builder/git-hook-options.ts
+++ b/apps/docs/app/components/recipe-builder/git-hook-options.ts
@@ -1,0 +1,48 @@
+import {
+  GIT_HOOK_PROVIDERS,
+  type GitHookProviderValue,
+} from "@repo/scaffold/browser";
+
+const providerModuleIds: ReadonlySet<string> = new Set(
+  GIT_HOOK_PROVIDERS.flatMap(({ moduleId }) =>
+    moduleId === undefined ? [] : [moduleId],
+  ),
+);
+
+const providerForModules = (modules: ReadonlyArray<string>) => {
+  const providers = modules.filter((moduleId) =>
+    providerModuleIds.has(moduleId),
+  );
+  return providers.length === 1
+    ? GIT_HOOK_PROVIDERS.find(({ moduleId }) => moduleId === providers[0])
+    : undefined;
+};
+
+export const getGitHookProviderValue = (
+  modules: ReadonlyArray<string>,
+): GitHookProviderValue => providerForModules(modules)?.value ?? "none";
+
+export const replaceGitHookProvider = (
+  modules: ReadonlyArray<string>,
+  value: GitHookProviderValue,
+): ReadonlyArray<string> => {
+  const unrelated = modules.filter(
+    (moduleId) => !providerModuleIds.has(moduleId),
+  );
+  const moduleId = GIT_HOOK_PROVIDERS.find(
+    (provider) => provider.value === value,
+  )?.moduleId;
+  return moduleId === undefined ? unrelated : [...unrelated, moduleId];
+};
+
+export const normalizeGitHookModules = (
+  modules: ReadonlyArray<string>,
+  context: { readonly gitEnabled: boolean; readonly runtime: "bun" | "node" },
+): ReadonlyArray<string> => {
+  const provider = providerForModules(modules);
+  return !context.gitEnabled ||
+    provider === undefined ||
+    (provider.value === "husky" && context.runtime === "bun")
+    ? replaceGitHookProvider(modules, "none")
+    : modules;
+};

--- a/apps/docs/app/components/recipe-builder/recipe-builder-url.ts
+++ b/apps/docs/app/components/recipe-builder/recipe-builder-url.ts
@@ -7,6 +7,7 @@ import {
   type TargetInstance,
   toRecipePreviewInput,
 } from "./form";
+import { normalizeGitHookModules } from "./git-hook-options";
 
 const defaults = initialRecipeBuilderValues.config;
 
@@ -158,8 +159,9 @@ const toInitialValues = (
     config,
     database,
     gitEnabled: !recipe.noGit,
-    developerExperienceModules: workspaceModules.filter(
-      (module) => module !== "workspace-devenv-git",
+    developerExperienceModules: normalizeGitHookModules(
+      workspaceModules.filter((module) => module !== "workspace-devenv-git"),
+      { gitEnabled: !recipe.noGit, runtime },
     ),
     targets: formTargets,
     supportSelections: [],

--- a/apps/docs/app/components/recipe-builder/stack-configurator.tsx
+++ b/apps/docs/app/components/recipe-builder/stack-configurator.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  GIT_HOOK_PROVIDERS,
+  type GitHookProviderValue,
+  isGitHookProviderEligible,
+} from "@repo/scaffold/browser";
 import { useSelector } from "@tanstack/react-form";
 import { String as Str } from "effect";
 import { AsyncResult } from "effect/unstable/reactivity";
@@ -26,6 +31,11 @@ import {
 import { Spinner } from "~/components/ui/spinner";
 import { Toggle } from "~/components/ui/toggle";
 import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+import {
+  getGitHookProviderValue,
+  normalizeGitHookModules,
+  replaceGitHookProvider,
+} from "./git-hook-options";
 import {
   useRecipeBuilderCatalog,
   useRecipeBuilderFormContext,
@@ -124,16 +134,21 @@ export function StackConfigurator() {
             className="grid w-full grid-cols-2"
             onValueChange={(values) => {
               const value = values[0] ?? runtime;
-              configure({
-                runtime:
-                  value === "bun"
-                    ? { _tag: "bun" }
-                    : {
-                        _tag: "node",
-                        packageManager:
-                          packageManager === "bun" ? "pnpm" : packageManager,
-                      },
-              });
+              const nextRuntime =
+                value === "bun"
+                  ? ({ _tag: "bun" } as const)
+                  : ({
+                      _tag: "node" as const,
+                      packageManager:
+                        packageManager === "bun" ? "pnpm" : packageManager,
+                    } as const);
+              configure({ runtime: nextRuntime });
+              form.setFieldValue("developerExperienceModules", (current) =>
+                normalizeGitHookModules(current, {
+                  gitEnabled,
+                  runtime: nextRuntime._tag,
+                }),
+              );
             }}
           >
             <ToggleGroupItem value="bun" className="w-full">
@@ -213,9 +228,15 @@ export function StackConfigurator() {
               title="Git"
               description="Initialize a Git repository with an initial commit."
               checked={gitEnabled}
-              onCheckedChange={(enabled) =>
-                form.setFieldValue("gitEnabled", enabled)
-              }
+              onCheckedChange={(enabled) => {
+                form.setFieldValue("gitEnabled", enabled);
+                form.setFieldValue("developerExperienceModules", (current) =>
+                  normalizeGitHookModules(current, {
+                    gitEnabled: enabled,
+                    runtime,
+                  }),
+                );
+              }}
             />
             {choices?.devenv.map((choice) => (
               <ConfigurationToggle
@@ -235,6 +256,35 @@ export function StackConfigurator() {
             ))}
           </FieldGroup>
         </FieldSet>
+
+        {gitEnabled ? (
+          <ConfigurationSelect
+            id="stack-git-hooks"
+            label="Git hooks"
+            value={getGitHookProviderValue(developerExperienceModules)}
+            options={GIT_HOOK_PROVIDERS.map((provider) => ({
+              value: provider.value,
+              label: provider.label,
+              disabled: !isGitHookProviderEligible(provider.value, {
+                runtime,
+                packageManager,
+                git: gitEnabled,
+                ...(config.format === undefined
+                  ? {}
+                  : { format: config.format }),
+                ...(config.lint === undefined ? {} : { lint: config.lint }),
+              }),
+            }))}
+            onChange={(value) =>
+              form.setFieldValue("developerExperienceModules", (current) =>
+                replaceGitHookProvider(
+                  current,
+                  (value || "none") as GitHookProviderValue,
+                ),
+              )
+            }
+          />
+        ) : null}
       </FieldGroup>
     </DisclosurePanel>
   );
@@ -247,6 +297,7 @@ type ConfigurationSelectProps = {
   readonly options: ReadonlyArray<{
     readonly value: string;
     readonly label: string;
+    readonly disabled?: boolean;
   }>;
   readonly disabled?: boolean;
   readonly onChange: (value: string) => void;
@@ -285,7 +336,11 @@ function ConfigurationSelect({
         <SelectContent>
           <SelectGroup>
             {options.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
+              <SelectItem
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+              >
                 {option.label}
               </SelectItem>
             ))}

--- a/apps/docs/app/content/reference/cli/create.mdx
+++ b/apps/docs/app/content/reference/cli/create.mdx
@@ -29,6 +29,7 @@ stack-effect create [flags] [<project-name>]
 | `--lint string` | Override the default lint tool |
 | `--format string` | Override the default format tool |
 | `--test string` | Override the default test framework |
+| `--git-hooks choice` | Git-hook provider (defaults to none) (choices: none, lefthook, husky) |
 | `--no-git` | Skip git repository initialization |
 | `--yes, -y` | Skip confirmation prompts (uses defaults where available) |
 | `--trust` | Skip finalize script approval prompt and run all scripts |

--- a/apps/docs/app/content/reference/cli/create.mdx
+++ b/apps/docs/app/content/reference/cli/create.mdx
@@ -26,8 +26,8 @@ stack-effect create [flags] [<project-name>]
 | `--package-manager choice` | Override the default package manager. bun implies --runtime bun; pnpm/npm imply --runtime node. (choices: bun, pnpm, npm) |
 | `--typescript choice` | TypeScript major version to configure (choices: 6, 7) |
 | `--monorepo string` | Override the default monorepo tool |
-| `--lint string` | Override the default lint tool |
-| `--format string` | Override the default format tool |
+| `--lint string` | Override the default lint tool (use none to opt out) |
+| `--format string` | Override the default format tool (use none to opt out) |
 | `--test string` | Override the default test framework |
 | `--git-hooks choice` | Git-hook provider (defaults to none) (choices: none, lefthook, husky) |
 | `--no-git` | Skip git repository initialization |

--- a/apps/docs/app/content/reference/cli/init.mdx
+++ b/apps/docs/app/content/reference/cli/init.mdx
@@ -26,6 +26,8 @@ stack-effect init [flags] [<project-name>]
 | `--show-files` | Include generated file contents in a dry-run preview |
 | `--runtime choice` | Runtime to use (choices: bun, node) |
 | `--typescript choice` | TypeScript major version to configure (choices: 6, 7) |
+| `--lint string` | Override the default lint tool (use none to opt out) |
+| `--format string` | Override the default format tool (use none to opt out) |
 | `--git-hooks choice` | Git-hook provider (defaults to none) (choices: none, lefthook, husky) |
 | `--no-git` | Skip git repository initialization |
 | `--trust` | Skip finalize script approval prompt and run all scripts |

--- a/apps/docs/app/content/reference/cli/init.mdx
+++ b/apps/docs/app/content/reference/cli/init.mdx
@@ -26,6 +26,7 @@ stack-effect init [flags] [<project-name>]
 | `--show-files` | Include generated file contents in a dry-run preview |
 | `--runtime choice` | Runtime to use (choices: bun, node) |
 | `--typescript choice` | TypeScript major version to configure (choices: 6, 7) |
+| `--git-hooks choice` | Git-hook provider (defaults to none) (choices: none, lefthook, husky) |
 | `--no-git` | Skip git repository initialization |
 | `--trust` | Skip finalize script approval prompt and run all scripts |
 

--- a/apps/docs/test/components/recipe-builder/recipe-builder-form.unit.test.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-builder-form.unit.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   initialRecipeBuilderValues,
   RecipeBuilderFormSchema,
+  toRecipePreviewInput,
 } from "../../../app/components/recipe-builder/form";
+import {
+  getGitHookProviderValue,
+  normalizeGitHookModules,
+  replaceGitHookProvider,
+} from "../../../app/components/recipe-builder/git-hook-options";
 
 const decodeForm = Schema.decodeUnknownOption(RecipeBuilderFormSchema);
 
@@ -37,5 +43,70 @@ describe("recipe builder form", () => {
     });
 
     expect(Option.isNone(result)).toBe(true);
+  });
+
+  it("replaces providers while preserving unrelated ordered DX modules", () => {
+    const modules = ["dx-first", "workspace-git-hooks-lefthook", "dx-second"];
+
+    expect(replaceGitHookProvider(modules, "husky")).toEqual([
+      "dx-first",
+      "dx-second",
+      "workspace-git-hooks-husky",
+    ]);
+    expect(replaceGitHookProvider(modules, "none")).toEqual([
+      "dx-first",
+      "dx-second",
+    ]);
+  });
+
+  it("normalizes malformed, Git-disabled, and Bun-ineligible provider state", () => {
+    const malformed = [
+      "dx-first",
+      "workspace-git-hooks-lefthook",
+      "workspace-git-hooks-husky",
+      "dx-second",
+    ];
+
+    expect(getGitHookProviderValue(malformed)).toBe("none");
+    expect(
+      normalizeGitHookModules(malformed, { gitEnabled: true, runtime: "node" }),
+    ).toEqual(["dx-first", "dx-second"]);
+    expect(
+      normalizeGitHookModules(
+        ["dx-first", "workspace-git-hooks-lefthook", "dx-second"],
+        { gitEnabled: false, runtime: "node" },
+      ),
+    ).toEqual(["dx-first", "dx-second"]);
+    expect(
+      normalizeGitHookModules(
+        ["dx-first", "workspace-git-hooks-husky", "dx-second"],
+        { gitEnabled: true, runtime: "bun" },
+      ),
+    ).toEqual(["dx-first", "dx-second"]);
+  });
+
+  it("normalizes stale provider state before constructing preview input", () => {
+    const input = toRecipePreviewInput({
+      ...initialRecipeBuilderValues,
+      config: {
+        ...initialRecipeBuilderValues.config,
+        runtime: { _tag: "bun" },
+      },
+      developerExperienceModules: [
+        "dx-first",
+        "workspace-git-hooks-husky",
+        "dx-second",
+      ],
+    });
+    const workspace = input.recipe.targets.find(
+      ({ target }) => target.kind === "workspace",
+    );
+
+    expect(workspace?.modules.map(String)).toEqual([
+      "workspace-devenv-git",
+      "dx-first",
+      "dx-second",
+    ]);
+    expect("gitHooks" in input.config).toBe(false);
   });
 });

--- a/apps/docs/test/components/recipe-builder/recipe-builder-url.unit.test.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-builder-url.unit.test.ts
@@ -93,4 +93,50 @@ describe("recipe builder URL", () => {
     ).toBe(false);
     expect(encoded.getAll("target")).toContain("package/db:package-db-sqlite");
   });
+
+  it("round trips a provider only through the workspace target parameter", () => {
+    const encoded = encodeRecipeBuilderUrl({
+      ...fullStackRecipeFixture,
+      config: {
+        ...fullStackRecipeFixture.config,
+        runtime: { _tag: "node", packageManager: "pnpm" },
+      },
+      developerExperienceModules: [
+        "dx-first",
+        "workspace-git-hooks-husky",
+        "dx-second",
+      ],
+    });
+    const decoded = decodeRecipeBuilderUrl(encoded);
+
+    expect(encoded.getAll("target").join("&")).toContain(
+      "workspace-git-hooks-husky",
+    );
+    expect([...encoded.keys()]).not.toContain("git-hooks");
+    expect([...encoded.keys()]).not.toContain("gitHooks");
+    expect(decoded.issue).toBeUndefined();
+    expect(decoded.initialValues.developerExperienceModules).toEqual([
+      "dx-first",
+      "workspace-git-hooks-husky",
+      "dx-second",
+    ]);
+  });
+
+  it("clears invalid provider state while decoding without clearing unrelated DX", () => {
+    const cases = [
+      "?name=shared&target=workspace%2Fshared%3Adx-first%2Cworkspace-git-hooks-lefthook%2Cworkspace-git-hooks-husky%2Cdx-second",
+      "?name=shared&runtime=bun&target=workspace%2Fshared%3Adx-first%2Cworkspace-git-hooks-husky%2Cdx-second",
+      "?name=shared&no-git&target=workspace%2Fshared%3Adx-first%2Cworkspace-git-hooks-lefthook%2Cdx-second",
+    ];
+
+    cases.forEach((search) => {
+      const decoded = decodeRecipeBuilderUrl(new URLSearchParams(search));
+
+      expect(decoded.issue).toBeUndefined();
+      expect(decoded.initialValues.developerExperienceModules).toEqual([
+        "dx-first",
+        "dx-second",
+      ]);
+    });
+  });
 });

--- a/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
+++ b/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
@@ -227,6 +227,53 @@ test("should replace valid URL edits and reset the existing form for external na
     .toHaveValue("my-effect-app");
 });
 
+test("should clear only ineligible Git-hook state across repeated transitions", async () => {
+  await renderRecipeBuilder();
+
+  const gitHooks = page.getByLabelText("Git hooks");
+  await expect.element(gitHooks).toHaveTextContent("None");
+  await gitHooks.click();
+  await expect
+    .element(page.getByRole("option", { name: "Lefthook" }))
+    .toBeVisible();
+  await expect
+    .element(
+      page.getByRole("option", {
+        name: "Husky + lint-staged (Node >=24 only)",
+      }),
+    )
+    .toBeDisabled();
+  await page.getByRole("option", { name: "Lefthook" }).click();
+  await expect.element(gitHooks).toHaveTextContent("Lefthook");
+
+  await page.getByRole("button", { name: /Git/u }).click();
+  await expect
+    .element(page.getByLabelText("Git hooks"))
+    .not.toBeInTheDocument();
+  await page.getByRole("button", { name: /Git/u }).click();
+  await expect
+    .element(page.getByLabelText("Git hooks"))
+    .toHaveTextContent("None");
+
+  await page.getByRole("button", { name: "Node" }).click();
+  await page.getByLabelText("Git hooks").click();
+  await page
+    .getByRole("option", { name: "Husky + lint-staged (Node >=24 only)" })
+    .click();
+  await expect
+    .element(page.getByLabelText("Git hooks"))
+    .toHaveTextContent("Husky + lint-staged (Node >=24 only)");
+
+  await page.getByRole("button", { name: "Bun" }).click();
+  await expect
+    .element(page.getByLabelText("Git hooks"))
+    .toHaveTextContent("None");
+  await page.getByRole("button", { name: "Node" }).click();
+  await expect
+    .element(page.getByLabelText("Git hooks"))
+    .toHaveTextContent("None");
+});
+
 test("should generate a usable preview when the user completes a valid Selection", async () => {
   await renderRecipeBuilder();
 

--- a/apps/docs/test/components/recipe-builder/recipe-fixtures.ts
+++ b/apps/docs/test/components/recipe-builder/recipe-fixtures.ts
@@ -231,6 +231,37 @@ export const recipeCatalogFixture = Schema.decodeUnknownSync(
   },
 });
 
+export const makeGitHookRecipeFixture = ({
+  provider = "none",
+  gitEnabled = true,
+  runtime = "bun",
+  packageManager = "pnpm",
+}: {
+  readonly provider?: "none" | "lefthook" | "husky";
+  readonly gitEnabled?: boolean;
+  readonly runtime?: "bun" | "node";
+  readonly packageManager?: "npm" | "pnpm";
+} = {}): RecipeBuilderFormValues => ({
+  config: {
+    name: "git-hook-preview",
+    runtime:
+      runtime === "bun" ? { _tag: "bun" } : { _tag: "node", packageManager },
+    typescript: "6",
+    monorepo: "turbo",
+    lint: "biome",
+    format: "biome",
+    test: "vitest",
+  },
+  gitEnabled,
+  database: "none",
+  developerExperienceModules: [
+    "workspace-devenv-nix-flake",
+    ...(provider === "none" ? [] : [`workspace-git-hooks-${provider}`]),
+  ],
+  targets: [],
+  supportSelections: [],
+});
+
 export const fullStackRecipeFixture: RecipeBuilderFormValues = {
   config: {
     name: "full-stack-app",

--- a/apps/docs/test/workers/recipe-builder.browser.test.ts
+++ b/apps/docs/test/workers/recipe-builder.browser.test.ts
@@ -219,6 +219,7 @@ it.live(
         assert.notProperty(config, "gitHookProvider");
       }
     }),
+  30_000,
 );
 
 it.live(

--- a/apps/docs/test/workers/recipe-builder.browser.test.ts
+++ b/apps/docs/test/workers/recipe-builder.browser.test.ts
@@ -4,7 +4,10 @@ import { Effect } from "effect";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import { catalogAtom, previewAtom } from "../../app/atom/recipe-builder-atom";
 import { toRecipePreviewInput } from "../../app/components/recipe-builder/form";
-import { fullStackRecipeFixture } from "../components/recipe-builder/recipe-fixtures";
+import {
+  fullStackRecipeFixture,
+  makeGitHookRecipeFixture,
+} from "../components/recipe-builder/recipe-fixtures";
 
 const runAtom = <Arg, A, E>(
   atom: import("effect/unstable/reactivity").Atom.AtomResultFn<Arg, A, E>,
@@ -41,6 +44,180 @@ it.live(
       assert.include(paths, "apps/server-api/package.json");
       assert.include(paths, "packages/domain/package.json");
       assert.include(preview.preview.command, "full-stack-app");
+    }),
+);
+
+const workspaceModules = (preview: {
+  readonly selection: {
+    readonly targets: ReadonlyArray<{
+      readonly identity: { readonly kind: string };
+      readonly modules: ReadonlyArray<{ readonly id: string }>;
+    }>;
+  };
+}) =>
+  preview.selection.targets
+    .find(({ identity }) => identity.kind === "workspace")
+    ?.modules.map(({ id }) => id) ?? [];
+
+const blueprintModules = (preview: {
+  readonly blueprint: {
+    readonly nodes: ReadonlyArray<
+      | { readonly _tag: "target" }
+      | { readonly _tag: "attached-module"; readonly moduleId: string }
+    >;
+  };
+}) =>
+  preview.blueprint.nodes.flatMap((node) =>
+    node._tag === "attached-module" ? [node.moduleId] : [],
+  );
+
+const previewFile = (
+  preview: {
+    readonly files: ReadonlyArray<{ path: string; contents: string }>;
+  },
+  path: string,
+) => preview.files.find((file) => file.path === path);
+
+const assertNoProviderArtifacts = (preview: {
+  readonly files: ReadonlyArray<{ path: string; contents: string }>;
+}) => {
+  const paths = preview.files.map(({ path }) => path);
+  assert.notInclude(paths, "lefthook.yml");
+  assert.notInclude(paths, ".husky/pre-commit");
+  assert.notInclude(paths, "lint-staged.config.mjs");
+  const packageJson = JSON.parse(
+    previewFile(preview, "package.json")?.contents ?? "{}",
+  );
+  assert.notProperty(packageJson.devDependencies ?? {}, "lefthook");
+  assert.notProperty(packageJson.devDependencies ?? {}, "husky");
+  assert.notProperty(packageJson.devDependencies ?? {}, "lint-staged");
+};
+
+it.live(
+  "should plan exclusive Git-hook artifacts through the unmocked browser Worker",
+  () =>
+    Effect.gen(function* () {
+      const runPreview = (
+        fixture: Parameters<typeof toRecipePreviewInput>[0],
+      ) =>
+        runAtom(previewAtom, {
+          targetIdentityKey: "git-hook-preview",
+          input: toRecipePreviewInput(fixture),
+        }).pipe(Effect.map(({ preview }) => preview));
+
+      const none = yield* runPreview(makeGitHookRecipeFixture());
+      assert.include(none.command, "--git-hooks none");
+      assert.include(workspaceModules(none), "workspace-devenv-git");
+      assert.include(workspaceModules(none), "workspace-devenv-nix-flake");
+      assert.isFalse(
+        blueprintModules(none).some((id) =>
+          id.startsWith("workspace-git-hooks-"),
+        ),
+      );
+      assertNoProviderArtifacts(none);
+
+      const lefthook = yield* runPreview(
+        makeGitHookRecipeFixture({
+          provider: "lefthook",
+          runtime: "node",
+          packageManager: "pnpm",
+        }),
+      );
+      assert.include(lefthook.command, "--git-hooks lefthook");
+      assert.include(
+        workspaceModules(lefthook),
+        "workspace-git-hooks-lefthook",
+      );
+      assert.include(
+        blueprintModules(lefthook),
+        "workspace-git-hooks-lefthook",
+      );
+      assert.notInclude(
+        blueprintModules(lefthook),
+        "workspace-git-hooks-husky",
+      );
+      assert.strictEqual(
+        previewFile(lefthook, "lefthook.yml")?.contents,
+        `pre-commit:\n  parallel: false\n  commands:\n    format:\n      glob: "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"\n      run: "pnpm run git-hooks:format -- {staged_files}"\n      stage_fixed: true\n    lint:\n      glob: "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"\n      run: "pnpm run git-hooks:lint -- {staged_files}"\n      stage_fixed: true\n`,
+      );
+      assert.strictEqual(
+        previewFile(lefthook, "pnpm-workspace.yaml")?.contents,
+        `packages:\n  - "apps/*"\n  - "packages/*"\n\nallowBuilds:\n  esbuild: true\n  msgpackr-extract: true\n  lefthook: true\n`,
+      );
+      const lefthookPackage = JSON.parse(
+        previewFile(lefthook, "package.json")?.contents ?? "{}",
+      );
+      assert.strictEqual(lefthookPackage.devDependencies.lefthook, "2.1.10");
+      assert.strictEqual(
+        lefthookPackage.scripts["lefthook:install"],
+        "lefthook install",
+      );
+      assert.strictEqual(
+        lefthookPackage.scripts.prepare,
+        "effect-language-service patch",
+      );
+
+      const husky = yield* runPreview(
+        makeGitHookRecipeFixture({
+          provider: "husky",
+          runtime: "node",
+          packageManager: "npm",
+        }),
+      );
+      assert.include(husky.command, "--git-hooks husky");
+      assert.include(workspaceModules(husky), "workspace-git-hooks-husky");
+      assert.include(blueprintModules(husky), "workspace-git-hooks-husky");
+      assert.notInclude(
+        blueprintModules(husky),
+        "workspace-git-hooks-lefthook",
+      );
+      assert.strictEqual(
+        previewFile(husky, ".husky/pre-commit")?.contents,
+        "npm run lint-staged\n",
+      );
+      assert.include(
+        previewFile(husky, "lint-staged.config.mjs")?.contents ?? "",
+        '"npm run git-hooks:format --",',
+      );
+      const huskyPackage = JSON.parse(
+        previewFile(husky, "package.json")?.contents ?? "{}",
+      );
+      assert.strictEqual(huskyPackage.devDependencies.husky, "9.1.7");
+      assert.strictEqual(huskyPackage.devDependencies["lint-staged"], "17.4.1");
+      assert.strictEqual(
+        huskyPackage.scripts.prepare,
+        "effect-language-service patch",
+      );
+      assert.isUndefined(previewFile(husky, "pnpm-workspace.yaml"));
+
+      for (const cleared of [
+        makeGitHookRecipeFixture({ provider: "lefthook", gitEnabled: false }),
+        makeGitHookRecipeFixture({ provider: "husky", runtime: "bun" }),
+      ]) {
+        const preview = yield* runPreview(cleared);
+        assert.include(preview.command, "--git-hooks none");
+        assert.include(workspaceModules(preview), "workspace-devenv-nix-flake");
+        assert.isFalse(
+          blueprintModules(preview).some((id) =>
+            id.startsWith("workspace-git-hooks-"),
+          ),
+        );
+        assertNoProviderArtifacts(preview);
+      }
+
+      const noGit = yield* runPreview(
+        makeGitHookRecipeFixture({ gitEnabled: false }),
+      );
+      assert.include(noGit.command, "--no-git");
+      assert.notInclude(workspaceModules(noGit), "workspace-devenv-git");
+
+      for (const preview of [none, lefthook, husky, noGit]) {
+        const config = JSON.parse(
+          previewFile(preview, "stack.effect.json")?.contents ?? "{}",
+        );
+        assert.notProperty(config, "gitHooks");
+        assert.notProperty(config, "gitHookProvider");
+      }
     }),
 );
 

--- a/packages/catalog/src/registry/content/git-hooks.ts
+++ b/packages/catalog/src/registry/content/git-hooks.ts
@@ -1,0 +1,33 @@
+export const lefthookYamlContents = `pre-commit:
+  parallel: false
+  commands:{{#if format=biome}}
+    format:
+      glob: "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"
+      run: "{{packageManager}} run git-hooks:format -- {staged_files}"
+      stage_fixed: true{{/if}}{{#if format=oxfmt}}
+    format:
+      glob: "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"
+      run: "{{packageManager}} run git-hooks:format -- {staged_files}"
+      stage_fixed: true{{/if}}{{#if lint=biome}}
+    lint:
+      glob: "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"
+      run: "{{packageManager}} run git-hooks:lint -- {staged_files}"
+      stage_fixed: true{{/if}}{{#if lint=oxlint}}
+    lint:
+      glob: "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"
+      run: "{{packageManager}} run git-hooks:lint -- {staged_files}"
+      stage_fixed: true{{/if}}
+`;
+
+export const huskyPreCommitContents = `{{packageManager}} run lint-staged
+`;
+
+export const lintStagedConfigContents = `export default {
+  "*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}": [{{#if format=biome}}
+    "{{packageManager}} run git-hooks:format --",{{/if}}{{#if format=oxfmt}}
+    "{{packageManager}} run git-hooks:format --",{{/if}}{{#if lint=biome}}
+    "{{packageManager}} run git-hooks:lint --",{{/if}}{{#if lint=oxlint}}
+    "{{packageManager}} run git-hooks:lint --",{{/if}}
+  ],
+};
+`;

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -70,7 +70,8 @@ export const pnpmWorkspaceContents = `packages:
 allowBuilds:
   esbuild: true
   msgpackr-extract: true{{#if monorepo=nx}}
-  nx: true{{/if}}
+  nx: true{{/if}}{{#if module=workspace-git-hooks-lefthook}}
+  lefthook: true{{/if}}
 `;
 
 export const configTypescriptBaseContents = `{

--- a/packages/catalog/src/registry/moduleRegistry.test.ts
+++ b/packages/catalog/src/registry/moduleRegistry.test.ts
@@ -1,5 +1,6 @@
 import { ModuleCapability } from "@repo/domain/Catalog";
 import { describe, expect, it } from "vitest";
+import { pnpmWorkspaceContents } from "./content/init";
 import { moduleRegistry } from "./moduleRegistry";
 
 describe("moduleRegistry", () => {
@@ -131,6 +132,129 @@ describe("moduleRegistry", () => {
       "workspace-quality-biome-format",
       "workspace-quality-dprint",
     ]);
+  });
+
+  it.each([
+    {
+      id: "workspace-git-hooks-lefthook",
+      conflict: "workspace-git-hooks-husky",
+      files: ["{{targetPath}}/lefthook.yml"],
+      dependencies: { lefthook: "2.1.10" },
+      scripts: {
+        "lefthook:install": "lefthook install",
+        "git-hooks:format":
+          "{{#if format=biome}}biome format --write{{/if}}{{#if format=oxfmt}}oxfmt{{/if}}",
+        "git-hooks:lint":
+          "{{#if lint=biome}}biome lint --write{{/if}}{{#if lint=oxlint}}oxlint --fix{{/if}}",
+      },
+      installer: "{{packageManager}} run lefthook:install",
+    },
+    {
+      id: "workspace-git-hooks-husky",
+      conflict: "workspace-git-hooks-lefthook",
+      files: [
+        "{{targetPath}}/.husky/pre-commit",
+        "{{targetPath}}/lint-staged.config.mjs",
+      ],
+      dependencies: { husky: "9.1.7", "lint-staged": "17.4.1" },
+      scripts: {
+        "husky:install": "husky",
+        "lint-staged": "lint-staged",
+        "git-hooks:format":
+          "{{#if format=biome}}biome format --write{{/if}}{{#if format=oxfmt}}oxfmt{{/if}}",
+        "git-hooks:lint":
+          "{{#if lint=biome}}biome lint --write{{/if}}{{#if lint=oxlint}}oxlint --fix{{/if}}",
+      },
+      installer: "{{packageManager}} run husky:install",
+    },
+  ])("registers exact native $id contributions", (contract) => {
+    const provider = moduleRegistry.find((mod) => mod.id === contract.id);
+
+    expect(provider).toBeDefined();
+    expect(provider?.categories).toEqual(["git-hooks"]);
+    expect(provider?.conflictsWith).toEqual([contract.conflict]);
+    expect(provider?.dependencies).toContainEqual({
+      _tag: "required-module",
+      target: expect.objectContaining({ kind: "workspace", name: "root" }),
+      moduleId: "workspace-devenv-git",
+    });
+
+    const files = provider?.contributions.filter(
+      (item) => item._tag === "file",
+    );
+    expect(files?.map((item) => item.path)).toEqual(contract.files);
+
+    const entries = Object.fromEntries(
+      (provider?.contributions ?? [])
+        .filter((item) => item._tag === "pkg-json-entry")
+        .map((item) => [`${item.field}.${item.name}`, item.value]),
+    );
+    expect(entries).toMatchObject(
+      Object.fromEntries(
+        Object.entries(contract.dependencies).map(([name, value]) => [
+          `devDependencies.${name}`,
+          value,
+        ]),
+      ),
+    );
+    expect(entries).toMatchObject(
+      Object.fromEntries(
+        Object.entries(contract.scripts).map(([name, value]) => [
+          `scripts.${name}`,
+          value,
+        ]),
+      ),
+    );
+    expect(entries["scripts.prepare"]).toBeUndefined();
+    expect(provider?.scripts).toEqual([
+      expect.objectContaining({
+        command: contract.installer,
+        phase: "post-finalize",
+      }),
+    ]);
+    expect(provider?.nextSteps).toEqual([
+      expect.stringContaining("initial commit"),
+      expect.stringContaining("staged"),
+      expect.stringContaining("non-fixable"),
+    ]);
+  });
+
+  it("defines filename-aware serial provider configurations without prohibited setup", () => {
+    const providers = moduleRegistry.filter((mod) =>
+      mod.id.startsWith("workspace-git-hooks-"),
+    );
+    const contents = providers
+      .flatMap((provider) =>
+        provider.contributions.flatMap((item) =>
+          item._tag === "file" ? [item.contents] : [],
+        ),
+      )
+      .join("\n");
+    const commands = providers
+      .flatMap((provider) => [
+        ...(provider.scripts ?? []).map((script) => script.command),
+        ...provider.contributions.flatMap((item) =>
+          item._tag === "pkg-json-entry" ? [item.value] : [],
+        ),
+      ])
+      .join("\n");
+
+    expect(providers.map((provider) => provider.id)).toEqual([
+      "workspace-git-hooks-lefthook",
+      "workspace-git-hooks-husky",
+    ]);
+    expect(contents).toContain("*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}");
+    expect(contents).toContain("parallel: false");
+    expect(contents).toContain("stage_fixed: true");
+    expect(contents).toContain('"{{packageManager}} run git-hooks:format --"');
+    expect(contents).toContain('"{{packageManager}} run git-hooks:lint --"');
+    expect(commands).not.toMatch(/husky init|git add|chmod|postinstall/);
+  });
+
+  it("adds the Lefthook pnpm allow-build entry only through module presence", () => {
+    expect(pnpmWorkspaceContents).toContain(
+      "{{#if module=workspace-git-hooks-lefthook}}\n  lefthook: true{{/if}}",
+    );
   });
 
   it("should explain the global executable requirement when Vite+ is selected", () => {

--- a/packages/catalog/src/registry/moduleRegistry.test.ts
+++ b/packages/catalog/src/registry/moduleRegistry.test.ts
@@ -142,9 +142,9 @@ describe("moduleRegistry", () => {
       dependencies: { lefthook: "2.1.10" },
       scripts: {
         "lefthook:install": "lefthook install",
-        "git-hooks:format":
+        "{{#if format=biome}}git-hooks:format{{/if}}{{#if format=oxfmt}}git-hooks:format{{/if}}":
           "{{#if format=biome}}biome format --write{{/if}}{{#if format=oxfmt}}oxfmt{{/if}}",
-        "git-hooks:lint":
+        "{{#if lint=biome}}git-hooks:lint{{/if}}{{#if lint=oxlint}}git-hooks:lint{{/if}}":
           "{{#if lint=biome}}biome lint --write{{/if}}{{#if lint=oxlint}}oxlint --fix{{/if}}",
       },
       installer: "{{packageManager}} run lefthook:install",
@@ -160,9 +160,9 @@ describe("moduleRegistry", () => {
       scripts: {
         "husky:install": "husky",
         "lint-staged": "lint-staged",
-        "git-hooks:format":
+        "{{#if format=biome}}git-hooks:format{{/if}}{{#if format=oxfmt}}git-hooks:format{{/if}}":
           "{{#if format=biome}}biome format --write{{/if}}{{#if format=oxfmt}}oxfmt{{/if}}",
-        "git-hooks:lint":
+        "{{#if lint=biome}}git-hooks:lint{{/if}}{{#if lint=oxlint}}git-hooks:lint{{/if}}":
           "{{#if lint=biome}}biome lint --write{{/if}}{{#if lint=oxlint}}oxlint --fix{{/if}}",
       },
       installer: "{{packageManager}} run husky:install",

--- a/packages/catalog/src/registry/moduleRegistry.ts
+++ b/packages/catalog/src/registry/moduleRegistry.ts
@@ -4,6 +4,7 @@ import { clientModules } from "./modules/client";
 import { clientFoldkitModules } from "./modules/client-foldkit";
 import { configModules } from "./modules/config";
 import { domainModules } from "./modules/domain";
+import { gitHookModules } from "./modules/git-hooks";
 import { initModules } from "./modules/init";
 import { mcpModules } from "./modules/mcp";
 import { packageModules } from "./modules/packages";
@@ -11,6 +12,7 @@ import { serverModules } from "./modules/server";
 
 export const moduleRegistry: ReadonlyArray<typeof ModuleDefinition.Type> = [
   ...initModules,
+  ...gitHookModules,
   ...configModules,
   ...domainModules,
   ...serverModules,

--- a/packages/catalog/src/registry/modules/git-hooks.ts
+++ b/packages/catalog/src/registry/modules/git-hooks.ts
@@ -27,7 +27,7 @@ const taskScripts = [
     _tag: "pkg-json-entry" as const,
     path: "{{targetPath}}/package.json",
     field: "scripts" as const,
-    name: "git-hooks:format",
+    name: "{{#if format=biome}}git-hooks:format{{/if}}{{#if format=oxfmt}}git-hooks:format{{/if}}",
     value:
       "{{#if format=biome}}biome format --write{{/if}}{{#if format=oxfmt}}oxfmt{{/if}}",
   },
@@ -35,7 +35,7 @@ const taskScripts = [
     _tag: "pkg-json-entry" as const,
     path: "{{targetPath}}/package.json",
     field: "scripts" as const,
-    name: "git-hooks:lint",
+    name: "{{#if lint=biome}}git-hooks:lint{{/if}}{{#if lint=oxlint}}git-hooks:lint{{/if}}",
     value:
       "{{#if lint=biome}}biome lint --write{{/if}}{{#if lint=oxlint}}oxlint --fix{{/if}}",
   },

--- a/packages/catalog/src/registry/modules/git-hooks.ts
+++ b/packages/catalog/src/registry/modules/git-hooks.ts
@@ -1,0 +1,150 @@
+import {
+  ModuleCategory,
+  type ModuleDefinition,
+  ModuleId,
+  TargetIdentity,
+  TargetKind,
+} from "@repo/domain/Catalog";
+import {
+  huskyPreCommitContents,
+  lefthookYamlContents,
+  lintStagedConfigContents,
+} from "../content/git-hooks";
+
+const workspaceRoot = new TargetIdentity({
+  kind: TargetKind.make("workspace"),
+  name: "root",
+});
+
+const requiredGit = {
+  _tag: "required-module" as const,
+  target: workspaceRoot,
+  moduleId: ModuleId.make("workspace-devenv-git"),
+};
+
+const taskScripts = [
+  {
+    _tag: "pkg-json-entry" as const,
+    path: "{{targetPath}}/package.json",
+    field: "scripts" as const,
+    name: "git-hooks:format",
+    value:
+      "{{#if format=biome}}biome format --write{{/if}}{{#if format=oxfmt}}oxfmt{{/if}}",
+  },
+  {
+    _tag: "pkg-json-entry" as const,
+    path: "{{targetPath}}/package.json",
+    field: "scripts" as const,
+    name: "git-hooks:lint",
+    value:
+      "{{#if lint=biome}}biome lint --write{{/if}}{{#if lint=oxlint}}oxlint --fix{{/if}}",
+  },
+];
+
+const nextSteps = [
+  "Git hooks: Protection starts after the complete initial commit.",
+  "Git hooks: Successful fixes may update staged content for that commit; inspect staged and unstaged state after interruption.",
+  "Git hooks: non-fixable errors block the commit.",
+];
+
+export const gitHookModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
+  {
+    id: ModuleId.make("workspace-git-hooks-lefthook"),
+    title: "Lefthook",
+    description: "Run filename-aware format and lint tasks with Lefthook",
+    visibility: "internal",
+    categories: [ModuleCategory.make("git-hooks")],
+    conflictsWith: [ModuleId.make("workspace-git-hooks-husky")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [requiredGit],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/lefthook.yml",
+        contents: lefthookYamlContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "lefthook",
+        value: "2.1.10",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "lefthook:install",
+        value: "lefthook install",
+      },
+      ...taskScripts,
+    ],
+    scripts: [
+      {
+        label: "Install Lefthook",
+        command: "{{packageManager}} run lefthook:install",
+        phase: "post-finalize",
+      },
+    ],
+    nextSteps,
+  },
+  {
+    id: ModuleId.make("workspace-git-hooks-husky"),
+    title: "Husky + lint-staged",
+    description: "Run filename-aware format and lint tasks with Husky",
+    visibility: "internal",
+    categories: [ModuleCategory.make("git-hooks")],
+    conflictsWith: [ModuleId.make("workspace-git-hooks-lefthook")],
+    supportedOn: [{ _tag: "kind", kind: TargetKind.make("workspace") }],
+    dependencies: [requiredGit],
+    contributions: [
+      {
+        _tag: "file",
+        path: "{{targetPath}}/.husky/pre-commit",
+        contents: huskyPreCommitContents,
+      },
+      {
+        _tag: "file",
+        path: "{{targetPath}}/lint-staged.config.mjs",
+        contents: lintStagedConfigContents,
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "husky",
+        value: "9.1.7",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "devDependencies",
+        name: "lint-staged",
+        value: "17.4.1",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "husky:install",
+        value: "husky",
+      },
+      {
+        _tag: "pkg-json-entry",
+        path: "{{targetPath}}/package.json",
+        field: "scripts",
+        name: "lint-staged",
+        value: "lint-staged",
+      },
+      ...taskScripts,
+    ],
+    scripts: [
+      {
+        label: "Install Husky",
+        command: "{{packageManager}} run husky:install",
+        phase: "post-finalize",
+      },
+    ],
+    nextSteps,
+  },
+];

--- a/packages/domain/src/Scaffold.test.ts
+++ b/packages/domain/src/Scaffold.test.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
-import { TargetIdentity, TargetKey, TargetKind } from "./Catalog";
+import { ModuleId, TargetIdentity, TargetKey, TargetKind } from "./Catalog";
 import { ContributionTokenContext, StackConfig } from "./Scaffold";
 
 describe("@repo/domain Scaffold", () => {
@@ -336,6 +336,46 @@ describe("ContributionTokenContext.resolve", () => {
         "is node",
       );
     });
+  });
+
+  describe("module-presence conditionals", () => {
+    it.each([
+      [undefined, "workspace-git-hooks-lefthook", ""],
+      [[], "workspace-git-hooks-lefthook", ""],
+      [["workspace-quality-biome-format"], "workspace-git-hooks-lefthook", ""],
+      [
+        ["workspace-git-hooks-lefthook"],
+        "workspace-git-hooks-lefthook",
+        "enabled",
+      ],
+      [
+        ["unknown", "workspace-git-hooks-husky", "another"],
+        "workspace-git-hooks-husky",
+        "enabled",
+      ],
+    ] as const)(
+      "resolves target-local attached module IDs with a default-false result",
+      (attachedModuleIds, moduleId, expected) => {
+        const context = new ContributionTokenContext({
+          targetKey: TargetKey.make("apps/server-api"),
+          identity: new TargetIdentity({
+            kind: TargetKind.make("server"),
+            name: "api",
+          }),
+          config: new StackConfig({
+            name: "my-project" as typeof Schema.NonEmptyString.Type,
+            runtime: { _tag: "bun" },
+          }),
+          ...(attachedModuleIds === undefined
+            ? {}
+            : { attachedModuleIds: attachedModuleIds.map(ModuleId.make) }),
+        });
+
+        expect(
+          context.resolve(`{{#if module=${moduleId}}}enabled{{/if}}`),
+        ).toBe(expected);
+      },
+    );
   });
 
   describe("unknown fields", () => {

--- a/packages/domain/src/Scaffold.ts
+++ b/packages/domain/src/Scaffold.ts
@@ -72,6 +72,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
   targetKey: TargetKey,
   identity: TargetIdentity,
   config: StackConfig,
+  attachedModuleIds: Schema.optional(Schema.Array(ModuleId)),
 }) {
   /**
    * Resolve template tokens and conditionals in a string.
@@ -92,6 +93,7 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
    * ## Conditionals
    * - `{{#if field}}...{{/if}}` - Include content if field is truthy (non-empty)
    * - `{{#if field=value}}...{{/if}}` - Include content if field equals value
+   * - `{{#if module=<id>}}...{{/if}}` - Include content if the module is attached to this target
    *
    * Unknown fields in conditionals silently evaluate as falsy.
    */
@@ -134,6 +136,13 @@ export class ContributionTokenContext extends Schema.Class<ContributionTokenCont
       const conditionalRegex =
         /\{\{#if\s+(\w+)(?:=([\w-]+))?\}\}([\s\S]*?)\{\{\/if\}\}/g;
       return t.replace(conditionalRegex, (_, field, value, content) => {
+        if (field === "module") {
+          return value !== undefined &&
+            (this.attachedModuleIds ?? []).includes(ModuleId.make(value))
+            ? content
+            : "";
+        }
+
         const configValue = getConfigValue(field);
         if (value !== undefined) {
           return configValue === value ? content : "";

--- a/packages/scaffold/src/browser.ts
+++ b/packages/scaffold/src/browser.ts
@@ -7,6 +7,15 @@ export {
 export { BlueprintService } from "./service/blueprint/BlueprintService";
 export { PlanService } from "./service/plan/PlanService";
 export {
+  GIT_HOOK_PROVIDER_VALUES,
+  GIT_HOOK_PROVIDERS,
+  type GitHookProviderModuleId,
+  type GitHookProviderValue,
+  getGitHookProvider,
+  hasSupportedGitHookTask,
+  isGitHookProviderEligible,
+} from "./service/recipe/GitHookProviders";
+export {
   type RecipePreview,
   type RecipePreviewError,
   type RecipePreviewInput,

--- a/packages/scaffold/src/index.ts
+++ b/packages/scaffold/src/index.ts
@@ -21,6 +21,15 @@ export {
 } from "./service/plan/PlanRenderer";
 export { PlanService } from "./service/plan/PlanService";
 export {
+  GIT_HOOK_PROVIDER_VALUES,
+  GIT_HOOK_PROVIDERS,
+  type GitHookProviderModuleId,
+  type GitHookProviderValue,
+  getGitHookProvider,
+  hasSupportedGitHookTask,
+  isGitHookProviderEligible,
+} from "./service/recipe/GitHookProviders";
+export {
   type RecipePreview,
   type RecipePreviewError,
   type RecipePreviewInput,

--- a/packages/scaffold/src/service/finalize/FinalizeService.test.ts
+++ b/packages/scaffold/src/service/finalize/FinalizeService.test.ts
@@ -71,6 +71,28 @@ const targetWithModule = (
     ],
   });
 
+const targetWithModules = (
+  identity: TargetIdentity,
+  moduleIds: ReadonlyArray<typeof ModuleId.Type>,
+) =>
+  new Blueprint({
+    nodes: [
+      { _tag: "target", id: identity.toKey(), identity },
+      ...moduleIds.map((moduleId) => ({
+        _tag: "attached-module" as const,
+        id: toAttachedModuleNodeId(identity.toKey(), moduleId),
+        targetId: identity.toKey(),
+        moduleId,
+      })),
+    ],
+    edges: moduleIds.map((moduleId) => ({
+      id: `owns-module=>${identity.toPath()}=>${toAttachedModuleNodeId(identity.toKey(), moduleId)}`,
+      from: identity.toKey(),
+      to: toAttachedModuleNodeId(identity.toKey(), moduleId),
+      reason: "owns-module" as const,
+    })),
+  });
+
 const makeCatalogLayer = (
   targets: Record<string, Partial<typeof TargetDefinition.Type>> = {},
   modules: Record<string, Partial<typeof ModuleDefinition.Type>> = {},
@@ -447,6 +469,76 @@ describe("FinalizeService", () => {
                 },
               },
             }),
+          ),
+        ),
+    );
+
+    it.each([
+      ["workspace-git-hooks-lefthook", "pnpm run lefthook:install"],
+      ["workspace-git-hooks-husky", "pnpm run husky:install"],
+    ])(
+      "orders install, quality, complete Git initialization, then %s",
+      (providerId, installer) =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const svc = yield* FinalizeService;
+            const blueprint = targetWithModules(serverIdentity, [
+              ModuleId.make("workspace-devenv-git"),
+              ModuleId.make(providerId),
+            ]);
+            const config = new StackConfig({
+              name: "test" as typeof import("effect").Schema.NonEmptyString.Type,
+              runtime: { _tag: "node", packageManager: "pnpm" },
+              lint: "biome",
+              format: "biome",
+            });
+
+            const scripts = yield* svc.preview(blueprint, makeConfig(config));
+
+            expect(scripts.map((script) => script.command)).toEqual([
+              "pnpm install",
+              "pnpm run lint",
+              "pnpm run format",
+              "git init --initial-branch=main",
+              "git add -A",
+              'git commit -m "initial commit"',
+              installer,
+            ]);
+          }).pipe(
+            Effect.provide(
+              makeFinalizeLayer([], {
+                modules: {
+                  "workspace-devenv-git": {
+                    scripts: [
+                      {
+                        label: "Initialize git repository",
+                        command: "git init --initial-branch=main",
+                        phase: "post-finalize",
+                      },
+                      {
+                        label: "Stage all files",
+                        command: "git add -A",
+                        phase: "post-finalize",
+                      },
+                      {
+                        label: "Create initial commit",
+                        command: 'git commit -m "initial commit"',
+                        phase: "post-finalize",
+                      },
+                    ],
+                  },
+                  [providerId]: {
+                    scripts: [
+                      {
+                        label: "Install Git hooks",
+                        command: installer,
+                        phase: "post-finalize",
+                      },
+                    ],
+                  },
+                },
+              }),
+            ),
           ),
         ),
     );

--- a/packages/scaffold/src/service/plan/ContributionResolver.test.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.test.ts
@@ -1,0 +1,70 @@
+import { Blueprint, toAttachedModuleNodeId } from "@repo/domain/Blueprint";
+import {
+  ModuleId,
+  TargetIdentity,
+  TargetKey,
+  TargetKind,
+} from "@repo/domain/Catalog";
+import { describe, expect, it } from "vitest";
+import { attachedModuleIdsByTarget } from "./ContributionResolver";
+
+const target = (id: string, kind: string, name: string) => ({
+  _tag: "target" as const,
+  id: TargetKey.make(id),
+  identity: new TargetIdentity({
+    kind: TargetKind.make(kind),
+    name,
+  }),
+});
+
+const attached = (targetId: string, moduleId: string) => ({
+  _tag: "attached-module" as const,
+  id: toAttachedModuleNodeId(TargetKey.make(targetId), ModuleId.make(moduleId)),
+  targetId: TargetKey.make(targetId),
+  moduleId: ModuleId.make(moduleId),
+});
+
+describe("attachedModuleIdsByTarget", () => {
+  it("groups zero, one, multiple, and unknown IDs by owning target only", () => {
+    const api = target("apps/server-api", "server", "api");
+    const web = target("apps/client-react-web", "client-react", "web");
+    const blueprint = new Blueprint({
+      nodes: [
+        api,
+        web,
+        attached(api.id, "workspace-git-hooks-lefthook"),
+        attached(api.id, "unknown-module"),
+        attached(web.id, "workspace-git-hooks-husky"),
+      ],
+      edges: [
+        {
+          id: "api-lefthook",
+          from: api.id,
+          to: `${api.id}#workspace-git-hooks-lefthook`,
+          reason: "owns-module",
+        },
+        {
+          id: "api-unknown",
+          from: api.id,
+          to: `${api.id}#unknown-module`,
+          reason: "owns-module",
+        },
+        {
+          id: "web-husky",
+          from: web.id,
+          to: `${web.id}#workspace-git-hooks-husky`,
+          reason: "owns-module",
+        },
+      ],
+    });
+
+    const grouped = attachedModuleIdsByTarget(blueprint);
+
+    expect(grouped.get(api.id)).toEqual([
+      "workspace-git-hooks-lefthook",
+      "unknown-module",
+    ]);
+    expect(grouped.get(web.id)).toEqual(["workspace-git-hooks-husky"]);
+    expect(grouped.get(TargetKey.make("packages/empty"))).toBeUndefined();
+  });
+});

--- a/packages/scaffold/src/service/plan/ContributionResolver.ts
+++ b/packages/scaffold/src/service/plan/ContributionResolver.ts
@@ -1,6 +1,10 @@
 import { CatalogService } from "@repo/catalog";
 import { type Blueprint, BlueprintNode } from "@repo/domain/Blueprint";
-import { Contribution } from "@repo/domain/Catalog";
+import {
+  Contribution,
+  type ModuleId,
+  type TargetKey,
+} from "@repo/domain/Catalog";
 import {
   ContributionTokenContext,
   ModuleContribution,
@@ -20,6 +24,7 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
         blueprint: typeof Blueprint.Type,
         config: typeof StackConfig.Type,
       ) {
+        const attachedModuleIds = attachedModuleIdsByTarget(blueprint);
         const targetResults = yield* Effect.forEach(
           Arr.filter(blueprint.nodes, BlueprintNode.guards.target),
           (node) =>
@@ -29,6 +34,7 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
                 targetKey: node.id,
                 identity: node.identity,
                 config,
+                attachedModuleIds: attachedModuleIds.get(node.id) ?? [],
               });
 
               return {
@@ -91,6 +97,19 @@ export class ContributionResolver extends Context.Service<ContributionResolver>(
     ContributionResolver.make,
   ).pipe(Layer.provide(CatalogService.layer));
 }
+
+export const attachedModuleIdsByTarget = (
+  blueprint: typeof Blueprint.Type,
+): ReadonlyMap<typeof TargetKey.Type, ReadonlyArray<typeof ModuleId.Type>> =>
+  Arr.reduce(
+    Arr.filter(blueprint.nodes, BlueprintNode.guards["attached-module"]),
+    new Map<typeof TargetKey.Type, ReadonlyArray<typeof ModuleId.Type>>(),
+    (grouped, node) =>
+      grouped.set(node.targetId, [
+        ...(grouped.get(node.targetId) ?? []),
+        node.moduleId,
+      ]),
+  );
 
 const resolveContributionTokens = (
   contributions: ReadonlyArray<typeof Contribution.Type>,

--- a/packages/scaffold/src/service/recipe/GitHookProviders.test.ts
+++ b/packages/scaffold/src/service/recipe/GitHookProviders.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  GIT_HOOK_PROVIDER_VALUES,
+  getGitHookProvider,
+  hasSupportedGitHookTask,
+  isGitHookProviderEligible,
+} from "./GitHookProviders";
+
+describe("GitHookProviders", () => {
+  it("defines the exact finite values, module IDs, and labels", () => {
+    expect(GIT_HOOK_PROVIDER_VALUES).toEqual(["none", "lefthook", "husky"]);
+    expect(
+      GIT_HOOK_PROVIDER_VALUES.map((value) => getGitHookProvider(value)),
+    ).toEqual([
+      { value: "none", moduleId: undefined, label: "None" },
+      {
+        value: "lefthook",
+        moduleId: "workspace-git-hooks-lefthook",
+        label: "Lefthook",
+      },
+      {
+        value: "husky",
+        moduleId: "workspace-git-hooks-husky",
+        label: "Husky + lint-staged (Node >=24 only)",
+      },
+    ]);
+  });
+
+  it.each([
+    [undefined, undefined, false],
+    ["biome", undefined, true],
+    ["oxfmt", undefined, true],
+    [undefined, "biome", true],
+    [undefined, "oxlint", true],
+    ["biome", "oxlint", true],
+    ["dprint", "eslint", false],
+  ] as const)(
+    "detects supported formatter/linter compositions",
+    (format, lint, expected) => {
+      expect(
+        hasSupportedGitHookTask({
+          ...(format === undefined ? {} : { format }),
+          ...(lint === undefined ? {} : { lint }),
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    ["none", "bun", "bun", false, true],
+    ["none", "bun", "bun", true, true],
+    ["lefthook", "bun", "bun", true, true],
+    ["lefthook", "node", "npm", true, true],
+    ["lefthook", "node", "pnpm", true, true],
+    ["husky", "bun", "bun", true, false],
+    ["husky", "node", "npm", true, true],
+    ["husky", "node", "pnpm", true, true],
+    ["husky", "node", "bun", true, false],
+    ["lefthook", "node", "npm", false, false],
+  ] as const)(
+    "checks runtime, package manager, Git, and supported-task eligibility",
+    (value, runtime, packageManager, git, expected) => {
+      expect(
+        isGitHookProviderEligible(value, {
+          runtime,
+          packageManager,
+          git,
+          format: "biome",
+        }),
+      ).toBe(expected);
+    },
+  );
+});

--- a/packages/scaffold/src/service/recipe/GitHookProviders.ts
+++ b/packages/scaffold/src/service/recipe/GitHookProviders.ts
@@ -1,0 +1,57 @@
+export const GIT_HOOK_PROVIDER_VALUES = ["none", "lefthook", "husky"] as const;
+
+export type GitHookProviderValue = (typeof GIT_HOOK_PROVIDER_VALUES)[number];
+export type GitHookProviderModuleId =
+  | "workspace-git-hooks-lefthook"
+  | "workspace-git-hooks-husky";
+
+type GitHookProvider = {
+  readonly value: GitHookProviderValue;
+  readonly moduleId: GitHookProviderModuleId | undefined;
+  readonly label: string;
+};
+
+export const GIT_HOOK_PROVIDERS: ReadonlyArray<GitHookProvider> = [
+  { value: "none", moduleId: undefined, label: "None" },
+  {
+    value: "lefthook",
+    moduleId: "workspace-git-hooks-lefthook",
+    label: "Lefthook",
+  },
+  {
+    value: "husky",
+    moduleId: "workspace-git-hooks-husky",
+    label: "Husky + lint-staged (Node >=24 only)",
+  },
+];
+
+export const getGitHookProvider = (
+  value: GitHookProviderValue,
+): GitHookProvider =>
+  GIT_HOOK_PROVIDERS.find((provider) => provider.value === value) ??
+  GIT_HOOK_PROVIDERS[0]!;
+
+export const hasSupportedGitHookTask = (config: {
+  readonly format?: string;
+  readonly lint?: string;
+}): boolean =>
+  config.format === "biome" ||
+  config.format === "oxfmt" ||
+  config.lint === "biome" ||
+  config.lint === "oxlint";
+
+export const isGitHookProviderEligible = (
+  value: GitHookProviderValue,
+  config: {
+    readonly runtime: "bun" | "node";
+    readonly packageManager: "bun" | "npm" | "pnpm";
+    readonly git: boolean;
+    readonly format?: string;
+    readonly lint?: string;
+  },
+): boolean =>
+  value === "none" ||
+  (config.git &&
+    hasSupportedGitHookTask(config) &&
+    (value === "lefthook" ||
+      (config.runtime === "node" && config.packageManager !== "bun")));

--- a/packages/scaffold/src/service/recipe/RecipeService.ts
+++ b/packages/scaffold/src/service/recipe/RecipeService.ts
@@ -65,10 +65,10 @@ const configWorkspaceModules = (
       config.monorepo === undefined
         ? undefined
         : toWorkspaceModuleId("tool", config.monorepo),
-      config.lint === undefined
+      config.lint === undefined || config.lint === "none"
         ? undefined
         : toWorkspaceModuleId("lint", config.lint),
-      config.format === undefined
+      config.format === undefined || config.format === "none"
         ? undefined
         : toWorkspaceModuleId("format", config.format),
       config.test === undefined

--- a/packages/scaffold/src/service/recipe/RecipeService.ts
+++ b/packages/scaffold/src/service/recipe/RecipeService.ts
@@ -5,6 +5,10 @@ import { StackConfig } from "@repo/domain/Scaffold";
 import type { Selection } from "@repo/domain/Selection";
 import { Array as Arr, Context, Effect, Layer, Option, pipe } from "effect";
 import {
+  GIT_HOOK_PROVIDERS,
+  hasSupportedGitHookTask,
+} from "./GitHookProviders";
+import {
   InvalidRecipeSpec,
   type RecipeError,
   type RecipeResolveOptions,
@@ -167,6 +171,60 @@ const selectionTargetToRecipeTargetSpec = (
   modules: Arr.map(target.modules, (moduleSelection) => moduleSelection.id),
 });
 
+const gitHookProviderModuleIds: ReadonlySet<string> = new Set(
+  GIT_HOOK_PROVIDERS.flatMap((provider) =>
+    provider.moduleId === undefined ? [] : [provider.moduleId],
+  ),
+);
+
+const validateGitHookProvider = (
+  targets: ReadonlyArray<CollectedRecipeTarget>,
+  config: typeof StackConfig.Type,
+) => {
+  const workspaceModules = targets
+    .filter((target) => target.identity.kind === "workspace")
+    .flatMap((target) => target.modules);
+  const providers = workspaceModules.filter((moduleId) =>
+    gitHookProviderModuleIds.has(moduleId),
+  );
+  const hasGit = workspaceModules.includes(
+    ModuleId.make("workspace-devenv-git"),
+  );
+  const provider = providers[0];
+  const message =
+    providers.length > 1
+      ? "Git hooks accept at most one provider. Choose none, lefthook, or husky."
+      : provider !== undefined && !hasGit
+        ? `Git-hook provider "${provider}" requires Git. Remove --no-git or choose --git-hooks none.`
+        : provider === "workspace-git-hooks-husky" &&
+            config.runtime._tag !== "node"
+          ? "Git-hook provider husky requires the Node >=24 runtime with npm or pnpm."
+          : provider !== undefined &&
+              !hasSupportedGitHookTask({
+                ...(config.format === undefined
+                  ? {}
+                  : { format: config.format }),
+                ...(config.lint === undefined ? {} : { lint: config.lint }),
+              })
+            ? `Git-hook provider "${provider}" requires at least one supported Biome or Oxc format or lint task.`
+            : undefined;
+
+  return message === undefined
+    ? Effect.void
+    : Effect.fail(
+        new InvalidRecipeSpec({
+          issues: [{ path: ["targets", "modules"], message }],
+        }),
+      );
+};
+
+const selectedGitHookProvider = (selection: typeof Selection.Type) =>
+  GIT_HOOK_PROVIDERS.find(
+    (provider) =>
+      provider.moduleId !== undefined &&
+      selectionIncludesWorkspaceModule(selection, provider.moduleId),
+  )?.value ?? "none";
+
 const selectionIncludesWorkspaceModule = (
   selection: typeof Selection.Type,
   moduleId: string,
@@ -212,18 +270,18 @@ export class RecipeService extends Context.Service<
         }),
       );
 
-      return toSelection(
-        mergeTargets([
-          {
-            identity: new TargetIdentity({
-              kind: TargetKind.make("workspace"),
-              name: options.config.name,
-            }),
-            modules: configWorkspaceModules(options.config),
-          },
-          ...recipeTargets,
-        ]),
-      );
+      const targets = mergeTargets([
+        {
+          identity: new TargetIdentity({
+            kind: TargetKind.make("workspace"),
+            name: options.config.name,
+          }),
+          modules: configWorkspaceModules(options.config),
+        },
+        ...recipeTargets,
+      ]);
+      yield* validateGitHookProvider(targets, options.config);
+      return toSelection(targets);
     });
 
     const renderCreateCommand: RecipeServiceShape["renderCreateCommand"] = ({
@@ -243,7 +301,8 @@ export class RecipeService extends Context.Service<
             target.modules,
             (module) =>
               !configModuleIds.has(module.id) &&
-              module.id !== "workspace-devenv-git",
+              module.id !== "workspace-devenv-git" &&
+              !gitHookProviderModuleIds.has(module.id),
           );
           return modules.length === 0
             ? []
@@ -283,6 +342,8 @@ export class RecipeService extends Context.Service<
         ...renderChangedFlag("--lint", config.lint, defaults.lint ?? ""),
         ...renderChangedFlag("--format", config.format, defaults.format ?? ""),
         ...renderChangedFlag("--test", config.test, defaults.test ?? ""),
+        "--git-hooks",
+        selectedGitHookProvider(selection),
         ...(selectionIncludesWorkspaceModule(selection, "workspace-devenv-git")
           ? []
           : ["--no-git"]),

--- a/packages/scaffold/src/service/recipe/RecipeService.ts
+++ b/packages/scaffold/src/service/recipe/RecipeService.ts
@@ -248,6 +248,17 @@ const renderChangedFlag = (
     ? []
     : [flag, quoteShellArg(value)];
 
+const renderQualityFlag = (
+  flag: string,
+  value: string | undefined,
+  defaultValue: string,
+) =>
+  value === undefined
+    ? [flag, "none"]
+    : value === defaultValue
+      ? []
+      : [flag, quoteShellArg(value)];
+
 export class RecipeService extends Context.Service<
   RecipeService,
   RecipeServiceShape
@@ -339,8 +350,8 @@ export class RecipeService extends Context.Service<
           config.monorepo,
           defaults.monorepo ?? "",
         ),
-        ...renderChangedFlag("--lint", config.lint, defaults.lint ?? ""),
-        ...renderChangedFlag("--format", config.format, defaults.format ?? ""),
+        ...renderQualityFlag("--lint", config.lint, defaults.lint ?? ""),
+        ...renderQualityFlag("--format", config.format, defaults.format ?? ""),
         ...renderChangedFlag("--test", config.test, defaults.test ?? ""),
         "--git-hooks",
         selectedGitHookProvider(selection),


### PR DESCRIPTION
## Goals/Scope

Add optional, mutually exclusive Git hook providers to both the CLI and Recipe Builder:

- `none` (default)
- Lefthook
- Husky + lint-staged for Node >=24

Success means generated hooks install only after the unhooked initial commit, run the selected formatter before the linter, preserve provider-native staging behavior, and reject unsupported combinations before writing files.

Closes #231

## Description

- Adds canonical `--git-hooks <none|lefthook|husky>` selection and explicit `--lint none` / `--format none` quality opt-outs.
- Generates Lefthook 2.1.10 or Husky 9.1.7 + lint-staged 17.4.1 configuration without taking ownership of `prepare`.
- Adds Recipe Builder selection, URL/state reconciliation, and real Worker Preview coverage. Husky remains visible but disabled for Bun.
- Adds generated-project and real-commit acceptance coverage across Bun/Node, npm/pnpm, Biome, Oxfmt/Oxlint, formatter-only, linter-only, and combined configurations.

### How to Test

```bash
bun install
bun run test --filter=stack-effect
bun run test
bun format
bun lint
bun run type-check
```

The runtime acceptance suite covers 30 provider/runtime/package-manager/tool cells and verifies:

- successful real commits and same-commit formatter fixes;
- provider-native formatter-before-linter ordering;
- non-fixable failures leaving `HEAD` unchanged;
- partial staging and preservation of unstaged user content;
- initial commit before provider installation;
- Husky `core.hooksPath` setup without `prepare` ownership;
- Lefthook pnpm build approval.

## Comments

- The feature remains optional and defaults to `none`.
- Husky + lint-staged is intentionally restricted to Node >=24.
- No fallback hook mechanism or provider-specific Apply policy is introduced.

---

- [x] Timeframe: `3 days`
- [ ] Urgent!
- [ ] Merge without review
- [ ] cc: @person
