### PR TITLE
fix: align tsgo with toolchain

### DIFF
--- a/.changeset/heavy-rabbits-give.md
+++ b/.changeset/heavy-rabbits-give.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+Generated TypeScript 7 workspaces now use the tested TSGo, Vite+, Oxfmt, Oxlint, and Vitest toolchain versions.

--- a/.changeset/small-feet-cover.md
+++ b/.changeset/small-feet-cover.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+TypeScript 7 workspaces now activate the Effect language-service plugin from the root tsconfig.

--- a/.changeset/strict-pigs-decide.md
+++ b/.changeset/strict-pigs-decide.md
@@ -1,0 +1,5 @@
+---
+"stack-effect": patch
+---
+
+TypeScript 7 projects now configure VS Code to use the patched workspace TSGo server.

--- a/apps/cli/e2e/harness.ts
+++ b/apps/cli/e2e/harness.ts
@@ -128,6 +128,10 @@ interface ProjectContext {
     relativePath: string,
     pattern: string | RegExp,
   ) => Effect.Effect<void>;
+  readonly expectFileNotContaining: (
+    relativePath: string,
+    pattern: string | RegExp,
+  ) => Effect.Effect<void>;
   readonly expectDirectoryContains: (
     relativePath: string,
     entries: ReadonlyArray<string>,
@@ -216,6 +220,24 @@ const makeProjectContext = (
                   `File ${relativePath} does not match pattern: ${pattern}`,
                 ),
               );
+        }),
+        Effect.orDie,
+      ),
+
+    expectFileNotContaining: (relativePath, pattern) =>
+      fs.readFileString(path.join(projectDir, relativePath)).pipe(
+        Effect.flatMap((content) => {
+          const matches =
+            typeof pattern === "string"
+              ? content.includes(pattern)
+              : pattern.test(content);
+          return matches
+            ? Effect.die(
+                new Error(
+                  `File ${relativePath} unexpectedly matches pattern: ${pattern}`,
+                ),
+              )
+            : Effect.void;
         }),
         Effect.orDie,
       ),

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -112,6 +112,29 @@ describe("init", () => {
     );
 
     it.effect(
+      "should activate the Effect language-service plugin in the TypeScript 7 root config",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+
+          yield* cli.run(
+            "init",
+            "typescript-7-root-plugin-app",
+            "--yes",
+            "--root",
+            cli.workdir,
+          );
+
+          yield* cli.expectExitCode(0);
+          yield* cli.expectFileContaining(
+            "typescript-7-root-plugin-app/tsconfig.json",
+            '"name": "@effect/language-service"',
+          );
+        }),
+      { timeout: 30_000 },
+    );
+
+    it.effect(
       "should generate the Vite+ toolchain when using the defaults",
       () =>
         Effect.gen(function* () {

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -40,7 +40,7 @@ describe("init", () => {
           yield* cli.expectJsonFile(
             "my-app/package.json",
             "devDependencies.@effect/tsgo",
-            "^0.22.0",
+            "0.38.0",
           );
           yield* cli.expectJsonFile(
             "my-app/tsconfig.json",
@@ -290,7 +290,7 @@ describe("init", () => {
           yield* cli.expectJsonFile(
             "catalog-oxfmt/package.json",
             "devDependencies.oxfmt",
-            "^0.62.0",
+            "^0.65.0",
           );
           yield* cli.expectFileContaining(
             "catalog-oxfmt/.catalog-build-manifest.json",
@@ -341,7 +341,7 @@ describe("init", () => {
           yield* cli.expectJsonFile(
             "nx-bun-app/package.json",
             "devDependencies.@effect/tsgo",
-            "^0.22.0",
+            "0.38.0",
           );
           yield* cli.expectJsonFile(
             "nx-bun-app/package.json",
@@ -596,7 +596,7 @@ describe("init", () => {
           yield* cli.expectJsonFile(
             "vite-plus-app/package.json",
             "devDependencies.vite-plus",
-            "^0.2.8",
+            "^0.3.0",
           );
           yield* cli.expectJsonFile(
             "vite-plus-app/package.json",

--- a/apps/cli/e2e/init.test.ts
+++ b/apps/cli/e2e/init.test.ts
@@ -52,6 +52,10 @@ describe("init", () => {
             "$schema",
             "../../node_modules/@effect/tsgo/schema.json",
           );
+          yield* cli.expectFileContaining(
+            "my-app/.vscode/settings.json",
+            '"js/ts.experimental.useTsgo": true',
+          );
         }),
       { timeout: 30_000 },
     );

--- a/apps/cli/e2e/language-service.test.ts
+++ b/apps/cli/e2e/language-service.test.ts
@@ -1,0 +1,155 @@
+import { assert, describe, layer } from "@effect/vitest";
+import { Effect } from "effect";
+import { CLI } from "./harness";
+
+const fixtureContents = `import { Effect } from "effect";
+
+export const now = Effect.gen(function* () {
+  return new Date();
+});
+`;
+
+const smokeConfigContents = `{
+  "extends": "./tsconfig.json",
+  "files": ["src/effect-lsp-smoke.ts"]
+}
+`;
+
+const createCommand = (projectName: string, typescript: "6" | "7") =>
+  [
+    "create",
+    projectName,
+    "--target",
+    "cli/app:cli-command-hello",
+    "--typescript",
+    typescript,
+    "--yes",
+    "--no-git",
+  ] as const;
+
+describe("generated language services", () => {
+  layer(CLI.layer)("layer", (it) => {
+    it.effect(
+      "should report Effect diagnostics through patched tsc when TypeScript 6 is selected",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const projectName = "typescript-6-lsp";
+
+          yield* cli.run(
+            ...createCommand(projectName, "6"),
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject(projectName, function* (project) {
+            yield* project.writeFile(
+              "apps/cli-app/src/effect-lsp-smoke.ts",
+              fixtureContents,
+            );
+            yield* project.writeFile(
+              "apps/cli-app/tsconfig.effect-lsp-smoke.json",
+              smokeConfigContents,
+            );
+            yield* project.expectFileNotContaining(
+              ".vscode/settings.json",
+              "js/ts.experimental.useTsgo",
+            );
+
+            const diagnostics = yield* project.exec(
+              "./node_modules/.bin/tsc",
+              "--noEmit",
+              "--project",
+              "apps/cli-app/tsconfig.effect-lsp-smoke.json",
+            );
+            assert.strictEqual(
+              diagnostics.exitCode,
+              0,
+              `${diagnostics.stdout}\n${diagnostics.stderr}`,
+            );
+            assert.match(
+              `${diagnostics.stdout}\n${diagnostics.stderr}`,
+              /globalDateInEffect/,
+            );
+          });
+        }),
+      { timeout: 60_000 },
+    );
+
+    it.effect(
+      "should enable TSGo in VS Code when TypeScript 7 is selected",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const projectName = "typescript-7-editor-settings";
+
+          yield* cli.run(
+            ...createCommand(projectName, "7"),
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject(projectName, function* (project) {
+            yield* project.expectFileContaining(
+              ".vscode/settings.json",
+              '"js/ts.experimental.useTsgo": true',
+            );
+            yield* project.expectFileContaining(
+              ".vscode/settings.json",
+              '"js/ts.tsdk.path": "./node_modules/typescript/bin"',
+            );
+          });
+        }),
+      { timeout: 60_000 },
+    );
+
+    it.effect(
+      "should report Effect diagnostics through TSGo when TypeScript 7 is selected",
+      () =>
+        Effect.gen(function* () {
+          const cli = yield* CLI;
+          const projectName = "typescript-7-lsp";
+
+          yield* cli.run(
+            ...createCommand(projectName, "7"),
+            "--root",
+            cli.workdir,
+          );
+          yield* cli.expectExitCode(0);
+
+          yield* cli.withinProject(projectName, function* (project) {
+            yield* project.writeFile(
+              "apps/cli-app/src/effect-lsp-smoke.ts",
+              fixtureContents,
+            );
+            yield* project.writeFile(
+              "apps/cli-app/tsconfig.effect-lsp-smoke.json",
+              smokeConfigContents,
+            );
+
+            const diagnostics = yield* project.exec(
+              "./node_modules/.bin/effect-tsgo",
+              "diagnostics",
+              "--project",
+              "apps/cli-app/tsconfig.effect-lsp-smoke.json",
+              "--format",
+              "json",
+            );
+            assert.strictEqual(diagnostics.exitCode, 0);
+
+            const output = JSON.parse(diagnostics.stdout);
+            assert.isTrue(
+              output.diagnostics.some(
+                (diagnostic: { readonly name: string }) =>
+                  diagnostic.name === "globalDateInEffect",
+              ),
+              diagnostics.stdout,
+            );
+          });
+        }),
+      { timeout: 60_000 },
+    );
+  });
+});

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -366,7 +366,11 @@ export const workspaceVscodeSettingsContents = `{
   },
   "[jsonc]": {
     "editor.defaultFormatter": "{{#if format=biome}}biomejs.biome{{/if}}{{#if format=dprint}}dprint.dprint{{/if}}{{#if format=oxfmt}}oxc.oxc-vscode{{/if}}"
-  }
+  }{{#if typescript=7}},
+  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/bin",
+  "js/ts.experimental.useTsgo": true{{/if}}
 }
 `;
 

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -59,7 +59,14 @@ export const rootPackageJsonContents = `{
 export const rootTsconfigContents = `{
   "$schema": "{{#if typescript=6}}./node_modules/@effect/language-service/schema.json{{/if}}{{#if typescript=7}}./node_modules/@effect/tsgo/schema.json{{/if}}",
   "extends": "./packages/config-typescript/base.json",
-  "files": []
+  "files": []{{#if typescript=7}},
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
+  }{{/if}}
 }
 `;
 

--- a/packages/catalog/src/registry/content/init.ts
+++ b/packages/catalog/src/registry/content/init.ts
@@ -117,7 +117,6 @@ export const configTypescriptBaseContents = `{
         "name": "@effect/language-service",
         "barrelImportPackages": ["effect"],
         "includeSuggestionsInTsc": true,
-        "quickinfoMaximumLength": 1200,
         "diagnosticSeverity": {
           "cryptoRandomUUIDInEffect": "suggestion",
           "globalDateInEffect": "suggestion",

--- a/packages/catalog/src/registry/modules/init.ts
+++ b/packages/catalog/src/registry/modules/init.ts
@@ -184,7 +184,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "devDependencies",
         name: "@effect/tsgo",
-        value: "^0.22.0",
+        value: "0.38.0",
       },
       {
         _tag: "pkg-json-entry",
@@ -370,7 +370,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "devDependencies",
         name: "vite-plus",
-        value: "^0.2.8",
+        value: "^0.3.0",
       },
       {
         _tag: "pkg-json-entry",
@@ -547,7 +547,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "devDependencies",
         name: "oxfmt",
-        value: "^0.62.0",
+        value: "^0.65.0",
       },
       {
         _tag: "pkg-json-entry",
@@ -636,7 +636,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "devDependencies",
         name: "oxlint",
-        value: "^1.42.0",
+        value: "^1.80.0",
       },
       {
         _tag: "pkg-json-entry",
@@ -681,7 +681,7 @@ export const initModules: ReadonlyArray<typeof ModuleDefinition.Type> = [
         path: "{{targetPath}}/package.json",
         field: "devDependencies",
         name: "vitest",
-        value: "^4.1.4",
+        value: "^4.1.11",
       },
       {
         _tag: "pkg-json-entry",

--- a/packages/scaffold/src/service/recipe/RecipePreviewService.test.ts
+++ b/packages/scaffold/src/service/recipe/RecipePreviewService.test.ts
@@ -74,7 +74,7 @@ it.effect(
 
       assert.strictEqual(packageJson.scripts.format, "oxfmt");
       assert.strictEqual(packageJson.scripts["format:check"], "oxfmt --check");
-      assert.strictEqual(packageJson.devDependencies.oxfmt, "^0.62.0");
+      assert.strictEqual(packageJson.devDependencies.oxfmt, "^0.65.0");
       assert.isUndefined(fileContents("dprint.json"));
     }).pipe(Effect.provide(RecipePreviewService.layer)),
 );


### PR DESCRIPTION
## Goals/Scope

Align the toolchains with typescript 7 after some recent usage.

## Description

- Configure TypeScript 7 editors for TSGo
- Activate the TypeScript 7 root plugin
- Refresh the TypeScript 7 Oxc toolchain
- Add tests covering generated Effect language services