### PR TITLE
fix(builder): preserve Bun after package manager changes

### DIFF
--- a/.changeset/recipe-builder-bun-runtime.md
+++ b/.changeset/recipe-builder-bun-runtime.md
@@ -1,0 +1,5 @@
+---
+"@stack-effect/docs": patch
+---
+
+Preserve the selected Bun runtime when restoring Recipe Builder state.

--- a/apps/docs/app/components/recipe-builder/stack-configurator.tsx
+++ b/apps/docs/app/components/recipe-builder/stack-configurator.tsx
@@ -159,12 +159,18 @@ export function StackConfigurator() {
           }
           disabled={runtime === "bun"}
           onChange={(value) =>
-            configure({
-              runtime: {
-                _tag: "node",
-                packageManager: value === "npm" ? "npm" : "pnpm",
-              },
-            })
+            form.setFieldValue("config", (current) =>
+              current.runtime._tag === "node" &&
+              (value === "pnpm" || value === "npm")
+                ? {
+                    ...current,
+                    runtime: {
+                      ...current.runtime,
+                      packageManager: value,
+                    },
+                  }
+                : current,
+            )
           }
         />
 

--- a/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
+++ b/apps/docs/test/components/recipe-builder/recipe-builder.browser.test.tsx
@@ -227,6 +227,29 @@ test("should replace valid URL edits and reset the existing form for external na
     .toHaveValue("my-effect-app");
 });
 
+test("should keep Bun selected after rapidly changing the Node package manager", async () => {
+  await renderRecipeBuilder();
+
+  const bunRuntime = page.getByRole("button", { name: "Bun" });
+  const packageManager = page.getByLabelText("Package manager");
+  await expect.element(bunRuntime).toHaveAttribute("aria-pressed", "true");
+
+  await page.getByRole("button", { name: "Node" }).click();
+  await packageManager.click();
+  await page.getByRole("option", { name: "npm", exact: true }).click();
+  await bunRuntime.click();
+
+  await expect.element(bunRuntime).toHaveAttribute("aria-pressed", "true");
+  await expect.element(packageManager).toBeDisabled();
+  await expect.element(packageManager).toHaveTextContent("Bun");
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .not.toHaveTextContent("runtime=node");
+  await expect
+    .element(page.getByLabelText("Recipe URL search"))
+    .not.toHaveTextContent("package-manager=");
+});
+
 test("should generate a usable preview when the user completes a valid Selection", async () => {
   await renderRecipeBuilder();
 


### PR DESCRIPTION
## Goals/Scope

- Prevent stale package-manager callbacks from switching the Recipe Builder from Bun back to Node.
- Keep package-manager updates scoped to an existing Node runtime.
- Add browser regression coverage for the rapid Node/npm → Bun transition.

Reviewer focus: the current-state guard in `StackConfigurator` and the regression assertions around runtime, package-manager state, and URL parameters.

## Description

The package-manager Select may emit a late null or stale value while Base UI reconciles its options. The previous handler mapped every non-`npm` value to `pnpm` and rebuilt a Node runtime, overwriting a newer Bun selection.

This change updates the package manager only when the current runtime is still Node and the emitted value is exactly `pnpm` or `npm`. All other callbacks preserve the current configuration.

### How to Test

- `bun run test --filter=@stack-effect/docs`
- `bun format`
- `bun lint`
- `bun run type-check`
- Manually verified Bun → Node/npm → Bun in the local Recipe Builder.

All automated commands pass. The docs test gate reports 23 files and 195 tests passed.

## Comments

Closes #232

---

- [ ] Timeframe: [`24 hr`, `3 days`, `1 week`]
- [ ] Urgent!
- [ ] Merge without review
- [ ] cc: @person
